### PR TITLE
Fix problems in install with user-specified python involving `__PYVENV_LAUNCHER__`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+dev
+
+- [bugfix] Fixed a `pipx install` bug causing incorrect python binary to be used when using the optional --python argument in certain situations, such as running pipx from a Framework python on macOS and specifying a non-Framework python.
+
 0.15.1.2
 
 - [bugfix] Fix recursive search of dependencies' apps so no apps are missed.

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -75,7 +75,7 @@ else:
         return bin_path, python_path
 
 
-def get_script_output(interpreter: Path, script: str, *args) -> str:
+def get_script_output(interpreter: Path, script: str, *args: Union[str, Path]) -> str:
     proc = run_subprocess([interpreter, "-c", script, *args], capture_stderr=False)
     return proc.stdout
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -95,12 +95,11 @@ def run_subprocess(
     """Run arbitrary command as subprocess, capturing stderr and stout"""
     env = dict(os.environ)
 
-    # Remove PYTHONPATH because some platforms (macOS with Homebrew) add
-    #   pipx directories to it, and can make it appear to venvs as though
-    #   pipx dependencies are in the venv path (#233)
-    # Remove __PYVENV_LAUNCHER__ because it is only meant to be communication
-    #   between main python binary and its subprocess and can cause the wrong
-    #   python binary to be used (#334)
+    # Remove PYTHONPATH because some platforms (macOS with Homebrew) add pipx
+    #   directories to it, and can make it appear to venvs as though pipx
+    #   dependencies are in the venv path (#233)
+    # Remove __PYVENV_LAUNCHER__ because it can cause the wrong python binary
+    #   to be used (#334)
     env_blacklist = ["PYTHONPATH", "__PYVENV_LAUNCHER__"]
     for env_to_remove in env_blacklist:
         env.pop(env_to_remove, None)

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -93,16 +93,18 @@ def run_subprocess(
     capture_stderr: bool = True,
 ) -> subprocess.CompletedProcess:
     """Run arbitrary command as subprocess, capturing stderr and stout"""
-
     env = dict(os.environ)
+
     # Remove PYTHONPATH because some platforms (macOS with Homebrew) add
     #   pipx directories to it, and can make it appear to venvs as though
     #   pipx dependencies are in the venv path (#233)
-    env.pop("PYTHONPATH", None)
     # Remove __PYVENV_LAUNCHER__ because it is only meant to be communication
     #   between main python binary and its subprocess and can cause the wrong
     #   python binary to be used (#334)
-    env.pop("__PYVENV_LAUNCHER__", None)
+    env_blacklist = ["PYTHONPATH", "__PYVENV_LAUNCHER__"]
+    for env_to_remove in env_blacklist:
+        env.pop(env_to_remove, None)
+
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
     cmd_str = " ".join(str(c) for c in cmd)
     logging.info(f"running {cmd_str}")

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -76,14 +76,8 @@ else:
 
 
 def get_script_output(interpreter: Path, script: str, *args) -> str:
-    # Make sure that Python writes output in UTF-8
-    env = os.environ.copy()
-    env["PYTHONIOENCODING"] = "utf-8"
-    env.pop("__PYVENV_LAUNCHER__", None)
-    output = subprocess.run(
-        [str(interpreter), "-c", script, *args], stdout=subprocess.PIPE, env=env
-    ).stdout.decode(encoding="utf-8")
-    return output
+    proc = run_subprocess([str(interpreter), "-c", script, *args], capture_stderr=False)
+    return proc.stdout
 
 
 def get_site_packages(python: Path) -> Path:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -76,7 +76,7 @@ else:
 
 
 def get_script_output(interpreter: Path, script: str, *args) -> str:
-    proc = run_subprocess([str(interpreter), "-c", script, *args], capture_stderr=False)
+    proc = run_subprocess([interpreter, "-c", script, *args], capture_stderr=False)
     return proc.stdout
 
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -100,10 +100,14 @@ def run_subprocess(
 ) -> subprocess.CompletedProcess:
     """Run arbitrary command as subprocess, capturing stderr and stout"""
 
-    # Null out PYTHONPATH because some platforms (macOS with Homebrew) add
+    env = dict(os.environ)
+    # Remove PYTHONPATH because some platforms (macOS with Homebrew) add
     #   pipx directories to it, and can make it appear to venvs as though
     #   pipx dependencies are in the venv path (#233)
-    env = {k: v for k, v in os.environ.items() if k.upper() != "PYTHONPATH"}
+    env.pop("PYTHONPATH", None)
+    # Remove __PYVENV_LAUNCHER__ because it is only meant to be communication
+    #   between main python binary and its subprocess and can cause the wrong
+    #   python binary to be used (#334)
     env.pop("__PYVENV_LAUNCHER__", None)
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
     cmd_str = " ".join(str(c) for c in cmd)

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -79,6 +79,7 @@ def get_script_output(interpreter: Path, script: str, *args) -> str:
     # Make sure that Python writes output in UTF-8
     env = os.environ.copy()
     env["PYTHONIOENCODING"] = "utf-8"
+    env.pop("__PYVENV_LAUNCHER__", None)
     output = subprocess.run(
         [str(interpreter), "-c", script, *args], stdout=subprocess.PIPE, env=env
     ).stdout.decode(encoding="utf-8")
@@ -103,6 +104,7 @@ def run_subprocess(
     #   pipx directories to it, and can make it appear to venvs as though
     #   pipx dependencies are in the venv path (#233)
     env = {k: v for k, v in os.environ.items() if k.upper() != "PYTHONPATH"}
+    env.pop("__PYVENV_LAUNCHER__", None)
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
     cmd_str = " ".join(str(c) for c in cmd)
     logging.info(f"running {cmd_str}")

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -105,6 +105,9 @@ def run_subprocess(
         env.pop(env_to_remove, None)
 
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    # Make sure that Python writes output in UTF-8
+    env["PYTHONIOENCODING"] = "utf-8"
+
     cmd_str = " ".join(str(c) for c in cmd)
     logging.info(f"running {cmd_str}")
     # windows cannot take Path objects, only strings
@@ -114,7 +117,8 @@ def run_subprocess(
         env=env,
         stdout=subprocess.PIPE if capture_stdout else None,
         stderr=subprocess.PIPE if capture_stderr else None,
-        universal_newlines=True,  # implies decoded strings in stdout, stderr
+        encoding="utf-8",
+        universal_newlines=True,
     )
 
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -242,7 +242,7 @@ class Venv:
     def get_venv_metadata_for_package(self, package: str) -> VenvMetadata:
         data = json.loads(
             get_script_output(
-                self.python_path, VENV_METADATA_INSPECTOR, package, str(self.bin_path)
+                self.python_path, VENV_METADATA_INSPECTOR, package, self.bin_path
             )
         )
         app_paths = [Path(p) for p in data["app_paths"]]


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
Fixes #334

This removes `__PYVENV_LAUNCHER__` from the env of subprocess commands.  `__PYVENV_LAUNCHER__` is used for the python main process to communicate to a subprocess it spawns, and is not meant to be in the environment for a user running python.  It was set in pipx's inherited env for certain python builds, and it sometimes caused any argument-supplied python binary to be ignored in favor of the python interpreter in this environment variable.

In the process of fixing this bug, I converted `get_script_output()` to use `run_subprocess()`, so `run_subprocess()` is the only function needing to carefully control environment variables (and simplifying the `get_script_output()` code in the process).

There is only one other situation in `util.py` that uses `subprocess.run()`, and that is in `run_pypackage_bin()`.  I left it alone, but it may also suffer from similar issues.  It is so infrequently used (only with running an app in a local `__pypackages__` directory), and not tested, so I was a little afraid to mess with it.