### PR TITLE
inject, install accept package spec without --spec option

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,7 @@
 dev
 
+- `install` now has no `--spec` option.  You may specify any valid pip specification for `install`'s main argument.
+- `inject` will now accept pip specifications for dependency arguments
 - Metadata is now stored for each application installed, including install options like `--spec`, and injected packages. This information allows upgrade, upgrade-all and reinstall-all to work properly even with non-pypi installed packages.  (#222)
 - `upgrade` options `--spec` and `--include-deps` were removed.  Pipx now uses the original options used to install each application instead. (#222)
 - `upgrade-all` options `--include-deps`, `--system-site-packages`, `--index-url`, `--editable`, and `--pip-args` were removed.  Pipx now uses the original options used to install each application instead. (#222)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -16,12 +16,12 @@ pipx install --include-deps jupyter
 pipx enables you to test various combinations of Python versions and package versions in ephemeral environments:
 ```
 pipx run BINARY  # latest version of binary is run with python3
-pipx --spec PACKAGE==2.0.0 run BINARY  # specific version of package is run
-pipx --python 3.4 run BINARY  # Installed and invoked with specific Python version
-pipx --python 3.7 --spec PACKAGE=1.7.3 run BINARY
-pipx --spec git+https://url.git run BINARY  # latest version on master is run
-pipx --spec git+https://url.git@branch run BINARY
-pipx --spec git+https://url.git@hash run BINARY
+pipx run --spec PACKAGE==2.0.0 BINARY  # specific version of package is run
+pipx run --python 3.4 BINARY  # Installed and invoked with specific Python version
+pipx run --python 3.7 --spec PACKAGE=1.7.3 BINARY
+pipx run --spec git+https://url.git BINARY  # latest version on master is run
+pipx run --spec git+https://url.git@branch BINARY
+pipx run --spec git+https://url.git@hash BINARY
 pipx run pycowsay moo
 pipx --version  # prints pipx version
 pipx run pycowsay --version  # prints pycowsay version

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -24,14 +24,14 @@ pipx --spec git+https://url.git@branch run BINARY
 pipx --spec git+https://url.git@hash run BINARY
 pipx run pycowsay moo
 pipx --version  # prints pipx version
-pipx run pycowsay  --version  # prints pycowsay version
-pipx --python pythonX pycowsay
-pipx --spec pycowsay==2.0 pycowsay --version
-pipx --spec git+https://github.com/psf/black.git black
-pipx --spec git+https://github.com/psf/black.git@branch-name black
-pipx --spec git+https://github.com/psf/black.git@git-hash black
-pipx --spec https://github.com/psf/black/archive/18.9b0.zip black --help
-pipx https://gist.githubusercontent.com/cs01/fa721a17a326e551ede048c5088f9e0f/raw/6bdfbb6e9c1132b1c38fdd2f195d4a24c540c324/pipx-demo.py
+pipx run pycowsay --version  # prints pycowsay version
+pipx run --python pythonX pycowsay
+pipx run --spec pycowsay==2.0 pycowsay --version
+pipx run --spec git+https://github.com/psf/black.git black
+pipx run --spec git+https://github.com/psf/black.git@branch-name black
+pipx run --spec git+https://github.com/psf/black.git@git-hash black
+pipx run --spec https://github.com/psf/black/archive/18.9b0.zip black --help
+pipx run https://gist.githubusercontent.com/cs01/fa721a17a326e551ede048c5088f9e0f/raw/6bdfbb6e9c1132b1c38fdd2f195d4a24c540c324/pipx-demo.py
 ```
 
 ## `pipx inject` example

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -3,11 +3,11 @@
 pipx install pycowsay
 pipx install --python python3.6 pycowsay
 pipx install --python python3.7 pycowsay
-pipx install --spec git+https://github.com/ambv/black black
-pipx --spec git+https://github.com/ambv/black.git@branch-name black
-pipx --spec git+https://github.com/ambv/black.git@git-hash black
-pipx install --spec https://github.com/ambv/black/archive/18.9b0.zip black
-pipx install --spec black[d] black
+pipx install git+https://github.com/ambv/black
+pipx install git+https://github.com/ambv/black.git@branch-name
+pipx install git+https://github.com/ambv/black.git@git-hash
+pipx install https://github.com/ambv/black/archive/18.9b0.zip
+pipx install black[d]
 pipx install --include-deps jupyter
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -3,10 +3,10 @@
 pipx install pycowsay
 pipx install --python python3.6 pycowsay
 pipx install --python python3.7 pycowsay
-pipx install git+https://github.com/ambv/black
-pipx install git+https://github.com/ambv/black.git@branch-name
-pipx install git+https://github.com/ambv/black.git@git-hash
-pipx install https://github.com/ambv/black/archive/18.9b0.zip
+pipx install git+https://github.com/psf/black
+pipx install git+https://github.com/psf/black.git@branch-name
+pipx install git+https://github.com/psf/black.git@git-hash
+pipx install https://github.com/psf/black/archive/18.9b0.zip
 pipx install black[d]
 pipx install --include-deps jupyter
 ```
@@ -27,10 +27,10 @@ pipx --version  # prints pipx version
 pipx run pycowsay  --version  # prints pycowsay version
 pipx --python pythonX pycowsay
 pipx --spec pycowsay==2.0 pycowsay --version
-pipx --spec git+https://github.com/ambv/black.git black
-pipx --spec git+https://github.com/ambv/black.git@branch-name black
-pipx --spec git+https://github.com/ambv/black.git@git-hash black
-pipx --spec https://github.com/ambv/black/archive/18.9b0.zip black --help
+pipx --spec git+https://github.com/psf/black.git black
+pipx --spec git+https://github.com/psf/black.git@branch-name black
+pipx --spec git+https://github.com/psf/black.git@git-hash black
+pipx --spec https://github.com/psf/black/archive/18.9b0.zip black --help
 pipx https://gist.githubusercontent.com/cs01/fa721a17a326e551ede048c5088f9e0f/raw/6bdfbb6e9c1132b1c38fdd2f195d4a24c540c324/pipx-demo.py
 ```
 

--- a/src/pipx/commands/commands.py
+++ b/src/pipx/commands/commands.py
@@ -215,8 +215,7 @@ def inject(
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
     if package_name is None:
-        # TODO 20191223: make '_python' member public 'python'.
-        package_name = _package_name_from_spec(package_spec, venv._python)
+        package_name = _package_name_from_spec(package_spec, venv.python)
 
     try:
         venv.install_package(

--- a/src/pipx/commands/commands.py
+++ b/src/pipx/commands/commands.py
@@ -14,7 +14,7 @@ from pipx import constants
 from pipx.colors import bold
 from pipx.commands.common import expose_apps_globally, get_package_summary
 from pipx.emojies import hazard, stars
-from pipx.util import WINDOWS, PipxError, rmdir
+from pipx.util import WINDOWS, PipxError, rmdir, valid_pypi_name
 from pipx.venv import Venv, VenvContainer, PackageInstallFailureError
 
 
@@ -89,6 +89,15 @@ def install(
 
 def _package_name_from_spec(package_spec: str, python: str) -> str:
     start_time = time.time()
+
+    package_name: Optional[str]
+
+    # TODO 20191223: Need to check if --editable and local path?
+    if valid_pypi_name(package_spec):
+        package_name = package_spec
+        logging.info(f"Determined package name: {package_name}")
+        logging.info(f"Elapsed time: {time.time()-start_time:.1f}s")
+        return package_name
 
     with tempfile.TemporaryDirectory() as temp_venv_dir:
         venv = Venv(Path(temp_venv_dir), python=python)

--- a/src/pipx/commands/commands.py
+++ b/src/pipx/commands/commands.py
@@ -58,21 +58,14 @@ def install(
     venv = Venv(venv_dir, python=python, verbose=verbose)
     try:
         venv.create_venv(venv_args, pip_args)
-        try:
-            venv.install_package(
-                package=package_name,
-                package_or_url=package_spec,
-                pip_args=pip_args,
-                include_dependencies=include_dependencies,
-                include_apps=True,
-                is_main_package=True,
-            )
-        except PackageInstallFailureError:
-            venv.remove_venv()
-            raise PipxError(
-                f"Could not install package {package_name}. Is the name or spec correct?"
-            )
-
+        venv.install_package(
+            package=package_name,
+            package_or_url=package_spec,
+            pip_args=pip_args,
+            include_dependencies=include_dependencies,
+            include_apps=True,
+            is_main_package=True,
+        )
         _run_post_install_actions(
             venv,
             package_name,
@@ -105,8 +98,7 @@ def _package_name_from_spec(package_spec: str, python: str) -> str:
         package_name = venv.install_package_no_deps(
             package_or_url=package_spec, pip_args=[]
         )
-        if package_name is None:
-            raise PipxError(f"Unable to validate {package_spec}")
+
     logging.info(f"Package name determined in {time.time()-start_time:.1f}s")
     return package_name
 

--- a/src/pipx/commands/commands.py
+++ b/src/pipx/commands/commands.py
@@ -14,13 +14,7 @@ from pipx import constants
 from pipx.colors import bold
 from pipx.commands.common import expose_apps_globally, get_package_summary
 from pipx.emojies import hazard, stars
-from pipx.util import (
-    WINDOWS,
-    PipxError,
-    PackageInstallFailureError,
-    rmdir,
-    valid_pypi_name,
-)
+from pipx.util import WINDOWS, PipxError, rmdir, valid_pypi_name
 from pipx.venv import Venv, VenvContainer
 
 
@@ -215,19 +209,14 @@ def inject(
     if package_name is None:
         package_name = _package_name_from_spec(package_spec, venv.python)
 
-    try:
-        venv.install_package(
-            package=package_name,
-            package_or_url=package_spec,
-            pip_args=pip_args,
-            include_dependencies=include_dependencies,
-            include_apps=include_apps,
-            is_main_package=False,
-        )
-    except PackageInstallFailureError:
-        raise PipxError(
-            f"Could not inject package {package_spec}. Is the name or spec correct?"
-        )
+    venv.install_package(
+        package=package_name,
+        package_or_url=package_spec,
+        pip_args=pip_args,
+        include_dependencies=include_dependencies,
+        include_apps=include_apps,
+        is_main_package=False,
+    )
     if include_apps:
         _run_post_install_actions(
             venv,

--- a/src/pipx/commands/commands.py
+++ b/src/pipx/commands/commands.py
@@ -102,22 +102,14 @@ def _package_name_from_spec(package_spec: str, python: str) -> str:
     with tempfile.TemporaryDirectory() as temp_venv_dir:
         venv = Venv(Path(temp_venv_dir), python=python)
         venv.create_venv(venv_args=[], pip_args=[])
-        try:
-            venv.install_package(
-                package=None,
-                package_or_url=package_spec,
-                pip_args=[],
-                include_dependencies=False,
-                include_apps=True,  # metadata-only, so metadata validates
-                is_main_package=True,
-            )
-        except PackageInstallFailureError:
-            raise PipxError(f"Unable to validate {package_spec}")
-        package_name = venv.pipx_metadata.main_package.package
+        package_name = venv.install_package_no_deps(
+            package_or_url=package_spec, pip_args=[]
+        )
         if package_name is None:
             raise PipxError(f"Unable to validate {package_spec}")
-    logging.info(f"Determined package name: {package_name}")
-    logging.info(f"Elapsed time: {time.time()-start_time:.1f}s")
+    logging.info(
+        f"Package name determination elapsed time: {time.time()-start_time:.1f}s"
+    )
     return package_name
 
 

--- a/src/pipx/commands/commands.py
+++ b/src/pipx/commands/commands.py
@@ -83,8 +83,6 @@ def install(
 def _package_name_from_spec(package_spec: str, python: str) -> str:
     start_time = time.time()
 
-    package_name: Optional[str]
-
     # shortcut if valid PYPI name and not a local path
     if valid_pypi_name(package_spec) and not Path(package_spec).exists():
         package_name = package_spec

--- a/src/pipx/commands/commands.py
+++ b/src/pipx/commands/commands.py
@@ -14,8 +14,14 @@ from pipx import constants
 from pipx.colors import bold
 from pipx.commands.common import expose_apps_globally, get_package_summary
 from pipx.emojies import hazard, stars
-from pipx.util import WINDOWS, PipxError, rmdir, valid_pypi_name
-from pipx.venv import Venv, VenvContainer, PackageInstallFailureError
+from pipx.util import (
+    WINDOWS,
+    PipxError,
+    PackageInstallFailureError,
+    rmdir,
+    valid_pypi_name,
+)
+from pipx.venv import Venv, VenvContainer
 
 
 def install(

--- a/src/pipx/commands/commands.py
+++ b/src/pipx/commands/commands.py
@@ -4,6 +4,7 @@ import logging
 import sys
 import textwrap
 import tempfile
+import time
 from pathlib import Path
 from shutil import which
 from typing import List, Optional
@@ -87,6 +88,8 @@ def install(
 
 
 def _package_name_from_spec(package_spec: str, python: str) -> str:
+    start_time = time.time()
+
     with tempfile.TemporaryDirectory() as temp_venv_dir:
         venv = Venv(Path(temp_venv_dir), python=python)
         venv.create_venv(venv_args=[], pip_args=[])
@@ -96,7 +99,7 @@ def _package_name_from_spec(package_spec: str, python: str) -> str:
                 package_or_url=package_spec,
                 pip_args=[],
                 include_dependencies=False,
-                include_apps=True,  # TODO 20191223: is this ok? Needed for metadata to validate
+                include_apps=True,  # metadata-only, so metadata validates
                 is_main_package=True,
             )
         except PackageInstallFailureError:
@@ -105,6 +108,7 @@ def _package_name_from_spec(package_spec: str, python: str) -> str:
         if package_name is None:
             raise PipxError(f"Unable to validate {package_spec}")
     logging.info(f"Determined package name: {package_name}")
+    logging.info(f"Elapsed time: {time.time()-start_time:.1f}s")
     return package_name
 
 

--- a/src/pipx/commands/commands.py
+++ b/src/pipx/commands/commands.py
@@ -92,11 +92,11 @@ def _package_name_from_spec(package_spec: str, python: str) -> str:
 
     package_name: Optional[str]
 
-    # TODO 20191223: Need to check if --editable and local path?
-    if valid_pypi_name(package_spec):
+    # shortcut if valid PYPI name and not a local path
+    if valid_pypi_name(package_spec) and not Path(package_spec).exists():
         package_name = package_spec
         logging.info(f"Determined package name: {package_name}")
-        logging.info(f"Elapsed time: {time.time()-start_time:.1f}s")
+        logging.info(f"Package name determined in {time.time()-start_time:.1f}s")
         return package_name
 
     with tempfile.TemporaryDirectory() as temp_venv_dir:
@@ -107,9 +107,7 @@ def _package_name_from_spec(package_spec: str, python: str) -> str:
         )
         if package_name is None:
             raise PipxError(f"Unable to validate {package_spec}")
-    logging.info(
-        f"Package name determination elapsed time: {time.time()-start_time:.1f}s"
-    )
+    logging.info(f"Package name determined in {time.time()-start_time:.1f}s")
     return package_name
 
 

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -15,11 +15,12 @@ from pipx.emojies import hazard
 from pipx.util import (
     WINDOWS,
     PipxError,
+    PackageInstallFailureError,
     get_pypackage_bin_path,
     rmdir,
     run_pypackage_bin,
 )
-from pipx.venv import PackageInstallFailureError, Venv
+from pipx.venv import Venv
 
 
 def run(

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -15,7 +15,6 @@ from pipx.emojies import hazard
 from pipx.util import (
     WINDOWS,
     PipxError,
-    PackageInstallFailureError,
     get_pypackage_bin_path,
     rmdir,
     run_pypackage_bin,
@@ -120,17 +119,14 @@ def _download_and_run(
     #   pre-existing, otherwise is None to instruct venv.install_package to
     #   determine package name.
 
-    try:
-        venv.install_package(
-            package=venv.pipx_metadata.main_package.package,
-            package_or_url=package_or_url,
-            pip_args=pip_args,
-            include_dependencies=False,
-            include_apps=True,
-            is_main_package=True,
-        )
-    except PackageInstallFailureError:
-        raise PipxError(f"Unable to install {package_or_url}")
+    venv.install_package(
+        package=venv.pipx_metadata.main_package.package,
+        package_or_url=package_or_url,
+        pip_args=pip_args,
+        include_dependencies=False,
+        include_apps=True,
+        is_main_package=True,
+    )
 
     if not (venv.bin_path / app).exists():
         apps = venv.pipx_metadata.main_package.apps

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -177,8 +177,8 @@ def run_pipx_command(args):  # noqa: C901
         for dep in args.dependencies:
             commands.inject(
                 venv_dir,
+                None,
                 dep,
-                dep,  # NOP now, but in future can be package_or_url from --spec
                 pip_args,
                 verbose=verbose,
                 include_apps=args.include_apps,

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -74,13 +74,13 @@ you can cleanly upgrade or uninstall. Guaranteed to not have
 dependency version conflicts or interfere with your OS's python
 packages. 'sudo' is not required to do this.
 
-pipx install PACKAGE
-pipx install --python PYTHON PACKAGE
-pipx install --spec VCS_URL PACKAGE
-pipx install --spec ZIP_FILE PACKAGE
-pipx install --spec TAR_GZ_FILE PACKAGE
+pipx install PACKAGE_NAME
+pipx install --python PYTHON PACKAGE_NAME
+pipx install VCS_URL
+pipx install ZIP_FILE
+pipx install TAR_GZ_FILE
 
-The argument to `--spec` is passed directly to `pip install`.
+The PACKAGE_SPEC argument is passed directly to `pip install`.
 
 The default virtual environment location is {constants.DEFAULT_PIPX_HOME}
 and can be overridden by setting the environment variable `PIPX_HOME`
@@ -130,6 +130,7 @@ def run_pipx_command(args):  # noqa: C901
         if urllib.parse.urlparse(package).scheme:
             raise PipxError("Package cannot be a url")
 
+        # TODO 20191223: this may not be used anymore
         if "spec" in args and args.spec is not None:
             if urllib.parse.urlparse(args.spec).scheme:
                 if "#egg=" not in args.spec:
@@ -157,13 +158,10 @@ def run_pipx_command(args):  # noqa: C901
             use_cache,
         )
     elif args.command == "install":
-        package_or_url = (
-            args.spec if ("spec" in args and args.spec is not None) else package
-        )
         return commands.install(
-            venv_dir,
-            package,
-            package_or_url,
+            None,
+            None,
+            args.package_spec,
             constants.LOCAL_BIN_DIR,
             args.python,
             pip_args,
@@ -264,8 +262,7 @@ def _add_install(subparsers):
         formatter_class=LineWrapRawTextHelpFormatter,
         description=INSTALL_DESCRIPTION,
     )
-    p.add_argument("package", help="package name")
-    p.add_argument("--spec", help=SPEC_HELP)
+    p.add_argument("package_spec", help="package name or pip installation spec")
     add_include_dependencies(p)
     p.add_argument("--verbose", action="store_true")
     p.add_argument(

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -130,7 +130,6 @@ def run_pipx_command(args):  # noqa: C901
         if urllib.parse.urlparse(package).scheme:
             raise PipxError("Package cannot be a url")
 
-        # TODO 20191223: this may not be used anymore
         if "spec" in args and args.spec is not None:
             if urllib.parse.urlparse(args.spec).scheme:
                 if "#egg=" not in args.spec:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -294,7 +294,7 @@ def _add_inject(subparsers, autocomplete_list_of_installed_packages):
     p.add_argument(
         "dependencies",
         nargs="+",
-        help="the packages to inject into the Virtual Environment",
+        help="the packages to inject into the Virtual Environment--either package name or pip package spec",
     )
     p.add_argument(
         "--include-apps",

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -140,5 +140,5 @@ def valid_pypi_name(package_name: str) -> bool:
 def full_package_description(package, package_or_url):
     name_str = f"{package}"
     if package != package_or_url:
-        name_str += f" from specification {package_or_url!r}"
+        name_str += f" from spec. {package_or_url!r}"
     return name_str

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -14,6 +14,10 @@ class PipxError(Exception):
     pass
 
 
+class PackageInstallFailureError(PipxError):
+    pass
+
+
 def rmdir(path: Path):
     logging.info(f"removing directory {path}")
     try:
@@ -123,9 +127,8 @@ def run(cmd: Sequence[Union[str, Path]], check=True) -> int:
         cmd, capture_stdout=False, capture_stderr=False
     ).returncode
 
-    cmd_str = " ".join(str(c) for c in cmd)
-
     if check and returncode:
+        cmd_str = " ".join(str(c) for c in cmd)
         raise PipxError(f"{cmd_str!r} failed")
     return returncode
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -135,3 +135,10 @@ def valid_pypi_name(package_name: str) -> bool:
     return bool(
         re.search(r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", package_name, re.I)
     )
+
+
+def full_package_description(package, package_or_url):
+    name_str = f"{package}"
+    if package != package_or_url:
+        name_str += f" from specification {package_or_url!r}"
+    return name_str

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -137,8 +137,8 @@ def valid_pypi_name(package_name: str) -> bool:
     )
 
 
-def full_package_description(package, package_spec):
-    name_str = f"{package}"
-    if package != package_spec:
-        name_str += f" from spec. {package_spec!r}"
-    return name_str
+def full_package_description(package: str, package_spec: str) -> str:
+    if package == package_spec:
+        return package
+    else:
+        return f"{package} from spec {package_spec!r}"

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -137,8 +137,8 @@ def valid_pypi_name(package_name: str) -> bool:
     )
 
 
-def full_package_description(package, package_or_url):
+def full_package_description(package, package_spec):
     name_str = f"{package}"
-    if package != package_or_url:
-        name_str += f" from spec. {package_or_url!r}"
+    if package != package_spec:
+        name_str += f" from spec. {package_spec!r}"
     return name_str

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -14,10 +14,6 @@ class PipxError(Exception):
     pass
 
 
-class PackageInstallFailureError(PipxError):
-    pass
-
-
 def rmdir(path: Path):
     logging.info(f"removing directory {path}")
     try:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -127,3 +128,10 @@ def run(cmd: Sequence[Union[str, Path]], check=True) -> int:
     if check and returncode:
         raise PipxError(f"{cmd_str!r} failed")
     return returncode
+
+
+def valid_pypi_name(package_name: str) -> bool:
+    # https://www.python.org/dev/peps/pep-0508/#names
+    return bool(
+        re.search(r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", package_name, re.I)
+    )

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -141,7 +141,7 @@ class Venv:
         # https://docs.python.org/3/library/site.html
         # A path configuration file is a file whose name has the form 'name.pth'.
         # its contents are additional items (one per line) to be added to sys.path
-        pipx_pth.write_text(str(shared_libs.site_packages) + "\n", encoding="utf-8")
+        pipx_pth.write_text(f"{shared_libs.site_packages}\n", encoding="utf-8")
 
         self.pipx_metadata.venv_args = venv_args
         self.pipx_metadata.python_version = self.get_python_version()
@@ -186,7 +186,7 @@ class Venv:
                 package = "??"
 
         with animate(
-            "installing " + full_package_description(package, package_or_url),
+            "installing {full_package_description(package, package_or_url)}",
             self.do_animation,
         ):
             cmd = ["install"] + pip_args + [package_or_url]
@@ -314,7 +314,7 @@ class Venv:
 
     def _upgrade_package_no_metadata(self, package: str, pip_args: List[str]) -> None:
         with animate(
-            "upgrading " + full_package_description(package, package), self.do_animation
+            "upgrading {full_package_description(package, package)}", self.do_animation
         ):
             self._run_pip(["install"] + pip_args + ["--upgrade", package])
 
@@ -328,7 +328,7 @@ class Venv:
         is_main_package: bool,
     ) -> None:
         with animate(
-            "upgrading " + full_package_description(package, package_or_url),
+            "upgrading {full_package_description(package, package_or_url)}",
             self.do_animation,
         ):
             self._run_pip(["install"] + pip_args + ["--upgrade", package_or_url])

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -231,7 +231,7 @@ class Venv:
             logging.info(f"Determined package name: '{package}'")
         else:
             package = None
-            logging.info(f"Unable to determined package name for: '{package_or_url}'")
+            logging.info(f"Unable to determine package name for: '{package_or_url}'")
 
         return package
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -182,9 +182,11 @@ class Venv:
             # If no package name is supplied, install only main package
             #   first in order to see what its name is
             package = self.install_package_no_deps(package_or_url, pip_args)
-            # TODO 20191228: should we just fail if we cannot determine package?
             if package is None:
-                package = "??"
+                logging.warning(
+                    f"Cannot determine package name for spec {package_or_url!r}. "
+                )
+                raise PackageInstallFailureError
 
         with animate(
             f"installing {full_package_description(package, package_or_url)}",
@@ -192,14 +194,6 @@ class Venv:
         ):
             cmd = ["install"] + pip_args + [package_or_url]
             self._run_pip(cmd)
-
-        if package is None:
-            logging.warning(
-                f"Cannot determine package name for package_or_url='{package_or_url}'. "
-                f"Unable to retrieve package metadata. "
-                f"Unable to verify if package was installed properly."
-            )
-            return
 
         self._update_package_metadata(
             package=package,

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -12,7 +12,6 @@ from pipx.pipx_metadata_file import PipxMetadata, PackageInfo
 from pipx.shared_libs import shared_libs
 from pipx.util import (
     PipxError,
-    PackageInstallFailureError,
     full_package_description,
     get_script_output,
     get_site_packages,
@@ -189,7 +188,7 @@ class Venv:
                 self._run_pip(cmd)
         except PipxError as e:
             logging.info(e)
-            raise PackageInstallFailureError(
+            raise PipxError(
                 f"Error installing "
                 f"{full_package_description(package, package_or_url)}."
             )
@@ -205,7 +204,7 @@ class Venv:
 
         # Verify package installed ok
         if self.package_metadata[package].package_version is None:
-            raise PackageInstallFailureError(
+            raise PipxError(
                 f"Unable to install "
                 f"{full_package_description(package, package_or_url)}.\n"
                 f"Check the name or spec for errors, and verify that it can "

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -182,10 +182,8 @@ class Venv:
             # If no package name is supplied, install only main package
             #   first in order to see what its name is
             package = self.install_package_no_deps(package_or_url, pip_args)
-
-        install_message = f"installing {package}"
-        if package != package_or_url:
-            install_message += f" from specification {package_or_url!r}"
+            if package is None:
+                package = "??"
 
         with animate(
             "installing " + full_package_description(package, package_or_url),

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -207,8 +207,9 @@ class Venv:
         if self.package_metadata[package].package_version is None:
             raise PackageInstallFailureError(
                 f"Unable to install "
-                f"{full_package_description(package, package_or_url)}."
-                f"Check the name or spec for errors."
+                f"{full_package_description(package, package_or_url)}.\n"
+                f"Check the name or spec for errors, and verify that it can "
+                f"be installed with pip."
             )
 
     def install_package_no_deps(self, package_or_url: str, pip_args: List[str]) -> str:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -17,6 +17,7 @@ from pipx.util import (
     rmdir,
     run,
     run_subprocess,
+    valid_pypi_name,
 )
 
 
@@ -340,11 +341,7 @@ def abs_path_if_local(package_or_url: str, venv: Venv, pip_args: List[str]) -> s
     if "--editable" in pip_args and pkg_path.exists():
         return str(pkg_path.resolve())
 
-    # https://www.python.org/dev/peps/pep-0508/#names
-    valid_pkg_name = bool(
-        re.search(r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", package_or_url, re.I)
-    )
-    if not valid_pkg_name:
+    if not valid_pypi_name(package_or_url):
         return str(pkg_path.resolve())
 
     # If all of the above conditions do not return, we may have used a pypi

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -182,11 +182,12 @@ class Venv:
             # If no package name is supplied, install only main package
             #   first in order to see what its name is
             package = self.install_package_no_deps(package_or_url, pip_args)
+            # TODO 20191228: should we just fail if we cannot determine package?
             if package is None:
                 package = "??"
 
         with animate(
-            "installing {full_package_description(package, package_or_url)}",
+            f"installing {full_package_description(package, package_or_url)}",
             self.do_animation,
         ):
             cmd = ["install"] + pip_args + [package_or_url]
@@ -314,7 +315,7 @@ class Venv:
 
     def _upgrade_package_no_metadata(self, package: str, pip_args: List[str]) -> None:
         with animate(
-            "upgrading {full_package_description(package, package)}", self.do_animation
+            f"upgrading {full_package_description(package, package)}", self.do_animation
         ):
             self._run_pip(["install"] + pip_args + ["--upgrade", package])
 
@@ -328,7 +329,7 @@ class Venv:
         is_main_package: bool,
     ) -> None:
         with animate(
-            "upgrading {full_package_description(package, package_or_url)}",
+            f"upgrading {full_package_description(package, package_or_url)}",
             self.do_animation,
         ):
             self._run_pip(["install"] + pip_args + ["--upgrade", package_or_url])

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -219,7 +219,9 @@ class Venv:
     ) -> Optional[str]:
         package: Optional[str]
 
-        with animate(f"resolving {package_or_url!r}", self.do_animation):
+        with animate(
+            f"determining package name from {package_or_url!r}", self.do_animation
+        ):
             old_package_set = self.list_installed_packages()
             cmd = ["install"] + pip_args + ["--no-dependencies"] + [package_or_url]
             self._run_pip(cmd)

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -80,7 +80,7 @@ class Venv:
         self, path: Path, *, verbose: bool = False, python: str = DEFAULT_PYTHON
     ) -> None:
         self.root = path
-        self._python = python
+        self.python = python
         self.bin_path, self.python_path = get_venv_paths(self.root)
         self.pipx_metadata = PipxMetadata(venv_dir=path)
         self.verbose = verbose
@@ -126,7 +126,7 @@ class Venv:
 
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
         with animate("creating virtual environment", self.do_animation):
-            cmd = [self._python, "-m", "venv", "--without-pip"]
+            cmd = [self.python, "-m", "venv", "--without-pip"]
             run(cmd + venv_args + [str(self.root)])
         shared_libs.create(pip_args, self.verbose)
         pipx_pth = get_site_packages(self.python_path) / PIPX_SHARED_PTH

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -2,6 +2,7 @@ import json
 import logging
 import pkgutil
 import re
+import urllib.parse
 from pathlib import Path
 from typing import Generator, List, NamedTuple, Dict, Set, Optional
 
@@ -354,6 +355,10 @@ def abs_path_if_local(package_or_url: str, venv: Venv, pip_args: List[str]) -> s
     """Return the absolute path if package_or_url represents a filepath
     and not a pypi package
     """
+    # if valid url leave it untouched
+    if urllib.parse.urlparse(package_or_url).scheme:
+        return package_or_url
+
     pkg_path = Path(package_or_url)
     if not pkg_path.exists():
         # no existing path, must be pypi package or non-existent

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -7,6 +7,11 @@ def test_simple(pipx_temp_env, capsys):
     assert not run_pipx_cli(["inject", "pycowsay", "black"])
 
 
+def test_spec(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", "pylint==2.3.1"])
+
+
 def test_include_apps(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert run_pipx_cli(["inject", "pycowsay", "black", "--include-deps"])

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -85,10 +85,8 @@ def test_install_same_package_twice_no_error(pipx_temp_env, capsys):
 
 
 def test_include_deps(pipx_temp_env, capsys):
-    assert run_pipx_cli(["install", "jupyter", "--spec", "jupyter==1.0.0"]) == 1
-    assert not run_pipx_cli(
-        ["install", "jupyter", "--spec", "jupyter==1.0.0", "--include-deps"]
-    )
+    assert run_pipx_cli(["install", "jupyter==1.0.0"]) == 1
+    assert not run_pipx_cli(["install", "jupyter==1.0.0", "--include-deps"])
 
 
 def test_path_warning(pipx_temp_env, capsys, monkeypatch, caplog):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -60,12 +60,13 @@ def test_install_tricky_packages(capsys, pipx_temp_env, caplog, package):
     install_package(capsys, pipx_temp_env, caplog, package)
 
 
-# TODO 20191223: Add git+... spec when git is in path
+# TODO 20191223: Add git+... spec when git is in binpath of tests
 @pytest.mark.parametrize(
     "package_name,package_spec",
     [
         # ("nox", "git+https://github.com/cs01/nox.git@5ea70723e9e6"),
         ("pylint", "pylint==2.3.1"),
+        ("black", "https://github.com/ambv/black/archive/18.9b0.zip"),
     ],
 )
 def test_install_package_specs(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -25,10 +25,13 @@ def test_help_text(monkeypatch, capsys):
     assert "apps you can run from anywhere" in captured.out
 
 
-def install_package(capsys, pipx_temp_env, caplog, package):
+def install_package(capsys, pipx_temp_env, caplog, package, package_name=""):
+    if not package_name:
+        package_name = package
+
     run_pipx_cli(["install", package, "--verbose"])
     captured = capsys.readouterr()
-    assert f"installed package {package}" in captured.out
+    assert f"installed package {package_name}" in captured.out
     if not sys.platform.startswith("win"):
         # TODO assert on windows too
         # https://github.com/pipxproject/pipx/issues/217
@@ -55,6 +58,19 @@ def test_install_tricky_packages(capsys, pipx_temp_env, caplog, package):
     if sys.platform.startswith("win"):
         pytest.skip("TODO make this work on Windows")
     install_package(capsys, pipx_temp_env, caplog, package)
+
+
+@pytest.mark.parametrize(
+    "package_name,package_spec",
+    [
+        ("nox", "git+https://github.com/cs01/nox.git@5ea70723e9e6"),
+        ("pylint", "pylint==2.3.1"),
+    ],
+)
+def test_install_package_specs(
+    capsys, pipx_temp_env, caplog, package_name, package_spec
+):
+    install_package(capsys, pipx_temp_env, caplog, package_spec, package_name)
 
 
 def test_force_install(pipx_temp_env, capsys):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -60,10 +60,11 @@ def test_install_tricky_packages(capsys, pipx_temp_env, caplog, package):
     install_package(capsys, pipx_temp_env, caplog, package)
 
 
+# TODO 20191223: Add git+... spec when git is in path
 @pytest.mark.parametrize(
     "package_name,package_spec",
     [
-        ("nox", "git+https://github.com/cs01/nox.git@5ea70723e9e6"),
+        # ("nox", "git+https://github.com/cs01/nox.git@5ea70723e9e6"),
         ("pylint", "pylint==2.3.1"),
     ],
 )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -60,7 +60,7 @@ def test_install_tricky_packages(capsys, pipx_temp_env, caplog, package):
     install_package(capsys, pipx_temp_env, caplog, package)
 
 
-# TODO 20191223: Add git+... spec when git is in binpath of tests
+# TODO: Add git+... spec when git is in binpath of tests (Issue #303)
 @pytest.mark.parametrize(
     "package_name,package_spec",
     [


### PR DESCRIPTION
This PR allows the user to specify any valid pip package specification instead of a package name for the main argument to `pip install` and each dependency argument to `pip inject`.  It removes the `--spec` option for `pip install` because now that option is unnecessary.  And it enables a package spec for `pip inject` which formerly wasn't possible.

It takes about 2 extra seconds on my local computer to determine the package name from package spec.  If `package_spec` is a valid pypi name and not a local path, I make a shortcut and assume that it is the package name and don't try to independently determine the name (in which case it takes no extra time).

I tried to add some tests, but there could be more tests added, specifically regarding the many different VCS and other URL methods to specify pip packages.  One issue with that is that `git+...` package specifications need `git` in the path, which I wasn't sure how to do.  (https://github.com/pipxproject/pipx/pull/298#issuecomment-568642820 seems like a good way forward on this.)  Additionally, I just wasn't sure where to find good package urls to use to test.

This PR is in reference to issue #147 

