### PR TITLE
pipx install --editable: fix regression

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+dev
+
+- [bugfix] fix regression that caused installing with --editable flag to fail package name determination.
+
 0.15.1.0
 
 - Add Python 3.8 to PyPI classifier and travis test matrix

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -102,11 +102,13 @@ def get_pip_args(parsed_args: Dict) -> List[str]:
     if parsed_args.get("index_url"):
         pip_args += ["--index-url", parsed_args["index_url"]]
 
-    if parsed_args.get("editable"):
-        pip_args += ["--editable"]
-
     if parsed_args.get("pip_args"):
         pip_args += shlex.split(parsed_args.get("pip_args", ""))
+
+    # make sure --editable is last because it needs to be right before
+    #   package specification
+    if parsed_args.get("editable"):
+        pip_args += ["--editable"]
     return pip_args
 
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -216,7 +216,7 @@ class Venv:
                 f"determining package name from {package_or_url!r}", self.do_animation
             ):
                 old_package_set = self.list_installed_packages()
-                cmd = ["install"] + pip_args + ["--no-dependencies"] + [package_or_url]
+                cmd = ["install"] + ["--no-dependencies"] + pip_args + [package_or_url]
                 self._run_pip(cmd)
         except PipxError as e:
             logging.info(e)


### PR DESCRIPTION
This is for #322 

There was a regression that occurred with #302 which made editable installations fail.

`--editable` needs either a local directory or VCS spec right after it to be valid for pip.

This PR puts the `--no-dependencies` option FIRST in the pip args inside of `venv.py` `install_package_no_deps()`, so that `--editable` is still last in options and right before the package specification.

This PR also reorders pip args in `main.py` `get_pip_args()` so that `--editable` is sure to be last (formerly, it used to precede pipx's `--pipx_args`.)