### PR TITLE
un-deprecate `pipx ensurepath` #178

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In a hurry? Here's how to get started with pipx:
 
 ```
 python3 -m pip install --user pipx
-python3 -m userpath append ~/.local/bin
+python3 -m pipx ensurepath
 ```
 
 For more details, see [installation](https://pipxproject.github.io/pipx/installation/).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+0.13.1.2
+
+- Un-deprecate `ensurepath`. Use `userpath` internally instead of instructing users to run the `userpath` cli command.
+
 0.13.1.1
 
 - Do not raise bare exception if no binaries found (#150)

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -44,8 +44,8 @@ subcommands:
                         directory (experimental).
     runpip              Run pip in an existing pipx-managed Virtual
                         Environment
-    ensurepath          Deprecated, will be removed in a future release. Use
-                        `userpath` instead.
+    ensurepath          Ensure directory where pipx stores binaries is on your
+                        PATH environment variable
 
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ _pipx uses the word "binary" to describe a CLI application that can be run direc
 
 ```
 python3 -m pip install --user pipx
-python3 -m userpath append ~/.local/bin
+python3 -m pipx ensurepath
 ```
 
 For more details, see [installation](installation).

--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -648,24 +648,33 @@ def run_pip(package: str, venv_dir: Path, pip_args: List[str], verbose: bool):
 
 
 def ensurepath(location: Path, *, force: bool):
-    if userpath.in_current_path(str(location)) or userpath.need_shell_restart(location):
+    location_str = str(location)
+
+    post_install_message = (
+        "You likely need to open a new terminal or re-login for "
+        "the changes to take effect."
+    )
+    if userpath.in_current_path(location_str) or userpath.need_shell_restart(
+        location_str
+    ):
         if not force:
-            if userpath.need_shell_restart(location):
+            if userpath.need_shell_restart(location_str):
                 print(
-                    f"{str(location)} has been already been added to PATH. "
-                    "Open a new terminal for the change to take effect."
+                    f"{location_str} has been already been added to PATH. "
+                    f"{post_install_message}"
                 )
             else:
                 logging.warning(
                     (
-                        f"The directory `{str(location)}` is already in PATH. If you "
+                        f"The directory `{location_str}` is already in PATH. If you "
                         "are sure you want to proceed, try again with "
-                        "the '--force' flag."
+                        "the '--force' flag.\n\n"
+                        f"Otherwise pipx is ready to go! {stars}"
                     )
                 )
             return
 
-    userpath.append(str(location))
-    print(f"Success! Added {str(location)} to the PATH environment variable.")
+    userpath.append(location_str)
+    print(f"Success! Added {location_str} to the PATH environment variable.")
     print("")
-    print(f"Open a new terminal to use pipx {stars}")
+    print(f"{post_install_message} {stars}")

--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -4,18 +4,18 @@ import datetime
 import hashlib
 import logging
 import multiprocessing
-import os
 import shlex
 import shutil
 import subprocess
 import textwrap
 import time
-import sys
 import urllib.parse
 import urllib.request
 from pathlib import Path
 from shutil import which
-from typing import List, Optional
+from typing import List
+
+import userpath  # type: ignore
 
 from .animate import animate
 from .colors import bold, red
@@ -25,7 +25,6 @@ from .constants import (
     PIPX_VENV_CACHEDIR,
     TEMP_VENV_EXPIRATION_THRESHOLD_DAYS,
 )
-
 from .emojies import hazard, sleep, stars
 from .util import (
     WINDOWS,
@@ -648,65 +647,18 @@ def run_pip(package: str, venv_dir: Path, pip_args: List[str], verbose: bool):
     venv._run_pip(pip_args)
 
 
-def ensurepath(bin_dir: Path):
-    print("ensurepath command is deprecated. Use 'userpath' instead.", file=sys.stderr)
-    print("See https://github.com/pipxproject/pipx for usage.", file=sys.stderr)
-
-    shell = os.environ.get("SHELL", "")
-    config_file: Optional[str]
-    if "bash" in shell:
-        config_file = "~/.bashrc"
-    elif "zsh" in shell:
-        config_file = "~/.zshrc"
-    elif "fish" in shell:
-        config_file = "~/.config/fish/config.fish"
-    else:
-        config_file = None
-
-    if config_file:
-        config_file = os.path.expanduser(config_file)
-
-    if config_file and os.path.exists(config_file):
-        with open(config_file, "a") as f:
-            f.write("\n# added by pipx (https://github.com/pipxproject/pipx)\n")
-            if "fish" in shell:
-                f.write(f"set -x PATH {str(bin_dir)} $PATH\n\n")
-            else:
-                f.write(f'export PATH="{str(bin_dir)}{os.pathsep}$PATH"\n')
-        print(f"Added {str(bin_dir)} to the PATH environment variable in {config_file}")
-        print("")
-        print(f"Open a new terminal to use pipx {stars}")
-    else:
-        if WINDOWS:
-            print(
-                textwrap.dedent(
-                    f"""
-                Note {hazard}:
-                To finish installation, {str(bin_dir)!r} must be added to your PATH
-                environment variable.
-
-                To do this, go to settings and type "Environment Variables".
-                In the Environment Variables window edit the PATH variable
-                by adding the following to the end of the value, then open a new
-                terminal.
-
-                    ;{str(bin_dir)}
-            """
+def ensurepath(location: Path, *, force: bool):
+    if userpath.in_current_path(str(location)):
+        if not force:
+            logging.warning(
+                (
+                    f"The directory `{str(location)}` is already in PATH. If you "
+                    "are sure you want to proceed, try again with "
+                    "the '--force' flag."
                 )
             )
-
-        else:
-            print(
-                textwrap.dedent(
-                    f"""
-                    Note:
-                    To finish installation, {str(bin_dir)!r} must be added to your PATH
-                    environemnt variable.
-
-                    To do this, add the following line to your shell
-                    config file (such as ~/.bashrc if using bash):
-
-                        export PATH={str(bin_dir)}:$PATH
-                """
-                )
-            )
+            return
+    userpath.append(str(location))
+    print(f"Success! Added {str(location)} to the PATH environment variable.")
+    print("")
+    print(f"Open a new terminal to use pipx {stars}")

--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -648,16 +648,23 @@ def run_pip(package: str, venv_dir: Path, pip_args: List[str], verbose: bool):
 
 
 def ensurepath(location: Path, *, force: bool):
-    if userpath.in_current_path(str(location)):
+    if userpath.in_current_path(str(location)) or userpath.need_shell_restart(location):
         if not force:
-            logging.warning(
-                (
-                    f"The directory `{str(location)}` is already in PATH. If you "
-                    "are sure you want to proceed, try again with "
-                    "the '--force' flag."
+            if userpath.need_shell_restart(location):
+                print(
+                    f"{str(location)} has been already been added to PATH. "
+                    "Open a new terminal for the change to take effect."
                 )
-            )
+            else:
+                logging.warning(
+                    (
+                        f"The directory `{str(location)}` is already in PATH. If you "
+                        "are sure you want to proceed, try again with "
+                        "the '--force' flag."
+                    )
+                )
             return
+
     userpath.append(str(location))
     print(f"Success! Added {str(location)} to the PATH environment variable.")
     print("")

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -440,7 +440,8 @@ def get_command_parser():
         "ensurepath",
         help=(
             "Ensure directory where pipx stores binaries is on your "
-            "PATH environment variable"
+            "PATH environment variable. Note that running this may modify "
+            "your shell's configuration file(s) such as '~/.bashrc'."
         ),
     )
     p.add_argument(

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -4,7 +4,6 @@
 
 import argparse
 import logging
-import os
 import shlex
 import sys
 import textwrap
@@ -13,10 +12,10 @@ from typing import Dict, List, Tuple
 
 from . import commands
 from .constants import (
+    DEFAULT_PIPX_BIN_DIR,
+    DEFAULT_PIPX_HOME,
     DEFAULT_PYTHON,
     LOCAL_BIN_DIR,
-    DEFAULT_PIPX_HOME,
-    DEFAULT_PIPX_BIN_DIR,
     PIPX_LOCAL_VENVS,
     PIPX_VENV_CACHEDIR,
     TEMP_VENV_EXPIRATION_THRESHOLD_DAYS,
@@ -215,14 +214,10 @@ def run_pipx_command(args, binary_args: List[str]):
             raise PipxError("developer error: venv dir is not defined")
         commands.run_pip(package, venv_dir, binary_args, args.verbose)
     elif args.command == "ensurepath":
-        paths = os.getenv("PATH", "").split(os.pathsep)
-        path_good = str(LOCAL_BIN_DIR) in paths
-        if not path_good or args.force:
-            commands.ensurepath(LOCAL_BIN_DIR)
-        else:
-            print(
-                "Your PATH looks like it already is set up for pipx. Pass `--force` to modify the PATH."
-            )
+        try:
+            commands.ensurepath(LOCAL_BIN_DIR, force=args.force)
+        except Exception as e:
+            raise PipxError(e)
     else:
         raise PipxError(f"Unknown command {args.command}")
 
@@ -443,7 +438,10 @@ def get_command_parser():
 
     p = subparsers.add_parser(
         "ensurepath",
-        help="Deprecated, will be removed in a future release. Use `userpath` instead.",
+        help=(
+            "Ensure directory where pipx stores binaries is on your "
+            "PATH environment variable"
+        ),
     )
     p.add_argument(
         "--force",

--- a/templates/index.md
+++ b/templates/index.md
@@ -26,7 +26,7 @@ _pipx uses the word "binary" to describe a CLI application that can be run direc
 
 ```
 python3 -m pip install --user pipx
-python3 -m userpath append ~/.local/bin
+python3 -m pipx ensurepath
 ```
 
 For more details, see [installation](installation).

--- a/templates/readme.md
+++ b/templates/readme.md
@@ -35,7 +35,7 @@ In a hurry? Here's how to get started with pipx:
 
 ```
 python3 -m pip install --user pipx
-python3 -m userpath append ~/.local/bin
+python3 -m pipx ensurepath
 ```
 
 For more details, see [installation](https://pipxproject.github.io/pipx/installation/).


### PR DESCRIPTION
For motivation/discussion issue #178 

## Test plan
```
>> pipx ensurepath
Success! Added /tmp/asdf to the PATH environment variable.

Open a new terminal to use pipx ✨ 🌟 ✨
>> pipx ensurepath
The path has been already been added. Open a new terminal for the change to take effect.
```
```
>> python3 -m pipx ensurepath
The directory `/Users/user/.local/bin` is already in PATH. If you are sure you want to proceed, try again with the '--force' flag.
```

```
>> python3 -m pipx ensurepath --force
Success! Added /Users/user/.local/bin to the PATH environment variable.

Open a new terminal to use pipx ✨ 🌟 ✨
```

cc @jaraco @AlJohri (I tried to add you as reviewers, but when I type your usernames, I get "nothing to show". Not sure what's going on with that.)
