### PR TITLE
Use a platform-agnostic home when rendering usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Install and execute binaries from Python packages.
 Binaries can either be installed globally into isolated Virtual Environments
 or run directly in an temporary Virtual Environment.
 
-Virtual Envrionment location is /home/USER/.local/pipx/venvs.
-Symlinks to binaries are placed in /home/USER/.local/bin.
+Virtual Envrionment location is ~/.local/pipx/venvs.
+Symlinks to binaries are placed in ~/.local/bin.
 These locations can be overridden with the environment variables
 PIPX_HOME and PIPX_BIN_DIR, respectively. (Virtual Environments will
 be installed to $PIPX_HOME/venvs)
@@ -173,7 +173,7 @@ subcommands:
                         (expiremental, see https://github.com/cs01/pythonloc)
     runpip              Run pip in an existing pipx-managed Virtual
                         Environment
-    ensurepath          Ensure /home/USER/.local/bin is on your PATH
+    ensurepath          Ensure ~/.local/bin is on your PATH
                         environment variable by modifying your shell's
                         configuration file.
 
@@ -207,11 +207,11 @@ pipx install --spec TAR_GZ_FILE PACKAGE
 
 The argument to `--spec` is passed directly to `pip install`.
 
-The default virtual environment location is /home/USER/.local/pipx
+The default virtual environment location is ~/.local/pipx
 and can be overridden by setting the environment variable `PIPX_HOME`
  (Virtual Environments will be installed to `$PIPX_HOME/venvs`).
 
-The default binary location is /home/USER/.local/bin and can be
+The default binary location is ~/.local/bin and can be
 overridden by setting the environment variable `PIPX_BIN_DIR`.
 
 positional arguments:
@@ -567,15 +567,15 @@ optional arguments:
 pipx ensurepath --help
 usage: pipx ensurepath [-h] [--force]
 
-Ensure /home/USER/.local/bin is on your PATH environment variable by
+Ensure ~/.local/bin is on your PATH environment variable by
 modifying your shell's configuration file. This only needs to be run once
-after initial installation if /home/USER/.local/bin is not already on your
+after initial installation if ~/.local/bin is not already on your
 PATH.
 
 optional arguments:
   -h, --help  show this help message and exit
   --force     Add text to your shell's config file even if it looks like your
-              PATH already has /home/USER/.local/bin
+              PATH already has ~/.local/bin
 
 ```
 

--- a/generate_readme.py
+++ b/generate_readme.py
@@ -3,14 +3,9 @@
 
 import subprocess
 from typing import Optional
-import getpass
 from pipx.main import __version__
 import os
 from jinja2 import Environment, FileSystemLoader
-
-
-USER = getpass.getuser()
-HOME = os.environ.get("HOME", f"/home/{USER}")
 
 
 def get_help(pipxcmd: Optional[str]) -> str:
@@ -22,7 +17,7 @@ def get_help(pipxcmd: Optional[str]) -> str:
     helptext = (
         subprocess.run(cmd, stdout=subprocess.PIPE, check=True)
         .stdout.decode()
-        .replace(HOME, "/home/USER")
+        .replace(os.path.expanduser('~'), "~")
     )
     return f"""
 ```


### PR DESCRIPTION
This change allows the usage in the README to be rendered without any username using the platform-agnostic `~` symbol. Now docs can be rendered on Windows too.