### PR TITLE
In upgrade-all, skip --editable packages

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 dev
 
 - [bugfix] Fix recursive search of dependencies' apps so no apps are missed.
+- `upgrade-all` now skips editable packages, because pip disallows upgrading editable packages.
 
 0.15.1.1
 

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -97,7 +97,7 @@ def upgrade_all(
         num_packages += 1
         package = venv_dir.name
         venv = Venv(venv_dir, verbose=verbose)
-        if package in skip:
+        if package in skip or "--editable" in venv.pipx_metadata.main_package.pip_args:
             continue
         try:
             packages_upgraded += upgrade(


### PR DESCRIPTION
Fixes #307 

Change to skip any packages with `--editable` switch during `upgrade-all`