### PR TITLE
do not advertise non-existent py2.6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         "Operating System :: OS Independent",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
[The readme](https://github.com/pipxproject/pipx#system-requirements) and parts of setup.py state that pipx is python 3.6+, but the setup.py mentions python 2.6. This PR removed the false advertising ;)