### PR TITLE
Add Travis Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ matrix:
   - python: '3.6'
   - python: '3.7'
     dist: xenial
+  - os: windows
+    language: bash
+    python: '3.7'
+    before_install:
+      - export TRAVIS_PYTHON_VERSION=3.7
+      - choco install python --version $TRAVIS_PYTHON_VERSION
+      - export PATH="/C/Python37:/C/Python37/Scripts:$PATH"
 install:
   - pip install git+https://github.com/cs01/nox.git@5ea70723e9e6#egg=nox
 script:

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import nox  # type: ignore
 from pathlib import Path
 
@@ -11,8 +14,16 @@ from pathlib import Path
 # https://github.com/theacodes/nox/issues/199
 
 
-python = ["3.6", "3.7"]
-nox.options.sessions = ["unittests", "lint", "docs"]
+travis_python_version = os.environ.get("TRAVIS_PYTHON_VERSION")
+if travis_python_version:
+    python = [travis_python_version]
+else:
+    python = ["3.6", "3.7"]
+
+nox.options.sessions = ["unittests", "lint"]
+# docs fail on Windows, even if `chcp.com 65001` is used
+if sys.platform != "win32":
+    nox.options.sessions.append("docs")
 
 
 doc_dependencies = [".", "jinja2", "mkdocs", "mkdocs-material"]

--- a/tests/test_pipx.py
+++ b/tests/test_pipx.py
@@ -260,9 +260,10 @@ class TestPipxCommands(unittest.TestCase):
             check=True,
         )
 
+    @unittest.skipIf(sys.platform == "win32", reason="fails on Windows")
     def test_existing_symlink_points_to_existing_wrong_location_warning(self):
         self.bin_dir.mkdir(exist_ok=True, parents=True)
-        (self.bin_dir / "pycowsay").symlink_to("/dev/null")
+        (self.bin_dir / "pycowsay").symlink_to(os.devnull)
 
         env = os.environ.copy()
         env["PATH"] = f"{str(self.bin_dir)}:{env.get('PATH')}"


### PR DESCRIPTION
One symlink test is skipped, as it fails on Windows, and symlinks are not as high priority scenario as they are on Unix.

This will at least prevent regressions, and will allow verifiable fixes of the few remaining Windows issues.

Related to https://github.com/pipxproject/pipx/issues/124 and https://github.com/pipxproject/pipx/issues/235