### PR TITLE
[bugfix] fix 'delay' in animate api

### DIFF
--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -19,7 +19,9 @@ NONEMOJI_FRAME_PERIOD = 1
 
 
 @contextmanager
-def animate(message: str, do_animation: bool) -> Generator[None, None, None]:
+def animate(
+    message: str, do_animation: bool, *, delay: float = 0
+) -> Generator[None, None, None]:
 
     if not do_animation or not stderr_is_tty:
         # no op
@@ -41,7 +43,7 @@ def animate(message: str, do_animation: bool) -> Generator[None, None, None]:
         "message": message,
         "event": event,
         "symbols": symbols,
-        "delay": 0,
+        "delay": delay,
         "period": period,
         "animate_at_beginning_of_line": animate_at_beginning_of_line,
     }
@@ -70,6 +72,7 @@ def print_animation(
     animate_at_beginning_of_line: bool,
 ):
     (term_cols, _) = shutil.get_terminal_size(fallback=(9999, 24))
+    event.wait(delay)
     while not event.wait(0):
         for s in symbols:
             if animate_at_beginning_of_line:

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -30,8 +30,8 @@ def test_delay_suppresses_output(capsys, monkeypatch):
 
     test_string = "asdf"
 
-    with pipx.animate.animate(test_string, do_animation=True, delay=0.1):
-        time.sleep(0.05)
+    with pipx.animate.animate(test_string, do_animation=True, delay=0.9):
+        time.sleep(0.5)
     captured = capsys.readouterr()
     assert test_string not in captured.err
 

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -25,6 +25,17 @@ def check_animate_output(
     assert captured.err[:chars_to_test] == expected_string[:chars_to_test]
 
 
+def test_delay_suppresses_output(capsys, monkeypatch):
+    monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
+
+    test_string = "asdf"
+
+    with pipx.animate.animate(test_string, do_animation=True, delay=0.1):
+        time.sleep(0.05)
+    captured = capsys.readouterr()
+    assert test_string not in captured.err
+
+
 def test_line_lengths_emoji(capsys, monkeypatch):
     # emoji_support and stderr_is_tty is set only at import animate.py
     # since we are already after that, we must override both here


### PR DESCRIPTION
Delay is an argument to functions, but wasn't used. This PR actually implements the delay.