### PR TITLE
Integrate flake8-bugbear in nox lint session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ else:
 
 
 doc_dependencies = [".", "jinja2", "mkdocs", "mkdocs-material"]
-lint_dependencies = ["black", "flake8", "mypy", "check-manifest"]
+lint_dependencies = ["black", "flake8", "flake8-bugbear", "mypy", "check-manifest"]
 
 
 @nox.session(python=python)


### PR DESCRIPTION
See #258.

Not able to install Python 3.7 for running the lint session locally, hence waiting for the output of the travis build.