### PR TITLE
`pip freeze`-like option for `pipx list`

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -347,12 +347,14 @@ optional arguments:
 
 ```
 pipx list --help
-usage: pipx list [-h] [--verbose]
+usage: pipx list [-h] [--freeze] [--verbose]
 
 List packages and apps installed with pipx
 
 optional arguments:
   -h, --help  show this help message and exit
+  --freeze    Print package information in `pip freeze`-like format. Unlike
+              `pip freeze`, dependencies are not included.
   --verbose
 
 ```

--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -648,6 +648,27 @@ def list_packages(venv_container: VenvContainer):
             print(package_summary)
 
 
+def _get_package_spec(path: Path, *, package: str = None) -> str:
+    venv = Venv(path)
+    if package is None:
+        package = path.name
+    metadata = venv.get_venv_metadata_for_package(package)
+    return f"{package}=={metadata.package_version}"
+
+
+def freeze_packages(venv_container: VenvContainer):
+    dirs = list(sorted(venv_container.iter_venv_dirs()))
+    if not dirs:
+        print("")
+        return
+
+    venv_container.verify_shared_libs()
+
+    with multiprocessing.Pool() as p:
+        for package_spec in p.map(_get_package_spec, dirs):
+            print(package_spec)
+
+
 def _get_exposed_app_paths_for_package(
     venv_bin_path: Path, package_binary_names: List[str], local_bin_dir: Path
 ):

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -2,8 +2,6 @@
 # PYTHON_ARGCOMPLETE_OK
 
 """The command line interface to pipx"""
-from pathlib import Path
-
 import argcomplete  # type: ignore
 import argparse
 import functools
@@ -31,7 +29,7 @@ from .Venv import VenvContainer
 
 
 __version__ = "0.14.0.0"
-__version_info__ = tuple(int(n) for n in __version__.split('.'))
+__version_info__ = tuple(int(n) for n in __version__.split("."))
 
 
 def print_version() -> None:
@@ -197,7 +195,10 @@ def run_pipx_command(args):  # noqa: C901
             force=args.force,
         )
     elif args.command == "list":
-        commands.list_packages(venv_container)
+        if args.freeze:
+            commands.freeze_packages(venv_container)
+        else:
+            commands.list_packages(venv_container)
     elif args.command == "uninstall":
         commands.uninstall(venv_dir, package, LOCAL_BIN_DIR, verbose)
     elif args.command == "uninstall-all":
@@ -417,6 +418,12 @@ def _add_list(subparsers):
         help="List installed packages",
         description="List packages and apps installed with pipx",
     )
+    p.add_argument(
+        "--freeze",
+        action="store_true",
+        help="Print package information in `pip freeze`-like format. "
+        "Unlike `pip freeze`, dependencies are not included.",
+    )
     p.add_argument("--verbose", action="store_true")
 
 
@@ -539,8 +546,7 @@ def get_command_parser():
 
     parser.add_argument("--version", action="store_true", help="Print version and exit")
     subparsers.add_parser(
-        "completions",
-        help="Print instructions on enabling shell completions for pipx",
+        "completions", help="Print instructions on enabling shell completions for pipx"
     )
     return parser
 


### PR DESCRIPTION
The first half of #109 and #156 .

Adds a `--freeze` option to `pipx list`, which prints information in the same format as `pip freeze` / `requirements.txt`. Unlike `pip freeze`, it does not capture all the packages' dependencies (because that wouldn't make any sense here). Like `pip freeze`, it only stores the package name and version, not capturing python/ platform restrictions, non-PyPI sources etc. This could possibly be addressed in a post- #222 world.

Nor does it deal with injected packages.

Next would be adding a `--requirement` option to `pipx install`, which will parse a requirements file and run `commands.install` for each. At that point I would also be inclined to add other ways to install multiple packages at once (e.g. `pip install package1 package2 package3`, `pip install package1  packge2 --spec spec1 --spec spec2`).

P.S. Fantastic project and a great codebase to work in!