### PR TITLE
remove python_requires from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,11 @@ import sys
 from setuptools import find_packages, setup  # type: ignore
 
 if sys.version_info < (3, 6, 0):
-    print("pipx requires Python 3.6 or later")
-    exit(1)
+    sys.exit(
+        "Python 3.6 or later is required. "
+        "See https://github.com/pipxproject/pipx "
+        "for installation instructions."
+    )
 
 import io  # noqa E402
 import os  # noqa E402

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,9 @@ import sys
 from setuptools import find_packages, setup  # type: ignore
 
 if sys.version_info < (3, 6, 0):
-    print("Python 3.6+ is required")
+    print("pipx requires Python 3.6 or later")
     exit(1)
+
 import io  # noqa E402
 import os  # noqa E402
 from pathlib import Path  # noqa E402
@@ -15,13 +16,13 @@ import re  # noqa E402
 
 CURDIR = Path(__file__).parent
 
-REQUIRED: List[str] = ["userpath", "argcomplete>=1.9.4, <2.0"]
+REQUIRED = ["userpath", "argcomplete>=1.9.4, <2.0"]  # type: List[str]
 
 with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
     README = f.read()
 
 
-def get_version() -> str:
+def get_version():
     main_file = CURDIR / "src" / "pipx" / "main.py"
     _version_re = re.compile(r"__version__\s+=\s+(?P<version>.*)")
     with open(main_file, "r", encoding="utf8") as f:
@@ -47,7 +48,6 @@ setup(
     scripts=[],
     entry_points={"console_scripts": ["pipx = pipx.main:cli"]},
     zip_safe=False,
-    python_requires=">=3.6",
     install_requires=REQUIRED,
     test_suite="tests.test_pipx",
     classifiers=[

--- a/src/pipx/__init__.py
+++ b/src/pipx/__init__.py
@@ -1,6 +1,7 @@
 import sys
 
-assert sys.version_info >= (3, 6, 0), (
-    "Python 3.6+ is required. See https://github.com/pipxproject/pipx "
-    "for installation instructions"
-)
+if sys.version_info < (3, 6, 0):
+    exit(
+        "Python 3.6+ is required. See https://github.com/pipxproject/pipx "
+        "for installation instructions."
+    )

--- a/src/pipx/__init__.py
+++ b/src/pipx/__init__.py
@@ -1,7 +1,8 @@
 import sys
 
 if sys.version_info < (3, 6, 0):
-    exit(
-        "Python 3.6+ is required. See https://github.com/pipxproject/pipx "
+    sys.exit(
+        "Python 3.6 or later is required. "
+        "See https://github.com/pipxproject/pipx "
         "for installation instructions."
     )


### PR DESCRIPTION
Test that python2 fails to install and prints a helpful error message
```
>> pip install .
Processing /home/csmith/git/pipx
    Complete output from command python setup.py egg_info:
    pipx requires Python 3.6 or later
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-XFhHFn-build/
```

fixes #237