### PR TITLE
Fix dependency apps recursive search

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+dev
+
+- [bugfix] Fix recursive search of dependencies' apps so no apps are missed.
+
 0.15.1.1
 
 - [bugfix] fix regression that caused installing with --editable flag to fail package name determination.

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -80,10 +80,10 @@ def _dfs_package_apps(
         if d not in dep_visited:
             # only search if this package isn't already listed to avoid
             # infinite recursion
+            dep_visited[d] = True
             app_paths_of_dependencies = _dfs_package_apps(
                 bin_path, d, app_paths_of_dependencies, dep_visited
             )
-            dep_visited[d] = True
     return app_paths_of_dependencies
 
 

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -62,7 +62,10 @@ def get_apps(package: str, bin_path: Path) -> List[str]:
 
 
 def _dfs_package_apps(
-    bin_path: Path, package: str, app_paths_of_dependencies: Dict[str, List[str]]
+    bin_path: Path,
+    package: str,
+    app_paths_of_dependencies: Dict[str, List[str]],
+    dep_visited: Dict[str, bool],
 ):
     dependencies = get_package_dependencies(package)
     for d in dependencies:
@@ -71,12 +74,13 @@ def _dfs_package_apps(
             apps = [str(Path(bin_path) / app) for app in app_names]
             app_paths_of_dependencies[d] = apps
         # recursively search for more
-        if d not in app_paths_of_dependencies:
+        if d not in dep_visited:
             # only search if this package isn't already listed to avoid
             # infinite recursion
             app_paths_of_dependencies = _dfs_package_apps(
-                bin_path, d, app_paths_of_dependencies
+                bin_path, d, app_paths_of_dependencies, dep_visited
             )
+            dep_visited[d] = True
     return app_paths_of_dependencies
 
 
@@ -88,7 +92,7 @@ def main():
     app_paths = [str(Path(bin_path) / app) for app in apps]
     app_paths_of_dependencies = {}  # type: Dict[str, List[str]]
     app_paths_of_dependencies = _dfs_package_apps(
-        bin_path, package, app_paths_of_dependencies
+        bin_path, package, app_paths_of_dependencies, {}
     )
 
     output = {

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -65,8 +65,11 @@ def _dfs_package_apps(
     bin_path: Path,
     package: str,
     app_paths_of_dependencies: Dict[str, List[str]],
-    dep_visited: Dict[str, bool],
+    dep_visited: Optional[Dict[str, bool]] = None,
 ):
+    if dep_visited is None:
+        dep_visited = {}
+
     dependencies = get_package_dependencies(package)
     for d in dependencies:
         app_names = get_apps(d, bin_path)
@@ -92,7 +95,7 @@ def main():
     app_paths = [str(Path(bin_path) / app) for app in apps]
     app_paths_of_dependencies = {}  # type: Dict[str, List[str]]
     app_paths_of_dependencies = _dfs_package_apps(
-        bin_path, package, app_paths_of_dependencies, {}
+        bin_path, package, app_paths_of_dependencies
     )
 
     output = {


### PR DESCRIPTION
Fixes #143 

This uses a new variable `dep_visited` to keep track of whether a package has already been recursively searched for apps.

Previously, `app_paths_of_dependencies` was used, which would mean if apps were found for a dep, no recursive search lower in the hierarchy would be performed.