### PR TITLE
Add default tool outputs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.nox/
+/.coverage
 *egg*
 .mypy_cache
 .vscode


### PR DESCRIPTION
Following the contributing guide in the docs creates the following:

* .coverage - for coverage information
* .nox/ - for nox environments

Adding these to the .gitignore improves the developer experience.