### PR TITLE
Monkeypatch PIPX_VENV_CACHEDIR in pipx_temp_env.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def pipx_temp_env(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, "PIPX_HOME", home_dir)
     monkeypatch.setattr(constants, "LOCAL_BIN_DIR", bin_dir)
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
+    monkeypatch.setattr(constants, "PIPX_VENV_CACHEDIR", home_dir / ".cache")
 
     # add /usr/bin so a compiled package can find gcc
     env_path = [Path("/usr/bin"), bin_dir]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -27,6 +27,7 @@ def test_simple_run(pipx_temp_env, monkeypatch, capsys):
 
 
 def test_cache(pipx_temp_env, monkeypatch, capsys, caplog):
+    run_pipx_cli(["run", "pycowsay", "cowsay", "args"])
     caplog.set_level(logging.DEBUG)
     assert not run_pipx_cli(["run", "--verbose", "pycowsay", "cowsay", "args"])
     assert "Reusing cached venv" in caplog.text


### PR DESCRIPTION
As of now, PIPX_VENV_CACHEDIR is not properly monkeypatched, and so is not isolated in the temp directory when using fixture `pipx_temp_env`.  It currently uses the user's `~/.local/pipx/.cache`.

This fixes that and properly monkeypatches PIPX_VENV_CACHEDIR for proper test isolation.