### PR TITLE
Add proper remote_name to gh-deploy config

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+dev
+
+- Add config to mkdocs.yml so gh-deploy pushes to proper remote_name
+
 0.15.1.2
 
 - [bugfix] Fix recursive search of dependencies' apps so no apps are missed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,4 +25,5 @@ markdown_extensions:
   - admonition  #  note blocks, warning blocks -- https://github.com/mkdocs/mkdocs/issues/1659
 
 # for mkdocs gh-deploy
-remote_name: git@github.com:pipxproject/pipx.git
+#   (make sure upstream is 'git@github.com:pipxproject/pipx.git')
+remote_name: upstream

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,3 +23,6 @@ nav:
 
 markdown_extensions:
   - admonition  #  note blocks, warning blocks -- https://github.com/mkdocs/mkdocs/issues/1659
+
+# for mkdocs gh-deploy
+remote_name: git@github.com:pipxproject/pipx.git


### PR DESCRIPTION
Simple addition of `remote_name` in mkdocs.yml config, so gh-deploy will always push to the pipxproject/pipx remote.