### PR TITLE
Windows: bugfix, correctly inventorying apps

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- [bugfix] On Windows, pipx now lists correct Windows apps (#217)
 - [bugfix] Fixed a `pipx install` bug causing incorrect python binary to be used when using the optional --python argument in certain situations, such as running pipx from a Framework python on macOS and specifying a non-Framework python.
 
 0.15.1.2

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -257,7 +257,7 @@ class Venv:
                 dep_app_paths = _windows_extra_app_paths(paths)
             else:
                 dep_app_paths = paths
-            data["app_paths_of_dependencies"][dep] = paths
+            data["app_paths_of_dependencies"][dep] = dep_app_paths
             data["apps_of_dependencies"] += [path.name for path in paths]
 
         return VenvMetadata(**data)

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -245,17 +245,7 @@ class Venv:
                 self.python_path, VENV_METADATA_INSPECTOR, package, self.bin_path
             )
         )
-        app_paths = [Path(p) for p in data["app_paths"]]
-        if WINDOWS:
-            windows_bin_paths = set()
-            for app in app_paths:
-                # windows has additional files staring with the same name that are required
-                # to run the app
-                for win_exec in app.parent.glob(f"{app.name}*.exe"):
-                    windows_bin_paths.add(win_exec)
-            data["app_paths"] = list(windows_bin_paths)
-        else:
-            data["app_paths"] = app_paths
+        data["app_paths"] = [Path(p) for p in data["app_paths"]]
 
         data["apps_of_dependencies"] = []
         for dep, raw_paths in data["app_paths_of_dependencies"].items():

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -353,7 +353,7 @@ class Venv:
         return run(cmd)
 
 
-def _windows_extra_app_paths(app_paths):
+def _windows_extra_app_paths(app_paths: List[Path]) -> List[Path]:
     app_paths_output = app_paths.copy()
     for app_path in app_paths:
         # In Windows, editable package have additional files starting

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -245,7 +245,17 @@ class Venv:
                 self.python_path, VENV_METADATA_INSPECTOR, package, self.bin_path
             )
         )
-        data["app_paths"] = [Path(p) for p in data["app_paths"]]
+        app_paths = [Path(p) for p in data["app_paths"]]
+        if WINDOWS:
+            windows_bin_paths = set()
+            for app in app_paths:
+                # windows has additional files staring with the same name that are required
+                # to run the app
+                for win_exec in app.parent.glob(f"{app.name}*.exe"):
+                    windows_bin_paths.add(win_exec)
+            data["app_paths"] = list(windows_bin_paths)
+        else:
+            data["app_paths"] = app_paths
 
         data["apps_of_dependencies"] = []
         for dep, raw_paths in data["app_paths_of_dependencies"].items():

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -247,19 +247,16 @@ class Venv:
         )
         app_paths = [Path(p) for p in data["app_paths"]]
         if WINDOWS:
-            windows_bin_paths = set()
-            for app in app_paths:
-                # windows has additional files staring with the same name that are required
-                # to run the app
-                for win_exec in app.parent.glob(f"{app.name}*.exe"):
-                    windows_bin_paths.add(win_exec)
-            data["app_paths"] = list(windows_bin_paths)
-        else:
-            data["app_paths"] = app_paths
+            app_paths = _windows_extra_app_paths(app_paths)
+        data["app_paths"] = app_paths
 
         data["apps_of_dependencies"] = []
         for dep, raw_paths in data["app_paths_of_dependencies"].items():
             paths = [Path(raw_path) for raw_path in raw_paths]
+            if WINDOWS:
+                dep_app_paths = _windows_extra_app_paths(paths)
+            else:
+                dep_app_paths = paths
             data["app_paths_of_dependencies"][dep] = paths
             data["apps_of_dependencies"] += [path.name for path in paths]
 
@@ -354,6 +351,17 @@ class Venv:
         if not self.verbose:
             cmd.append("-q")
         return run(cmd)
+
+
+def _windows_extra_app_paths(app_paths):
+    app_paths_output = app_paths.copy()
+    for app_path in app_paths:
+        # In Windows, editable package have additional files starting
+        #   with the same name that are required to run the app
+        win_app_path = app_path.parent / f"{app_path.stem}-script.py"
+        if win_app_path.exists():
+            app_paths_output.append(win_app_path)
+    return app_paths_output
 
 
 def abs_path_if_local(package_or_url: str, venv: Venv, pip_args: List[str]) -> str:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Generator, List, NamedTuple, Dict, Set, Optional
 
 from pipx.animate import animate
-from pipx.constants import DEFAULT_PYTHON, PIPX_SHARED_PTH, WINDOWS
+from pipx.constants import DEFAULT_PYTHON, PIPX_SHARED_PTH
 from pipx.pipx_metadata_file import PipxMetadata, PackageInfo
 from pipx.shared_libs import shared_libs
 from pipx.util import (

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -125,13 +125,13 @@ def main():
         bin_path, package, app_paths_of_dependencies
     )
     for dep in app_paths_of_dependencies:
-        apps_of_dependencies += [path.name for app_paths_of_dependencies[dep]]
+        apps_of_dependencies += [p.name for p in app_paths_of_dependencies[dep]]
         if WINDOWS:
             app_paths_of_dependencies[dep] = _windows_extra_app_paths(
                 app_paths_of_dependencies[dep]
             )
         app_paths_of_dependencies[dep] = [
-            str(app_path) for app_path in app_paths_of_dependencies[dep]
+            str(p) for p in app_paths_of_dependencies[dep]
         ]
 
     output = {

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -116,6 +116,7 @@ def main():
 
     apps = get_apps(package, bin_path)
     app_paths = [Path(bin_path) / app for app in apps]
+    # On Windows, only add extra "*-script.py" to app_paths, not to apps
     if WINDOWS:
         app_paths = _windows_extra_app_paths(app_paths)
     app_paths = [str(app_path) for app_path in app_paths]
@@ -129,6 +130,7 @@ def main():
         apps_of_dependencies += [
             dep_path.name for dep_path in app_paths_of_dependencies[dep]
         ]
+        # On Windows, only add extra "*-script.py" to app_paths, not to apps
         if WINDOWS:
             app_paths_of_dependencies[dep] = _windows_extra_app_paths(
                 app_paths_of_dependencies[dep]

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -44,11 +44,9 @@ def get_apps(package: str, bin_path: Path) -> List[str]:
         for name in pkg_resources.get_entry_map(dist).get(section, []):
             if (bin_path / name).exists():
                 apps.add(name)
-            if WINDOWS:
-                win_names = [f"{name}.exe", f"{name}-script.py", f"{name}.exe.manifest"]
-                for win_name in win_names:
-                    if (bin_path / win_name).exists():
-                        apps.add(win_name)
+            if WINDOWS and (bin_path / f"{name}.exe").exists():
+                # WINDOWS adds .exe to entry_point name
+                apps.add(f"{name}.exe")
 
     if dist.has_metadata("RECORD"):
         # for non-editable package installs, RECORD is files that got installed

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -44,9 +44,9 @@ def get_apps(package: str, bin_path: Path) -> List[str]:
         for name in pkg_resources.get_entry_map(dist).get(section, []):
             if (bin_path / name).exists():
                 apps.add(name)
-            if WINDOWS and (bin_path / f"{name}.exe").exists():
+            if WINDOWS and (bin_path / (name + ".exe")).exists():
                 # WINDOWS adds .exe to entry_point name
-                apps.add(f"{name}.exe")
+                apps.add(name + ".exe")
 
     if dist.has_metadata("RECORD"):
         # for non-editable package installs, RECORD is files that got installed

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -49,7 +49,7 @@ def get_apps(package: str, bin_path: Path) -> List[str]:
                 apps.add(name + ".exe")
 
     if dist.has_metadata("RECORD"):
-        # for non-editable package installs, RECORD is files that got installed
+        # for non-editable package installs, RECORD is list of installed files
         # "scripts" entry in setup.py is found here (test w/ awscli)
         for line in dist.get_metadata_lines("RECORD"):
             entry = line.split(",")[0]  # noqa: T484

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -115,9 +115,10 @@ def main():
     bin_path = Path(sys.argv[2])
 
     apps = get_apps(package, bin_path)
+    app_paths = [Path(bin_path) / app for app in apps]
     if WINDOWS:
         app_paths = _windows_extra_app_paths(app_paths)
-    app_paths = [str(Path(bin_path) / app) for app in apps]
+    app_paths = [str(app_path) for app_path in app_paths]
 
     app_paths_of_dependencies = {}  # type: Dict[str, List[str]]
     apps_of_dependencies = []  # type: List[str]
@@ -125,13 +126,15 @@ def main():
         bin_path, package, app_paths_of_dependencies
     )
     for dep in app_paths_of_dependencies:
-        apps_of_dependencies += [p.name for p in app_paths_of_dependencies[dep]]
+        apps_of_dependencies += [
+            dep_path.name for dep_path in app_paths_of_dependencies[dep]
+        ]
         if WINDOWS:
             app_paths_of_dependencies[dep] = _windows_extra_app_paths(
                 app_paths_of_dependencies[dep]
             )
         app_paths_of_dependencies[dep] = [
-            str(p) for p in app_paths_of_dependencies[dep]
+            str(dep_path) for dep_path in app_paths_of_dependencies[dep]
         ]
 
     output = {

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -118,7 +118,7 @@ def main():
     app_paths = [Path(bin_path) / app for app in apps]
     if WINDOWS:
         app_paths = _windows_extra_app_paths(app_paths)
-    app_str_paths = [str(app_path) for app_path in app_paths]
+    app_paths = [str(app_path) for app_path in app_paths]
 
     app_paths_of_dependencies = {}  # type: Dict[str, List[str]]
     apps_of_dependencies = []  # type: List[str]
@@ -139,7 +139,7 @@ def main():
 
     output = {
         "apps": apps,
-        "app_paths": app_str_paths,
+        "app_paths": app_paths,
         "apps_of_dependencies": apps_of_dependencies,
         "app_paths_of_dependencies": app_paths_of_dependencies,
         "package_version": get_package_version(package),

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -101,7 +101,7 @@ def _dfs_package_apps(
 
 def _windows_extra_app_paths(app_paths: List[Path]) -> List[Path]:
     # In Windows, editable package have additional files starting with the
-    #   same name that are required to run the app
+    #   same name that are required to be in the same dir to run the app
     app_paths_output = app_paths.copy()
     for app_path in app_paths:
         win_app_path = app_path.parent / (app_path.stem + "-script.py")

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -44,9 +44,11 @@ def get_apps(package: str, bin_path: Path) -> List[str]:
         for name in pkg_resources.get_entry_map(dist).get(section, []):
             if (bin_path / name).exists():
                 apps.add(name)
-            if WINDOWS and (bin_path / f"{name}.exe").exists():
-                # WINDOWS adds .exe to entry_point name
-                apps.add(f"{name}.exe")
+            if WINDOWS:
+                win_names = [f"{name}.exe", f"{name}-script.py", f"{name}.exe.manifest"]
+                for win_name in win_names:
+                    if (bin_path / win_name).exists():
+                        apps.add(win_name)
 
     if dist.has_metadata("RECORD"):
         # for non-editable package installs, RECORD is files that got installed

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -77,9 +77,9 @@ def get_apps(package: str, bin_path: Path) -> List[str]:
 def _dfs_package_apps(
     bin_path: Path,
     package: str,
-    app_paths_of_dependencies: Dict[str, List[str]],
+    app_paths_of_dependencies: Dict[str, List[Path]],
     dep_visited: Optional[Dict[str, bool]] = None,
-):
+) -> Dict[str, List[Path]]:
     if dep_visited is None:
         dep_visited = {}
 
@@ -118,7 +118,7 @@ def main():
     app_paths = [Path(bin_path) / app for app in apps]
     if WINDOWS:
         app_paths = _windows_extra_app_paths(app_paths)
-    app_paths = [str(app_path) for app_path in app_paths]
+    app_str_paths = [str(app_path) for app_path in app_paths]
 
     app_paths_of_dependencies = {}  # type: Dict[str, List[str]]
     apps_of_dependencies = []  # type: List[str]
@@ -139,7 +139,7 @@ def main():
 
     output = {
         "apps": apps,
-        "app_paths": app_paths,
+        "app_paths": app_str_paths,
         "apps_of_dependencies": apps_of_dependencies,
         "app_paths_of_dependencies": app_paths_of_dependencies,
         "package_version": get_package_version(package),

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -104,7 +104,7 @@ def _windows_extra_app_paths(app_paths: List[Path]) -> List[Path]:
     #   same name that are required to run the app
     app_paths_output = app_paths.copy()
     for app_path in app_paths:
-        win_app_path = app_path.parent / f"{app_path.stem}-script.py"
+        win_app_path = app_path.parent / (app_path.stem + "-script.py")
         if win_app_path.exists():
             app_paths_output.append(win_app_path)
     return app_paths_output

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -116,7 +116,8 @@ def main():
 
     apps = get_apps(package, bin_path)
     app_paths = [Path(bin_path) / app for app in apps]
-    # On Windows, only add extra "*-script.py" to app_paths, not to apps
+    # On Windows, add extra "*-script.py" to app_paths to make execution work;
+    #   do not add them to apps to ensure they are not listed
     if WINDOWS:
         app_paths = _windows_extra_app_paths(app_paths)
     app_paths = [str(app_path) for app_path in app_paths]
@@ -130,7 +131,8 @@ def main():
         apps_of_dependencies += [
             dep_path.name for dep_path in app_paths_of_dependencies[dep]
         ]
-        # On Windows, only add extra "*-script.py" to app_paths, not to apps
+        # On Windows, add extra "*-script.py" to app_paths to make execution
+        #   work; do not add them to apps to ensure they are not listed
         if WINDOWS:
             app_paths_of_dependencies[dep] = _windows_extra_app_paths(
                 app_paths_of_dependencies[dep]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -55,8 +55,8 @@ def test_install_tricky_packages(capsys, pipx_temp_env, caplog, package):
     if os.getenv("FAST"):
         pytest.skip("skipping slow tests")
 
-    if sys.platform.startswith("win"):
-        pytest.skip("TODO make this work on Windows")
+    #if sys.platform.startswith("win"):
+    #    pytest.skip("TODO make this work on Windows")
     install_package(capsys, pipx_temp_env, caplog, package)
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -54,9 +54,9 @@ def test_install_easy_packages(capsys, pipx_temp_env, caplog, package):
 def test_install_tricky_packages(capsys, pipx_temp_env, caplog, package):
     if os.getenv("FAST"):
         pytest.skip("skipping slow tests")
+    if sys.platform.startswith("win") and package=="ansible":
+        pytest.skip("Ansible is not installable on Windows")
 
-    #if sys.platform.startswith("win"):
-    #    pytest.skip("TODO make this work on Windows")
     install_package(capsys, pipx_temp_env, caplog, package)
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -54,7 +54,7 @@ def test_install_easy_packages(capsys, pipx_temp_env, caplog, package):
 def test_install_tricky_packages(capsys, pipx_temp_env, caplog, package):
     if os.getenv("FAST"):
         pytest.skip("skipping slow tests")
-    if sys.platform.startswith("win") and package=="ansible":
+    if sys.platform.startswith("win") and package == "ansible":
         pytest.skip("Ansible is not installable on Windows")
 
     install_package(capsys, pipx_temp_env, caplog, package)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -134,6 +134,9 @@ def test_existing_symlink_points_to_existing_wrong_location_warning(
 
 
 def test_existing_symlink_points_to_nothing(pipx_temp_env, caplog, capsys):
+    if sys.platform.startswith("win"):
+        pytest.skip("pipx does not use symlinks on Windows")
+
     constants.LOCAL_BIN_DIR.mkdir(exist_ok=True, parents=True)
     (constants.LOCAL_BIN_DIR / "pycowsay").symlink_to("/asdf/jkl")
     assert not run_pipx_cli(["install", "pycowsay"])

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -133,7 +133,7 @@ def test_package_install(monkeypatch, tmp_path, pipx_temp_env):
     if pipx.constants.WINDOWS:
         ref_replacement_fields = {
             "app_paths": [pipx_venvs_dir / "pycowsay" / "Scripts" / "pycowsay.exe"],
-            "apps": ["pycowsay", "pycowsay.exe"],
+            "apps": ["pycowsay.exe"],
         }
     else:
         ref_replacement_fields = {
@@ -158,7 +158,7 @@ def test_package_inject(monkeypatch, tmp_path, pipx_temp_env):
 
     if pipx.constants.WINDOWS:
         ref_replacement_fields = {
-            "apps": ["black", "black.exe", "blackd", "blackd.exe"],
+            "apps": ["black.exe", "blackd.exe"],
             "app_paths": [
                 pipx_venvs_dir / "pycowsay" / "Scripts" / "black.exe",
                 pipx_venvs_dir / "pycowsay" / "Scripts" / "blackd.exe",


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
Fixes #217 .

This properly finds and inventories the correct apps and app paths on Windows.
* It includes app names with a `.exe` at the end of the entry_point name if they exist in the venv bin_dir
* It excludes apps without the `.exe` at the end of the name if they don't exist in the venv bin_dir
* It looks for companion apps that end in `-script.py` that are needed for editable installs on Windows, and adds these to app_paths but not to the list of apps.  That way the `-script.py` files are copied to PIPX_BIN_DIR but do not show up during `pipx list`.

Tests were updated, especially to reflect correct list of apps.  Also, tests were enabled for previously skipped test packages ("cloudtoken", "awscli", "shell-functools") that now work on Windows.  "ansible" is still skipped because it officially is not installable on Windows.

A pre-existing test involving symlinks was changed to be excluded on Windows (test_existing_symlink_points_to_nothing).