### PR TITLE
Add python 3.8 to travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     - python: "3.7"
       env: NOXSESSION="tests-3.7"
       dist: xenial
+    - python: "3.8"
+      env: NOXSESSION="tests-3.8"
     - python: "3.7"
       env: NOXSESSION="lint"
       dist: xenial


### PR DESCRIPTION
Add python 3.8 test to travis matrix.  Related to #314 