### PR TITLE
allow direct invocation from src directory

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,46 +1,27 @@
 Thanks for your interest in contributing to pipx!
 
+## Running pipx From Source Tree
+To run the pipx executable from your source tree during development, run pipx from the src directory:
 
-## Dependencies
+```
+python src/pipx --version
+```
+
+## Running Tests
+
+### Setup
 pipx uses an automation tool called [nox](https://pypi.org/project/nox/) for development, continuous integration testing, and various tasks.
 
 `nox` defines tasks or "sessions" in `noxfile.py` which can be run with `nox -s SESSION_NAME`. Session names can be listed with `nox -l`.
 
 Install nox for pipx development:
 ```
-pip install --user git+https://github.com/cs01/nox.git@5ea70723e9e6 nox
+python -m pip install --user git+https://github.com/cs01/nox.git@5ea70723e9e6 nox
 ```
 
 !!! note
     A specific version of nox must be used for pipx development until [nox issue 233](https://github.com/theacodes/nox/issues/233) is resolved.
 
-
-## Developing pipx
-Clone pipx, then enter the root of the pipx repository. Run this command to see which commands you can run with nox.
-```
-nox -l
-```
-
-You should see some options that look like this
-```
-- develop-3.6
-- develop-3.7
-- develop-3.8
-```
-
-Choose the Python version you want to develop in and run the following commands, modifying with your version as necessary.
-```
-nox -s develop-3.8
-source .nox/develop-3.8/bin/activate
-```
-
-A virtual environment with required dependencies is now sandboxed and activated!
-
-Go ahead and make your changes now. You can confirm they still work by running unit tests (see the next section).
-
-To leave the environment, type `deactivate`.
-
-## Testing pipx locally
 Tests are defined as `nox` sessions. You can see all nox sessions with
 ```
 nox -l
@@ -66,11 +47,11 @@ Sessions defined in /home/csmith/git/pipx/noxfile.py:
 - publish_docs
 ```
 
-So to run unit tests in Python3.7, you can run
+### Unit Tests
+To run unit tests in Python3.7, you can run
 ```
 nox -s tests-3.7
 ```
-
 
 !!! tip
     You can running a specific unit test by passing arguments to pytest, the test runner pipx uses:
@@ -87,16 +68,16 @@ nox -s tests-3.7
 
     Coverage errors can usually be ignored when only running a subset of tests.
 
-To run lint checks, run
+### Lint Tests
+
 ```
 nox -s lint
 ```
-and so on.
 
 ## Testing pipx on Continuous Integration builds
 When you push a new git branch, tests will automatically be run against your code as defined in `.travis`.
 
-## Documentation
+## Building Documentation
 
 `pipx` autogenerates API documentation, and also uses templates.
 
@@ -119,14 +100,16 @@ nox -s watch_docs
 nox -s publish_docs
 ```
 
-## Release New `pipx` Version
+## Releasing New `pipx` Versions
 To create a new release
 
+* update pipx's version in `__main__.py` and regenerate documentation
 * make sure the changelog is updated
-* update the version of pipx defined in `setup.py`
 
 Finally, run
 ```bash
 nox -s publish
 nox -s publish_docs
 ```
+
+and create a new release in GitHub.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -103,7 +103,7 @@ nox -s publish_docs
 ## Releasing New `pipx` Versions
 To create a new release
 
-* update pipx's version in `__main__.py` and regenerate documentation
+* update pipx's version in `main.py` and regenerate documentation
 * make sure the changelog is updated
 
 Finally, run

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ python3 -m pip install -U pipx
 ```
 
 ### Note: Upgrading pipx from a pre-0.15.0.0 version to 0.15.0.0 or later
-When upgrading to pipx 0.15.0.0 or above from a pre-0.15.0.0 version, you must re-install all packages to take advantage of the new persistent pipx metadata files introduced in the 0.15.0.0 release. These metadata files store pip specification values, injected packages, any custom pip arguments, and more in each main package's venv.
+After upgrading to pipx 0.15.0.0 or above from a pre-0.15.0.0 version, you must re-install all packages to take advantage of the new persistent pipx metadata files introduced in the 0.15.0.0 release. These metadata files store pip specification values, injected packages, any custom pip arguments, and more in each main package's venv.
 
 If you have no packages installed using the `--spec` option, and no venvs with injected packages, you can do this by running `pipx reinstall-all`.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,15 +13,22 @@ python3 -m pip install --user pipx
 python3 -m pipx ensurepath
 ```
 
+### Installation Options
+pipx's default binary location is `~/.local/bin`. This can be overriden with the environment variable `PIPX_BIN_DIR`.
+
+pipx's default virtual environment location is `~/.local/pipx`. This can be overridden with the environment variable `PIPX_HOME`.
+
 ## Upgrade pipx
 ```
 python3 -m pip install -U pipx
 ```
 
-### Installation Options
-pipx's default binary location is `~/.local/bin`. This can be overriden with the environment variable `PIPX_BIN_DIR`.
+### Note: Upgrading pipx from a pre-0.15.0.0 version to 0.15.0.0 or later
+When upgrading to pipx 0.15.0.0 or above from a pre-0.15.0.0 version, you must re-install all packages to take advantage of the new persistent pipx metadata files introduced in the 0.15.0.0 release. These metadata files store pip specification values, injected packages, any custom pip arguments, and more in each main package's venv.
 
-pipx's default virtual environment location is `~/.local/pipx`. This can be overridden with the environment variable `PIPX_HOME`.
+If you have no packages installed using the `--spec` option, and no venvs with injected packages, you can do this by running `pipx reinstall-all`.
+
+If you have any packages installed using the `--spec` option or venvs with injected packages, you should reinstall packages manually using `pipx uninstall-all`, followed by `pipx install` and possibly `pipx inject`.
 
 ## Shell Completion
 You can easily get your shell's tab completions working by following instructions printed with this command:

--- a/src/pipx/__main__.py
+++ b/src/pipx/__main__.py
@@ -1,4 +1,15 @@
-from .main import cli
+import os
+import sys
+
+if not __package__:
+    # Running from source. Add pipx's source code to the system
+    # path to allow direct invocation, such as:
+    #   python src/pipx --help
+    pipx_package_source_path = os.path.dirname(os.path.dirname(__file__))
+    sys.path.insert(0, pipx_package_source_path)
+
+from pipx.main import cli  # noqa
+
 
 if __name__ == "__main__":
-    cli()
+    sys.exit(cli())


### PR DESCRIPTION
After looking at pip's instructions (https://pip.pypa.io/en/stable/development/getting-started/) I thought pipx could benefit from a similar contributor workflow. 

With this change, pipx can be run from source with `python src/pipx --version` with no setup, and no ambiguity about what is being run. The contributing instructions were updated to reflect this.