### PR TITLE
Add --clear to venv create for shared lib venv.

### DIFF
--- a/pipx/SharedLibs.py
+++ b/pipx/SharedLibs.py
@@ -26,7 +26,7 @@ class _SharedLibs:
     def create(self, pip_args: List[str], verbose: bool = False):
         if not self.is_valid:
             with animate("creating shared libraries", not verbose):
-                run([DEFAULT_PYTHON, "-m", "venv", self.root])
+                run([DEFAULT_PYTHON, "-m", "venv", "--clear", self.root])
             self.upgrade(pip_args, verbose)
 
     @property


### PR DESCRIPTION
This fixes a fatal error that would come with a invalid
python symlink in an existing shared library venv.
This is necessary for reinstall-all to be used successfully
to upgrade a system python (Issue #146)

Since we are creating the shared libraries over again,
it is also just cleaner to allow things to start from
scratch.