### PR TITLE
pass pip_args and verbose flag when determining package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See Contributing for how to update this file.
 <a href="https://travis-ci.org/pipxproject/pipx"><img src="https://travis-ci.org/pipxproject/pipx.svg?branch=master" /></a>
 
 <a href="https://pypi.python.org/pypi/pipx/">
-<img src="https://img.shields.io/badge/pypi-0.15.0.0-blue.svg" /></a>
+<img src="https://img.shields.io/badge/pypi-0.15.0.1-blue.svg" /></a>
 <a href="https://github.com/ambv/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+0.15.0.1
+
+- [bugfix] pass pip arguments to pip when determining package name
+
 0.15.0.0
 
 Upgrade instructions: When upgrading to 0.15.0.0 or above from a pre-0.15.0.0 version, you must re-install all packages to take advantage of the new persistent pipx metadata files introduced in this release. These metadata files store pip specification values, injected packages, any custom pip arguments, and more in each main package's venv. You can do this by running `pipx reinstall-all` or `pipx uninstall-all`, then reinstalling manually.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ See Contributing for how to update this file.
 <a href="https://travis-ci.org/pipxproject/pipx"><img src="https://travis-ci.org/pipxproject/pipx.svg?branch=master" /></a>
 
 <a href="https://pypi.python.org/pypi/pipx/">
-<img src="https://img.shields.io/badge/pypi-0.15.0.0-blue.svg" /></a>
+<img src="https://img.shields.io/badge/pypi-0.15.0.1-blue.svg" /></a>
 <a href="https://github.com/ambv/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -21,7 +21,7 @@ from . import constants
 from .util import PipxError, mkdir
 from .venv import VenvContainer
 
-__version__ = "0.15.0.0"
+__version__ = "0.15.0.1"
 
 
 def simple_parse_version(s, segments=4) -> Tuple[Union[int, str], ...]:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -148,3 +148,19 @@ def test_install_python3_5(pipx_temp_env):
         assert not run_pipx_cli(["install", "cowsay", "--python", PYTHON3_5])
     else:
         pytest.skip("python3.5 not on PATH")
+
+
+def test_pip_args_forwarded_to_package_name_determination(
+    pipx_temp_env, caplog, capsys
+):
+    assert run_pipx_cli(
+        [
+            "install",
+            # use a valid spec and invalid pip args
+            "https://github.com/ambv/black/archive/18.9b0.zip",
+            "--verbose",
+            "--pip-args='--asdf'",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert "Cannot determine package name from spec" in captured.err


### PR DESCRIPTION
This passes pip arguments to the command that determines the package name. It also passes the verbose flag to the venv creation which suppresses the animation output when running in verbose mode. These were regressions in the 0.15 release.

cc @tsiq-rob, @tsiq-alberto

fixes #320 