### PR TITLE
Introduce venv container to abstract away loop

### DIFF
--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -29,6 +29,7 @@ from .emojies import hazard, sleep, stars
 from .util import (
     WINDOWS,
     PipxError,
+    VenvContainer,
     get_pypackage_bin_path,
     mkdir,
     rmdir,
@@ -244,7 +245,7 @@ def upgrade(
 
 
 def upgrade_all(
-    pipx_local_venvs: Path,
+    venv_container: VenvContainer,
     pip_args: List[str],
     verbose: bool,
     *,
@@ -253,7 +254,7 @@ def upgrade_all(
 ):
     packages_upgraded = 0
     num_packages = 0
-    for venv_dir in pipx_local_venvs.iterdir():
+    for venv_dir in venv_container.iter_venv_dirs():
         num_packages += 1
         package = venv_dir.name
         if package in skip:
@@ -451,14 +452,14 @@ def uninstall(venv_dir: Path, package: str, local_bin_dir: Path, verbose: bool):
     print(f"uninstalled {package}! {stars}")
 
 
-def uninstall_all(pipx_local_venvs: Path, local_bin_dir: Path, verbose: bool):
-    for venv_dir in pipx_local_venvs.iterdir():
+def uninstall_all(venv_container: VenvContainer, local_bin_dir: Path, verbose: bool):
+    for venv_dir in venv_container.iter_venv_dirs():
         package = venv_dir.name
         uninstall(venv_dir, package, local_bin_dir, verbose)
 
 
 def reinstall_all(
-    pipx_local_venvs: Path,
+    venv_container: VenvContainer,
     local_bin_dir: Path,
     python: str,
     pip_args: List[str],
@@ -468,7 +469,7 @@ def reinstall_all(
     *,
     skip: List[str],
 ):
-    for venv_dir in pipx_local_venvs.iterdir():
+    for venv_dir in venv_container.iter_venv_dirs():
         package = venv_dir.name
         if package in skip:
             continue
@@ -600,13 +601,13 @@ def _get_list_output(
     return "\n".join(output)
 
 
-def list_packages(pipx_local_venvs: Path):
-    dirs = list(sorted(pipx_local_venvs.iterdir()))
+def list_packages(venv_container: VenvContainer):
+    dirs = list(sorted(venv_container.iter_venv_dirs()))
     if not dirs:
         print(f"nothing has been installed with pipx {sleep}")
         return
 
-    print(f"venvs are in {bold(str(pipx_local_venvs))}")
+    print(f"venvs are in {bold(str(venv_container))}")
     print(f"binaries are exposed on your $PATH at {bold(str(LOCAL_BIN_DIR))}")
 
     with multiprocessing.Pool() as p:

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -265,8 +265,7 @@ def get_command_parser():
     venv_container = VenvContainer(PIPX_LOCAL_VENVS)
 
     autocomplete_list_of_installed_packages = functools.partial(
-        _autocomplete_list_of_installed_packages,
-        venv_container,
+        _autocomplete_list_of_installed_packages, venv_container
     )
 
     parser = argparse.ArgumentParser(

--- a/pipx/util.py
+++ b/pipx/util.py
@@ -4,7 +4,7 @@ import logging
 import shutil
 import subprocess
 import sys
-from typing import List
+from typing import List, Generator
 
 
 class PipxError(Exception):
@@ -74,7 +74,7 @@ class VenvContainer:
     def __str__(self):
         return str(self._root)
 
-    def iter_venv_dirs(self) -> Path:
+    def iter_venv_dirs(self) -> Generator[Path, None, None]:
         """Iterate venv directories in this container.
         """
         for entry in self._root.iterdir():

--- a/pipx/util.py
+++ b/pipx/util.py
@@ -5,7 +5,6 @@ import shutil
 import subprocess
 import sys
 from typing import List
-from .constants import PIPX_LOCAL_VENVS
 
 
 class PipxError(Exception):
@@ -62,5 +61,35 @@ def run_pypackage_bin(bin_path: Path, args: List[str]) -> int:
         return 1
 
 
-def autocomplete_list_of_installed_packages(*args, **kwargs) -> List[str]:
-    return list(str(p.name) for p in sorted(PIPX_LOCAL_VENVS.iterdir()))
+class VenvContainer:
+    """A collection of venvs managed by pipx.
+    """
+    def __init__(self, root: Path):
+        self._root = root
+
+    def __repr__(self):
+        return f"VenvContainer({str(self._root)!r})"
+
+    def __str__(self):
+        return str(self._root)
+
+    def iter_venv_dirs(self) -> Path:
+        """Iterate venv directories in this container.
+        """
+        for entry in self._root.iterdir():
+            if not entry.is_dir():
+                continue
+            yield entry
+
+    def get_venv_dir(self, package: str) -> Path:
+        """Name the expected venv path for given `package`.
+        """
+        return self._root.joinpath(package)
+
+
+def autocomplete_list_of_installed_packages(
+    venv_container: VenvContainer,
+    *args,
+    **kwargs,
+) -> List[str]:
+    return list(str(p.name) for p in sorted(venv_container.iter_venv_dirs()))

--- a/pipx/util.py
+++ b/pipx/util.py
@@ -64,6 +64,7 @@ def run_pypackage_bin(bin_path: Path, args: List[str]) -> int:
 class VenvContainer:
     """A collection of venvs managed by pipx.
     """
+
     def __init__(self, root: Path):
         self._root = root
 
@@ -82,14 +83,12 @@ class VenvContainer:
             yield entry
 
     def get_venv_dir(self, package: str) -> Path:
-        """Name the expected venv path for given `package`.
+        """Return the expected venv path for given `package`.
         """
         return self._root.joinpath(package)
 
 
 def autocomplete_list_of_installed_packages(
-    venv_container: VenvContainer,
-    *args,
-    **kwargs,
+    venv_container: VenvContainer, *args, **kwargs
 ) -> List[str]:
     return list(str(p.name) for p in sorted(venv_container.iter_venv_dirs()))


### PR DESCRIPTION
Fix #185.

The obvious fix is to add `is_dir()` checks to every `iterdir()` calls, but that gets very tedious soon, and is susceptive to future maintainer errors. I decided to completely abstract away this logic instead, introducing a new class to hide the implementation detail. This would also help if pipx ever needs to add extra logic to exclude something from the `venvs` directory, or need to manage venvs in multiple locations.