### PR TITLE
correctly suggest --include-deps

### DIFF
--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -331,20 +331,6 @@ def _run_post_install_actions(
 ):
     metadata = venv.get_venv_metadata_for_package(package)
 
-    random_binary_name: str
-    if metadata.binaries:
-        random_binary_name = metadata.binaries[0]
-    elif metadata.binaries_of_dependencies and include_deps:
-        random_binary_name = metadata.binaries_of_dependencies[0]
-    else:
-        # No binaries associated with this package and we aren't including dependencies.
-        # This package has nothing for pipx to use, so this is an error.
-        if venv.safe_to_remove():
-            venv.remove_venv()
-        raise PipxError(
-            f"No binaries associated with package {package} or its dependencies."
-        )
-
     if not metadata.binary_paths and not include_deps:
         # No binaries associated with this package and we aren't including dependencies.
         # This package has nothing for pipx to use, so this is an error.
@@ -361,10 +347,25 @@ def _run_post_install_actions(
         if len(metadata.binary_paths_of_dependencies.keys()):
             raise PipxError(
                 f"No binaries associated with package {package}. "
-                "Try again with '--include-deps' to include binaries of dependent packages."
+                "Try again with '--include-deps' to include binaries of dependent packages, "
+                "which are listed above."
             )
         else:
             raise PipxError(f"No binaries associated with package {package}.")
+
+    random_binary_name: str
+    if metadata.binaries:
+        random_binary_name = metadata.binaries[0]
+    elif metadata.binaries_of_dependencies and include_deps:
+        random_binary_name = metadata.binaries_of_dependencies[0]
+    else:
+        # No binaries associated with this package and we aren't including dependencies.
+        # This package has nothing for pipx to use, so this is an error.
+        if venv.safe_to_remove():
+            venv.remove_venv()
+        raise PipxError(
+            f"No binaries associated with package {package} or its dependencies."
+        )
 
     _expose_binaries_globally(local_bin_dir, metadata.binary_paths, package)
 


### PR DESCRIPTION
In some cases, when `--include-deps` is the expected behavior, it isn't suggested. For example:

```
josh@mikasa $ pipx --version                
0.13.1.1
josh@mikasa $ pipx install --verbose jupyter
-- snip --
Successfully installed MarkupSafe-1.1.1 Send2Trash-1.5.0 attrs-19.1.0 backcall-0.1.0 bleach-3.1.0 decorator-4.4.0 defusedxml-0.6.0 entrypoints-0.3 ipykernel-5.1.1 ipython-7.5.0 ipython-genutils-0.2.0 ipywidgets-7.4.2 jedi-0.13.3 jinja2-2.10.1 jsonschema-3.0.1 jupyter-1.0.0 jupyter-client-5.2.4 jupyter-console-6.0.0 jupyter-core-4.4.0 mistune-0.8.4 nbconvert-5.5.0 nbformat-4.4.0 notebook-5.7.8 pandocfilters-1.4.2 parso-0.4.0 pexpect-4.7.0 pickleshare-0.7.5 prometheus-client-0.6.0 prompt-toolkit-2.0.9 ptyprocess-0.6.0 pygments-2.4.1 pyrsistent-0.15.2 python-dateutil-2.8.0 pyzmq-18.0.1 qtconsole-4.5.0 six-1.12.0 terminado-0.8.2 testpath-0.4.2 tornado-6.0.2 traitlets-4.3.2 wcwidth-0.1.7 webencodings-0.5.1 widgetsnbextension-3.4.2
pipx (rmdir:25): removing directory /home/josh/.local/pipx/venvs/jupyter
No binaries associated with package jupyter or its dependencies.
```

Not only is `--include-deps` not recommended here, the error message is also partially incorrect - "..or its dependencies".

This is because the detection logic is out of order - fixed in this branch. Now, you'll see this:

```
josh@mikasa $ pipx install jupyter
Note: Dependent package 'jupyter-console' contains 1 binaries
  - jupyter-console
Note: Dependent package 'ipython>=5.0.0' contains 4 binaries
  - iptest
  - iptest3
  - ipython
  - ipython3
Note: Dependent package 'jupyter-client' contains 3 binaries
  - jupyter-kernel
  - jupyter-kernelspec
  - jupyter-run
Note: Dependent package 'notebook' contains 4 binaries
  - jupyter-bundlerextension
  - jupyter-nbextension
  - jupyter-notebook
  - jupyter-serverextension
Note: Dependent package 'nbconvert' contains 1 binaries
  - jupyter-nbconvert
Note: Dependent package 'nbformat>=4.2.0' contains 1 binaries
  - jupyter-trust
Note: Dependent package 'notebook>=4.4.1' contains 4 binaries
  - jupyter-bundlerextension
  - jupyter-nbextension
  - jupyter-notebook
  - jupyter-serverextension
Note: Dependent package 'ipython>=4.0.0; python_version >= "3.3"' contains 4 binaries
  - iptest
  - iptest3
  - ipython
  - ipython3
Note: Dependent package 'qtconsole' contains 1 binaries
  - jupyter-qtconsole
No binaries associated with package jupyter. Try again with '--include-deps' to include binaries of dependent packages, which are listed above.
```

Note that some binaries (should really be changed to the term "executables") are reported more than once due to different pins of the same dependent packages - that should probably be fixed as well. Would it fit into the scope of this PR?