### PR TITLE
Typo of completion instead of completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Upgrade pipx with `python3 -m pip install -U pipx`.
 
 Shell completions are available by following the instructions printed with this command:
 ```
-pipx completions
+pipx completion
 ```
 
 For more details, see the [installation instructions](https://pipxproject.github.io/pipx/installation/).


### PR DESCRIPTION
```bash
pm@Velvet4Renaissance:~$ pipx completions
ERROR: unknown command "completions" - maybe you meant "completion"
pm@Velvet4Renaissance:~$ pipx completion
ERROR: You must pass --bash or --fish or --zsh
You are using pip version 9.0.1, however version 19.2.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
pm@Velvet4Renaissance:~$ pipx completion --bash

# pip bash completion start
_pip_completion()
{
    COMPREPLY=( $( COMP_WORDS="${COMP_WORDS[*]}" \
                   COMP_CWORD=$COMP_CWORD \
                   PIP_AUTO_COMPLETE=1 $1 ) )
}
complete -o default -F _pip_completion pip
# pip bash completion end

You are using pip version 9.0.1, however version 19.2.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
pm@Velvet4Renaissance:~$ 
```
(Ignore the pip upgrade, I´ve actually upgraded it before that. But probably ran the pipx command with the default python2 despite have it installed with python3 explicitely)