### PR TITLE
fix `unable to execute 'gcc'` error when running tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,6 @@ lint_dependencies = ["black", "flake8", "mypy", "check-manifest"]
 def tests(session):
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
-    session.run("which", "gcc")
     session.run(
         "pytest", "--cov=pipx", "--cov-config", ".coveragerc", "--cov-report=", *tests
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,6 @@ def tests(session):
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
     session.run("which", "gcc")
-    session.run("pip", "install", "black")
     session.run(
         "pytest", "--cov=pipx", "--cov-config", ".coveragerc", "--cov-report=", *tests
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,6 +35,7 @@ lint_dependencies = ["black", "flake8", "mypy", "check-manifest"]
 def tests(session):
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
+    session.run("which", "gcc")
     session.run(
         "pytest", "--cov=pipx", "--cov-config", ".coveragerc", "--cov-report=", *tests
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,6 +36,7 @@ def tests(session):
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
     session.run("which", "gcc")
+    session.run("pip", "install", "black")
     session.run(
         "pytest", "--cov=pipx", "--cov-config", ".coveragerc", "--cov-report=", *tests
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest  # type: ignore
@@ -20,6 +21,7 @@ def pipx_temp_env(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, "PIPX_HOME", home_dir)
     monkeypatch.setattr(constants, "LOCAL_BIN_DIR", bin_dir)
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
-
+    
+    # add /usr/bin so a compiled package can find gcc
     env_path = [Path("/usr/bin"), bin_dir]
-    monkeypatch.setenv("PATH", ":".join([str(x) for x in env_path]))
+    monkeypatch.setenv("PATH", os.pathsep.join([str(x) for x in env_path]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def pipx_temp_env(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, "PIPX_HOME", home_dir)
     monkeypatch.setattr(constants, "LOCAL_BIN_DIR", bin_dir)
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
-    
+
     # add /usr/bin so a compiled package can find gcc
     env_path = [Path("/usr/bin"), bin_dir]
     monkeypatch.setenv("PATH", os.pathsep.join([str(x) for x in env_path]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,4 +21,4 @@ def pipx_temp_env(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, "LOCAL_BIN_DIR", bin_dir)
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
 
-    monkeypatch.setenv("PATH", str(bin_dir))
+    monkeypatch.setenv("PATH", ":".join(["/usr/bin", str(bin_dir)]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,4 +21,5 @@ def pipx_temp_env(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, "LOCAL_BIN_DIR", bin_dir)
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
 
-    monkeypatch.setenv("PATH", ":".join(["/usr/bin", str(bin_dir)]))
+    env_path = [Path("/usr/bin"), bin_dir]
+    monkeypatch.setenv("PATH", ":".join([str(x) for x in env_path]))


### PR DESCRIPTION
Fixes #266 

gcc resides in `/usr/bin`.  Adding `/usr/bin` to the system path in `tests/conftest.py` allows gcc to be found if a python library needs to be compiled.

Possibly before all the libraries we needed had wheels, and now some do not have wheels for particular python versions?