### PR TITLE
add autocomplete functionality and instructions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,5 @@
-0.13.1.2
-
+0.13.2.0
+- Add shell autocompletions. Also add `pipx completions` command to print instructions on how to add pipx completions to your shell.
 - Un-deprecate `ensurepath`. Use `userpath` internally instead of instructing users to run the `userpath` cli command.
 - [dev] Migrate from tox to nox
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,3 +68,10 @@ pipx run nox --session docs
 pipx run nox --session docs
 .nox/docs-3-6/bin/mkdocs serve
 ```
+
+## Release
+To create a new release
+* make sure the changelog is updated
+* update the version of pipx defined in `setup.py`
+* run `make publish`
+* publish updated documenation

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -6,7 +6,7 @@ See Contributing for how to update this file.
 ```
 pipx --help
 usage: pipx [-h] [--version]
-            {install,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall-all,list,run,runpip,ensurepath}
+            {install,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall-all,list,run,runpip,ensurepath,completions}
             ...
 
 Install and execute binaries from Python packages.
@@ -27,7 +27,7 @@ optional arguments:
 subcommands:
   Get help for commands with pipx COMMAND --help
 
-  {install,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall-all,list,run,runpip,ensurepath}
+  {install,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall-all,list,run,runpip,ensurepath,completions}
     install             Install a package
     inject              Install packages into an existing Virtual Environment
     upgrade             Upgrade a package
@@ -48,6 +48,8 @@ subcommands:
                         PATH environment variable. Note that running this may
                         modify your shell's configuration file(s) such as
                         '~/.bashrc'.
+    completions         Print instructions on enabling shell completions for
+                        pipx
 
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,5 +20,3 @@ New versions of pipx are published as beta or release candidates. These versions
 ```
 pip install --user pipx --upgrade --dev
 ```
-Development occurs on the `dev` branch of this repository. If there is no such branch, that means there is no work currently in development for a new version.
-

--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -382,7 +382,7 @@ def _warn_if_not_on_path(local_bin_dir: Path, binary: str):
         logging.warning(
             f"{hazard}  Note: {str(local_bin_dir)!r} is not on your PATH environment "
             "variable. These binaries will not be globally accessible until "
-            "your PATH is updated. Run `userpath append ~/.local/bin` to "
+            "your PATH is updated. Run `pipx ensurepath` to "
             "automatically add it, or manually modify your PATH in your shell's "
             "config file (i.e. ~/.bashrc)."
         )

--- a/pipx/constants.py
+++ b/pipx/constants.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from pathlib import Path
+from textwrap import dedent
 
 DEFAULT_PYTHON = sys.executable
 DEFAULT_PIPX_HOME = Path.home() / ".local/pipx"
@@ -11,3 +12,32 @@ LOCAL_BIN_DIR = Path(os.environ.get("PIPX_BIN_DIR", DEFAULT_PIPX_BIN_DIR)).resol
 PIPX_VENV_CACHEDIR = PIPX_HOME / ".cache"
 PIPX_PACKAGE_NAME = "pipx"
 TEMP_VENV_EXPIRATION_THRESHOLD_DAYS = 14
+
+completion_instructions = dedent(
+    """
+Add the appropriate command to your shell's config file
+so that it is run on startup. You will likely have to restart
+or re-login for the autocompletion to start working.
+
+Bash:
+    eval "$(register-python-argcomplete pipx)"
+
+zsh:
+    To activate completions for zsh you need to have
+    bashcompinit enabled in zsh:
+
+    autoload -U bashcompinit
+    bashcompinit
+
+    Afterwards you can enable completion for pipx:
+
+    eval "$(register-python-argcomplete pipx)"
+
+tcsh:
+    eval `register-python-argcomplete --shell tcsh pipx`
+
+fish:
+    register-python-argcomplete --shell fish pipx | .
+
+"""
+)

--- a/pipx/constants.py
+++ b/pipx/constants.py
@@ -19,7 +19,7 @@ Add the appropriate command to your shell's config file
 so that it is run on startup. You will likely have to restart
 or re-login for the autocompletion to start working.
 
-Bash:
+bash:
     eval "$(register-python-argcomplete pipx)"
 
 zsh:

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -3,7 +3,7 @@
 
 """The command line interface to pipx"""
 
-import argcomplete
+import argcomplete  # type: ignore
 import argparse
 import logging
 import shlex

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
+
 """The command line interface to pipx"""
 
 import argcomplete
@@ -313,7 +315,7 @@ def get_command_parser():
         help="Upgrade a package",
         description="Upgrade a package in a pipx-managed Virtual Environment by running 'pip install --upgrade PACKAGE'",
     )
-    p.add_argument("package")
+    p.add_argument("package").completer = autocomplete_list_of_installed_packages
     p.add_argument("--spec", help=SPEC_HELP)
     add_include_deps(p)
     add_pip_venv_args(p)

--- a/pipx/util.py
+++ b/pipx/util.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import sys
 from typing import List
+from .constants import PIPX_LOCAL_VENVS
 
 
 class PipxError(Exception):
@@ -59,3 +60,7 @@ def run_pypackage_bin(bin_path: Path, args: List[str]) -> int:
         ).returncode
     except KeyboardInterrupt:
         return 1
+
+
+def autocomplete_list_of_installed_packages(*args, **kwargs) -> List[str]:
+    return list(str(p.name) for p in sorted(PIPX_LOCAL_VENVS.iterdir()))

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import re  # noqa E402
 CURDIR = Path(__file__).parent
 
 EXCLUDE_FROM_PACKAGES = ["tests"]
-REQUIRED: List[str] = ["userpath"]
+REQUIRED: List[str] = ["userpath", "argcomplete"]
 
 with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
     README = f.read()

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import re  # noqa E402
 CURDIR = Path(__file__).parent
 
 EXCLUDE_FROM_PACKAGES = ["tests"]
-REQUIRED: List[str] = ["userpath", "argcomplete"]
+REQUIRED: List[str] = ["userpath", "argcomplete>=1.9.4, <2.0"]
 
 with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
     README = f.read()

--- a/tests/test_pipx.py
+++ b/tests/test_pipx.py
@@ -81,6 +81,7 @@ class TestPipxCommands(unittest.TestCase):
     def test_basic_commands(self):
         subprocess.run([self.pipx_bin, "--version"], check=True)
         subprocess.run([self.pipx_bin, "list"], check=True)
+        subprocess.run([self.pipx_bin, "completions"], check=True)
 
     def test_pipx_help_contains_text(self):
         ret = subprocess.run(


### PR DESCRIPTION
As suggested in #181, this PR adds autocomplete functionality. It does not attempt to automatically install autocompletion into the user's shell, but does print instructions when the user types `pipx completions`, similar to `rustup completions`.

It uses the [argcomplete](https://github.com/kislyuk/argcomplete) package and shell installation instructions.

Test plan:
```
>> pipx completions

Add the appropriate command to your shell's config file
so that it is run on startup. You will likely have to restart
or re-login for the autocompletion to start working.

Bash:
    eval "$(register-python-argcomplete pipx)"

zsh:
    To activate completions for zsh you need to have
    bashcompinit enabled in zsh:

    autoload -U bashcompinit
    bashcompinit

    Afterwards you can enable completion for pipx:

    eval "$(register-python-argcomplete pipx)"

tcsh:
    eval `register-python-argcomplete --shell tcsh pipx`

fish:
    register-python-argcomplete --shell fish pipx | .
```

```
> pipx l<tab>
> pipx list
>> pipx list 
venvs are in /home/user/.local/pipx/venvs
binaries are exposed on your $PATH at /home/user/.local/bin
   package black 19.3b0, Python 3.6.8
    - black
    - blackd
   package cowsay 2.0.3, Python 3.6.8
    - cowsay
```

```
pipx uninstall <tab>
black      cowsay     -h         --help     --verbose
```