### PR TITLE
Fix help text for reinstall-all --python arg.

### DIFF
--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -411,7 +411,7 @@ def _add_reinstall_all(subparsers):
         "--python",
         default=constants.DEFAULT_PYTHON,
         help=(
-            "The Python executable used to reinstall the Virtual Environment "
+            "The Python executable used to recreate the Virtual Environment "
             "and run the associated app/apps. Must be v3.5+."
         ),
     )

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -410,7 +410,10 @@ def _add_reinstall_all(subparsers):
     p.add_argument(
         "--python",
         default=constants.DEFAULT_PYTHON,
-        help="The Python version to reinstall the package's CLI app with. Must be v3.5+.",
+        help=(
+            "The Python executable used to reinstall the Virtual Environment "
+            "and run the associated app/apps. Must be v3.5+."
+        ),
     )
     add_include_dependencies(p)
     add_pip_venv_args(p)


### PR DESCRIPTION
This is a tiny fix for an awkward help blurb for the --python option of reinstall-all.  I made it more clear and more in line with install help text.

I'm assuming this won't be problematic, and if there are no objections I will merge it myself.