### PR TITLE
fix bare exception if symlink existed and pointed to invalid path

### DIFF
--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -555,7 +555,7 @@ def _symlink_package_apps(
                         f"{hazard}  File exists at {str(symlink_path)} and points "
                         f"to {symlink_path.resolve()}, not {str(app_path)}. Not modifying."
                     )
-                    continue
+                continue
             except FileNotFoundError:
                 symlink_path.unlink()
 

--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -546,7 +546,7 @@ def _symlink_package_apps(
             except IsADirectoryError:
                 rmdir(symlink_path)
 
-        if symlink_path.exists() or symlink_path.is_file() or symlink_path.is_symlink():
+        if symlink_path.exists() or symlink_path.is_symlink():
             try:
                 if symlink_path.samefile(app_path):
                     logging.info(f"Same path {str(symlink_path)} and {str(app_path)}")

--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -546,15 +546,18 @@ def _symlink_package_apps(
             except IsADirectoryError:
                 rmdir(symlink_path)
 
-        if symlink_path.exists():
-            if symlink_path.samefile(app_path):
-                logging.info(f"Same path {str(symlink_path)} and {str(app_path)}")
-            else:
-                logging.warning(
-                    f"{hazard}  File exists at {str(symlink_path)} and points "
-                    f"to {symlink_path.resolve()}, not {str(app_path)}. Not modifying."
-                )
-            continue
+        if symlink_path.exists() or symlink_path.is_file() or symlink_path.is_symlink():
+            try:
+                if symlink_path.samefile(app_path):
+                    logging.info(f"Same path {str(symlink_path)} and {str(app_path)}")
+                else:
+                    logging.warning(
+                        f"{hazard}  File exists at {str(symlink_path)} and points "
+                        f"to {symlink_path.resolve()}, not {str(app_path)}. Not modifying."
+                    )
+                    continue
+            except FileNotFoundError:
+                symlink_path.unlink()
 
         existing_executable_on_path = which(app_name)
         symlink_path.symlink_to(app_path)

--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -546,18 +546,23 @@ def _symlink_package_apps(
             except IsADirectoryError:
                 rmdir(symlink_path)
 
-        if symlink_path.exists() or symlink_path.is_symlink():
-            try:
-                if symlink_path.samefile(app_path):
-                    logging.info(f"Same path {str(symlink_path)} and {str(app_path)}")
-                else:
-                    logging.warning(
-                        f"{hazard}  File exists at {str(symlink_path)} and points "
-                        f"to {symlink_path.resolve()}, not {str(app_path)}. Not modifying."
-                    )
-                continue
-            except FileNotFoundError:
-                symlink_path.unlink()
+        exists = symlink_path.exists()
+        is_symlink = symlink_path.is_symlink()
+        if exists:
+            if symlink_path.samefile(app_path):
+                logging.info(f"Same path {str(symlink_path)} and {str(app_path)}")
+            else:
+                logging.warning(
+                    f"{hazard}  File exists at {str(symlink_path)} and points "
+                    f"to {symlink_path.resolve()}, not {str(app_path)}. Not modifying."
+                )
+            continue
+        if is_symlink and not exists:
+            logging.info(
+                f"Removing existing symlink {str(symlink_path)} since it "
+                "pointed non-existent location"
+            )
+            symlink_path.unlink()
 
         existing_executable_on_path = which(app_name)
         symlink_path.symlink_to(app_path)

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -92,7 +92,7 @@ class LineWrapRawTextHelpFormatter(argparse.RawDescriptionHelpFormatter):
         return textwrap.wrap(text, width)
 
 
-def get_pip_args(parsed_args: Dict):
+def get_pip_args(parsed_args: Dict) -> List[str]:
     pip_args: List[str] = []
     if parsed_args.get("index_url"):
         pip_args += ["--index-url", parsed_args["index_url"]]
@@ -105,14 +105,14 @@ def get_pip_args(parsed_args: Dict):
     return pip_args
 
 
-def get_venv_args(parsed_args: Dict):
+def get_venv_args(parsed_args: Dict) -> List[str]:
     venv_args: List[str] = []
     if parsed_args.get("system_site_packages"):
         venv_args += ["--system-site-packages"]
     return venv_args
 
 
-def run_pipx_command(args):
+def run_pipx_command(args):  # noqa: C901
     setup(args)
     verbose = args.verbose if "verbose" in args else False
     pip_args = get_pip_args(vars(args))

--- a/tests/test_pipx.py
+++ b/tests/test_pipx.py
@@ -259,7 +259,7 @@ class TestPipxCommands(unittest.TestCase):
             check=True,
         )
 
-    def test_symlink_points_to_existing_wrong_location_warning(self):
+    def test_existing_symlink_points_to_existing_wrong_location_warning(self):
         self.bin_dir.mkdir(exist_ok=True, parents=True)
         (self.bin_dir / "pycowsay").symlink_to("/dev/null")
 
@@ -279,7 +279,7 @@ class TestPipxCommands(unittest.TestCase):
         # pointed to the wrong location)
         self.assertTrue("is not on your PATH environment variable" not in stderr)
 
-    def test_symlink_points_to_non_existing_wrong_location_warning(self):
+    def test_existing_symlink_points_to_nothing(self):
         self.bin_dir.mkdir(exist_ok=True, parents=True)
         (self.bin_dir / "pycowsay").symlink_to("/asdf/jkl")
 
@@ -294,6 +294,9 @@ class TestPipxCommands(unittest.TestCase):
         )
         stdout = ret.stdout.decode()
         self.assertTrue("These apps are now globally available" in stdout)
+        self.assertTrue(
+            "symlink missing or pointing to unexpected location" not in stdout
+        )
 
     def test_path_warning(self):
         # warning should appear since temp directory is not on PATH


### PR DESCRIPTION
pipx handled the case where, for example, `~/.local/bin/valid_symlink` existed and pointed to an existing path. pipx would print a warning `File exists at ...`, and would not modify it unless the `--force` flag was present.

This PR fixes the case where , for example, `~/.local/bin/invalid_symlink` exists and points to a non-existing path. pipx would raise a bare exception in this case. Now it removes the symlink and continues on without issue.

fixes #163