### PR TITLE
HTTP redirect, proxy support (pipx run https://....)

### DIFF
--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -3,7 +3,6 @@
 
 import datetime
 import hashlib
-import http.client
 import logging
 import multiprocessing
 import os
@@ -13,6 +12,7 @@ import subprocess
 import textwrap
 import time
 import urllib.parse
+import urllib.request
 from pathlib import Path
 from shutil import which
 from typing import List, Optional
@@ -180,14 +180,7 @@ def _remove_all_expired_venvs():
 
 
 def _http_get_request(url: str):
-    parts = urllib.parse.urlparse(url)
-    conn = http.client.HTTPSConnection(parts.hostname)
-    conn.request("GET", parts.path)
-    response = conn.getresponse()
-    if response.status != 200:
-        raise PipxError(response.reason)
-
-    return response.read().decode("utf-8")
+    return urllib.request.urlopen(url).read().decode("utf-8")
 
 
 def upgrade(

--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -180,7 +180,12 @@ def _remove_all_expired_venvs():
 
 
 def _http_get_request(url: str):
-    return urllib.request.urlopen(url).read().decode("utf-8")
+    try:
+        res = urllib.request.urlopen(url)
+        charset = res.headers.get_content_charset() or "utf-8"
+        return res.read().decode(charset)
+    except Exception as e:
+        raise PipxError(str(e))
 
 
 def upgrade(


### PR DESCRIPTION
replace `http.client` to `urllib.request` for some HTTP feature (30x redirect, proxy, etc...)

now you can `pipx run URL` behind proxy.

```
# export https_proxy=http://your-proxy-host:port
# pipx run https://gist.githubusercontent.com/cs01/fa721a17a326e551ede048c5088f9e0f/raw/6bdfbb6e9c1132b1c38fdd2f195d4a24c540c324/pipx-demo.py
pipx is working!
```
