### PR TITLE
Change venv_metadata_inspector to support venv python 3.5+

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -104,7 +104,7 @@ optional arguments:
                         PIPX_BIN_DIR
   --python PYTHON       The Python executable used to create the Virtual
                         Environment and run the associated app/apps. Must be
-                        v3.5+.
+                        v3.3+.
   --system-site-packages
                         Give the virtual environment access to the system
                         site-packages dir.
@@ -152,7 +152,7 @@ optional arguments:
                         git+https://github.com/user/repo.git@branch`
   --verbose
   --python PYTHON       The Python version to run package's CLI app with. Must
-                        be v3.5+.
+                        be v3.3+.
   --system-site-packages
                         Give the virtual environment access to the system
                         site-packages dir.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -104,7 +104,7 @@ optional arguments:
                         PIPX_BIN_DIR
   --python PYTHON       The Python executable used to create the Virtual
                         Environment and run the associated app/apps. Must be
-                        v3.3+.
+                        v3.5+.
   --system-site-packages
                         Give the virtual environment access to the system
                         site-packages dir.
@@ -152,7 +152,7 @@ optional arguments:
                         git+https://github.com/user/repo.git@branch`
   --verbose
   --python PYTHON       The Python version to run package's CLI app with. Must
-                        be v3.3+.
+                        be v3.5+.
   --system-site-packages
                         Give the virtual environment access to the system
                         site-packages dir.

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -293,7 +293,7 @@ def _add_install(subparsers):
         default=constants.DEFAULT_PYTHON,
         help=(
             "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. Must be v3.3+."
+            "associated app/apps. Must be v3.5+."
         ),
     )
     add_pip_venv_args(p)
@@ -469,7 +469,7 @@ def _add_run(subparsers):
     p.add_argument(
         "--python",
         default=constants.DEFAULT_PYTHON,
-        help="The Python version to run package's CLI app with. Must be v3.3+.",
+        help="The Python version to run package's CLI app with. Must be v3.5+.",
     )
     add_pip_venv_args(p)
 

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -293,7 +293,7 @@ def _add_install(subparsers):
         default=constants.DEFAULT_PYTHON,
         help=(
             "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. Must be v3.5+."
+            "associated app/apps. Must be v3.3+."
         ),
     )
     add_pip_venv_args(p)
@@ -469,7 +469,7 @@ def _add_run(subparsers):
     p.add_argument(
         "--python",
         default=constants.DEFAULT_PYTHON,
-        help="The Python version to run package's CLI app with. Must be v3.5+.",
+        help="The Python version to run package's CLI app with. Must be v3.3+.",
     )
     add_pip_venv_args(p)
 

--- a/pipx/venv_metadata_inspector.py
+++ b/pipx/venv_metadata_inspector.py
@@ -86,7 +86,7 @@ def main():
 
     apps = get_apps(package, bin_path)
     app_paths = [str(Path(bin_path) / app) for app in apps]
-    app_paths_of_dependencies: Dict[str, List[str]] = {}
+    app_paths_of_dependencies = {}  # type: Dict[str, List[str]]
     app_paths_of_dependencies = _dfs_package_apps(
         bin_path, package, app_paths_of_dependencies
     )

--- a/pipx/venv_metadata_inspector.py
+++ b/pipx/venv_metadata_inspector.py
@@ -96,7 +96,9 @@ def main():
         "app_paths": app_paths,
         "app_paths_of_dependencies": app_paths_of_dependencies,
         "package_version": get_package_version(package),
-        "python_version": f"Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        "python_version": "Python {}.{}.{}".format(
+            sys.version_info.major, sys.version_info.minor, sys.version_info.micro
+        ),
     }
 
     print(json.dumps(output))

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3,6 +3,8 @@
 import os
 import sys
 from unittest import mock
+from shutil import which
+
 
 import pytest  # type: ignore
 
@@ -10,6 +12,9 @@ from helpers import assert_not_in_virtualenv, run_pipx_cli
 from pipx import constants
 
 assert_not_in_virtualenv()
+
+
+PYTHON3_5 = which("python3.5")
 
 
 def test_help_text(monkeypatch, capsys):
@@ -122,3 +127,10 @@ def test_existing_symlink_points_to_nothing(pipx_temp_env, caplog, capsys):
     # pipx should realize the symlink points to nothing and replace it,
     # so no warning should be present
     assert "symlink missing or pointing to unexpected location" not in captured.out
+
+
+def test_install_python3_5(pipx_temp_env):
+    if PYTHON3_5:
+        assert not run_pipx_cli(["install", "cowsay", "--python", PYTHON3_5])
+    else:
+        pytest.skip("python3.5 not on PATH")


### PR DESCRIPTION
Changed some syntax in venv_metadata_inspector.py and to support python 3.5+
* Used type comment instead of inline type
* Used .format() instead of f-string

Changed help/docs to reflect that venvs support python 3.5+ (not python 3.3+)

Reference: #231 