### PR TITLE
catch FileNotFound exception when removing a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pipx: execute binaries from Python packages in isolated environments
 <a href="https://travis-ci.org/pipxproject/pipx"><img src="https://travis-ci.org/pipxproject/pipx.svg?branch=master" /></a>
 
 <a href="https://pypi.python.org/pypi/pipx/">
-<img src="https://img.shields.io/badge/pypi-0.13.2.2-blue.svg" /></a>
+<img src="https://img.shields.io/badge/pypi-0.13.2.3-blue.svg" /></a>
 <a href="https://github.com/ambv/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+0.13.2.3
+
+- Fix regression when installing a package that doesn't have any entry points
+
 0.13.2.2
 
 - Remove unneccesary and sometimes incorrect check after `pipx inject` (#195)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ See Contributing for how to update this file.
 <a href="https://travis-ci.org/pipxproject/pipx"><img src="https://travis-ci.org/pipxproject/pipx.svg?branch=master" /></a>
 
 <a href="https://pypi.python.org/pypi/pipx/">
-<img src="https://img.shields.io/badge/pypi-0.13.2.2-blue.svg" /></a>
+<img src="https://img.shields.io/badge/pypi-0.13.2.3-blue.svg" /></a>
 <a href="https://github.com/ambv/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -32,7 +32,7 @@ from .util import (
 )
 from .colors import bold, green
 
-__version__ = "0.13.2.2"
+__version__ = "0.13.2.3"
 
 
 def print_version() -> None:

--- a/pipx/util.py
+++ b/pipx/util.py
@@ -23,10 +23,13 @@ emoji_support = not WINDOWS and sys.getdefaultencoding() == "utf-8"
 
 def rmdir(path: Path):
     logging.info(f"removing directory {path}")
-    if WINDOWS:
-        os.system(f'rmdir /S /Q "{str(path)}"')
-    else:
-        shutil.rmtree(path)
+    try:
+        if WINDOWS:
+            os.system(f'rmdir /S /Q "{str(path)}"')
+        else:
+            shutil.rmtree(path)
+    except FileNotFoundError:
+        pass
 
 
 def mkdir(path: Path) -> None:


### PR DESCRIPTION
This was recently introduced when being more aggressive in cleaning up new venvs when installation fails. The existing code already tried to remove the venv in this case, and the new code tries to remove it again, raising this error. The fix is easy: just catch the `FileNotFound` and continue on.