### PR TITLE
dev workflow fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6"
   # - "3.7"
 install:
-  - pip install tox tox-venv .[dev]
+  - pip install tox tox-venv
 script:
   - python setup.py check --metadata --strict
   - check-manifest

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ install:
   - pip install tox tox-venv
 script:
   - python setup.py check --metadata --strict
-  - check-manifest
   - tox
   - tox -e docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - python setup.py check --metadata --strict
   - check-manifest
   - tox
+  - tox -e docs
 
 cache:
   pip: true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,7 +35,7 @@ tox -e docs
 ### Publishing
 To publish documentation to GitHub pages:
 ```
-mkdocs gh-pages
+.tox/docs/bin/mkdocs gh-pages
 ```
 
 When finished, you may remove the virtual environment with `rm -r .tox`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,18 +1,17 @@
-pipx uses [tox](https://pypi.org/project/tox/) for development and continuous integration testing and automation.
+pipx uses [tox](https://pypi.org/project/tox/) for development, continuous integration testing, and automation.
 
 ## Developing pipx
-To develop `pipx` first clone the repository, have `tox` installed somewhere on your system, then run `tox`.
+To develop `pipx`, first clone the repository, have `tox` installed somewhere on your system, then run:
 ```
 tox --notest
 ```
 
-Tox creates virtual environments in `.tox/` (`.tox/python` is the default). Make any changes and then invoke `pipx` like this:
+This will perform an editable install of `pipx` for each environment listed in `envlist` in the `tox.ini`. Any changes you make to pipx source code will be reflected immediately, if you invoke `pipx` in the virtual environment like so:
 ```
-.tox/python/bin/pipx ...
+.tox/py36/bin/pipx
 ```
-Any changes you make to pipx source code will be reflected immediately.
 
-Make sure your changes pass tests by running tox
+Make sure your changes pass tests:
 ```
 tox
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,34 +1,21 @@
 pipx uses [tox](https://pypi.org/project/tox/) for development, continuous integration testing, and automation.
 
 ## Developing pipx
+
 To develop `pipx`, first clone the repository, have `tox` installed somewhere on your system, then run:
 ```
 tox --notest
 ```
 
-This will perform an editable install of `pipx` for each environment listed in `envlist` in the `tox.ini`. Any changes you make to pipx source code will be reflected immediately, if you invoke `pipx` in the virtual environment like so:
-```
-.tox/py36/bin/pipx
-```
+This will perform an editable install of `pipx` for each environment listed in `envlist` in the `tox.ini`. Currently, this is only `py36`. Enter the virtualenv with `source .tox/py36/bin/activate`. Any changes you make to pipx source code will be reflected immediately in the virtualenv's `pipx` executable.
 
-Make sure your changes pass tests:
-```
-tox
-```
+Make sure your changes pass tests by first exiting the virtual environment, then running `tox`.
+
 
 ## Documentation
+
 Documentation is generated with `mkdocs` which generates documentation from several `.md` files in `docs`. Some of those `.md` files, as well as the main `README.md` file are generated from a `templates` directory.
 
 First, build the documentation virtualenv with `tox -e docs`. This will also build the documentation.
 
-If you make changes to any template files, rebuild the documentation with `.tox/docs/bin/mkdocs build`. To serve documentation, `.tox/docs/bin/mkdocs serve`.
-
-
-### Publishing
-To publish documentation to GitHub pages:
-```
-.tox/docs/bin/mkdocs gh-pages
-```
-
-When finished, you may remove the virtual environment with `rm -r .tox`.
-
+If you make changes to any template files, enter the virtualenv: `source .tox/docs/bin/activate`. Rebuild the documentation with `mkdocs build`. To serve documentation, `mkdocs serve`. To publish documentation to GitHub pages, `mkdocs gh-pages`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,17 +19,9 @@ tox
 ## Documentation
 Documentation is generated with `mkdocs` which generates documentation from several `.md` files in `docs`. Some of those `.md` files, as well as the main `README.md` file are generated from a `templates` directory.
 
+First, build the documentation virtualenv with `tox -e docs`. This will also build the documentation.
 
-### Serving
-To serve documenation with mkdocs that reflect the content of the `docs` folder as you make changes:
-```
-tox -e watchdocs
-```
-
-As you serve the docs, if you make changes to any template files, you generate the .md files by running:
-```
-tox -e docs
-```
+If you make changes to any template files, rebuild the documentation with `.tox/docs/bin/mkdocs build`. To serve documentation, `.tox/docs/bin/mkdocs serve`.
 
 
 ### Publishing

--- a/makefile
+++ b/makefile
@@ -1,5 +1,4 @@
-.PHONY: build publish docs test
-
+.PHONY: test build publish clean
 
 test:
 	python setup.py test
@@ -13,4 +12,3 @@ publish: build
 
 clean:
 	rm -r build dist *.egg-info || true
-

--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,12 @@ setup(
             "black",
             "flake8",
             "mypy",
+            "check-manifest",
+        ],
+        "docs": [
             "jinja2",
             "mkdocs",
             "mkdocs-material",
-            "check-manifest",
         ]
     },
     zip_safe=False,

--- a/tests/test_pipx.py
+++ b/tests/test_pipx.py
@@ -29,7 +29,6 @@ class PipxStaticTests(unittest.TestCase):
 
     def test_static(self):
         files = ["pipx", "tests"]
-        self.run_cmd(["mkdocs", "build"])
         self.run_cmd(["black", "--check"] + files)
         self.run_cmd(["flake8"] + files)
         self.run_cmd(["mypy"] + files)

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ commands =
 [testenv:docs]
 extras =
 	docs
-skip_install = True
 commands =
 	python generate_docs.py
 	mkdocs build
@@ -23,7 +22,6 @@ commands =
 [testenv:watchdocs]
 extras =
 	docs
-skip_install = True
 commands =
 	python generate_docs.py
 	mkdocs serve

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands =
     python -m unittest discover
 
 [testenv:docs]
+basepython = python3.6
 extras =
 	docs
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ extras =
 usedevelop = True
 commands =
     check-manifest
-	python -m unittest discover
+    python -m unittest discover
 
 [testenv:docs]
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -6,24 +6,24 @@ requires =
 	tox-venv
 
 [testenv]
-commands =
-	python -m unittest discover
 extras =
 	dev
 usedevelop = True
+commands =
+	python -m unittest discover
 
 [testenv:docs]
 extras =
-	dev
-skipinstall = True
+	docs
+skip_install = True
 commands =
 	python generate_docs.py
 	mkdocs build
 
 [testenv:watchdocs]
 extras =
-	dev
-skipinstall = True
+	docs
+skip_install = True
 commands =
 	python generate_docs.py
 	mkdocs serve

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ extras =
 	dev
 usedevelop = True
 commands =
+    check-manifest
 	python -m unittest discover
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,3 @@ extras =
 commands =
 	python generate_docs.py
 	mkdocs build
-
-[testenv:watchdocs]
-extras =
-	docs
-commands =
-	python generate_docs.py
-	mkdocs serve

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
-envlist = python
 minversion = 3.2
+envlist = py36
+skipsdist = true
 requires =
 	tox-venv
 
@@ -18,7 +19,6 @@ skipinstall = True
 commands =
 	python generate_docs.py
 	mkdocs build
-
 
 [testenv:watchdocs]
 extras =


### PR DESCRIPTION
Hi! Wanted to potentially contribute to pipx and noticed a few problems in the developer workflow. Summarily:

* `python` tox environment isn't a recognized factor e.g. `py36`, so it will default to using the interpreter that was used to invoke tox. You can reproduce this if you set `python` to like, 2.7, install tox on it, and run - it will fail. I changed this to `py36`, because it looks like that's the lowest version pipx is supporting. Developers will need `python3.6` in their path. I also updated the relevant docs.
* set `skipsdist` for some small speedup; looks like your makefile is building sdists already, and you have `usedevelop` - tox will editable install, instead from the sdist it generates, so this change doesn't break anything.
* moved packages exclusively necessary for docs stuff to separate `extras_require`, and removed `skipinstall`. That's not valid and silently ignored by tox - I corrected to `skip_install` initially, and then `tox -e docs` failed because those packages obviously need to be installed for the generation script, so I removed it - not sure why it was there in the first place.

Thanks!
