### PR TITLE
test_install: python3.5 compatibility with pyenv

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,5 @@
+from shutil import which
+import subprocess
 import sys
 from typing import List
 from unittest import mock
@@ -13,3 +15,12 @@ def assert_not_in_virtualenv():
 def run_pipx_cli(pipx_args: List[str]):
     with mock.patch.object(sys, "argv", ["pipx"] + pipx_args):
         return main.cli()
+
+
+def which_python(python_exe):
+    pyenv_which = subprocess.run(["pyenv", "which", python_exe], stdout=subprocess.PIPE)
+    if not pyenv_which.returncode:
+        python_path = pyenv_which.stdout.decode().strip()
+    else:
+        python_path = which(python_exe)
+    return python_path

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -20,13 +20,16 @@ def run_pipx_cli(pipx_args: List[str]):
 def which_python(python_exe):
     try:
         pyenv_which = subprocess.run(
-            ["pyenv", "which", python_exe], stdout=subprocess.PIPE, universal_newlines=True
+            ["pyenv", "which", python_exe],
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
         )
     except FileNotFoundError:
         # no pyenv on system
         return which(python_exe)
 
-    if pyenv_which.returncode==0:
+    if pyenv_which.returncode == 0:
         return pyenv_which.stdout.strip()
     else:
+        # pyenv on system, but pyenv has no path to python_exe
         return None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -18,9 +18,15 @@ def run_pipx_cli(pipx_args: List[str]):
 
 
 def which_python(python_exe):
-    pyenv_which = subprocess.run(["pyenv", "which", python_exe], stdout=subprocess.PIPE)
-    if not pyenv_which.returncode:
-        python_path = pyenv_which.stdout.decode().strip()
+    try:
+        pyenv_which = subprocess.run(
+            ["pyenv", "which", python_exe], stdout=subprocess.PIPE, universal_newlines=True
+        )
+    except FileNotFoundError:
+        # no pyenv on system
+        return which(python_exe)
+
+    if pyenv_which.returncode==0:
+        return pyenv_which.stdout.strip()
     else:
-        python_path = which(python_exe)
-    return python_path
+        return None

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3,18 +3,17 @@
 import os
 import sys
 from unittest import mock
-from shutil import which
 
 
 import pytest  # type: ignore
 
-from helpers import assert_not_in_virtualenv, run_pipx_cli
+from helpers import assert_not_in_virtualenv, run_pipx_cli, which_python
 from pipx import constants
 
 assert_not_in_virtualenv()
 
 
-PYTHON3_5 = which("python3.5")
+PYTHON3_5 = which_python("python3.5")
 
 
 def test_help_text(monkeypatch, capsys):


### PR DESCRIPTION
With the current test in `test_install.py` involving installing a package using python3.5, our current setup is incompatible with pyenv and fails with it.

The reason for this is because using `shutil.which()` returns a path to the pyenv shim script for the python3.5 executable, not the path to the executable itself.  This shim needs both env and bash for its shebang, and we don't have `/usr/bin` and `/bin` on our path, so this shim script fails.

This pull request adds a helper function that is pyenv-aware, `python_which()`, which first tries to use `pyenv which` if it exists to get the real path to the executable, and then if pyenv is not on the system falls back to using the same `shutil.which()` method as before.