### PR TITLE
Add Python 3.8 to classifiers in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3 :: Only",
     ],
     project_urls={


### PR DESCRIPTION
I noticed that the latest release doesn't specifically list Python 3.8 alongside other python versions.

Since we actually test for it I figured it was worth adding.