### PR TITLE
Also add *.exe.manifest on windows if present.

### DIFF
--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -102,9 +102,14 @@ def _dfs_package_apps(
 def _windows_extra_app_paths(app_paths: List[Path]) -> List[Path]:
     # In Windows, editable package have additional files starting with the
     #   same name that are required to be in the same dir to run the app
+    # Add "*-script.py", "*.exe.manifest" only to app_paths to make
+    #   execution work; do not add them to apps to ensure they are not listed
     app_paths_output = app_paths.copy()
     for app_path in app_paths:
         win_app_path = app_path.parent / (app_path.stem + "-script.py")
+        if win_app_path.exists():
+            app_paths_output.append(win_app_path)
+        win_app_path = app_path.parent / (app_path.stem + ".exe.manifest")
         if win_app_path.exists():
             app_paths_output.append(win_app_path)
     return app_paths_output
@@ -116,8 +121,6 @@ def main():
 
     apps = get_apps(package, bin_path)
     app_paths = [Path(bin_path) / app for app in apps]
-    # On Windows, add extra "*-script.py" to app_paths to make execution work;
-    #   do not add them to apps to ensure they are not listed
     if WINDOWS:
         app_paths = _windows_extra_app_paths(app_paths)
     app_paths = [str(app_path) for app_path in app_paths]
@@ -131,8 +134,6 @@ def main():
         apps_of_dependencies += [
             dep_path.name for dep_path in app_paths_of_dependencies[dep]
         ]
-        # On Windows, add extra "*-script.py" to app_paths to make execution
-        #   work; do not add them to apps to ensure they are not listed
         if WINDOWS:
             app_paths_of_dependencies[dep] = _windows_extra_app_paths(
                 app_paths_of_dependencies[dep]


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
This is an addendum to PR #340 .

To be safe, on Windows if a `.exe.manifest` file has been generated in the venv bin_dir, we will copy that over as well to PIPX_BIN_DIR.  (Along with `<file>.exe`, and `<file>-script.py`.

The `.exe.manifest` file ensures that 32-bit Windows will not mistake an `.exe` file in the same dir as an installer, for example if the main `.exe` file contains the words "install", or "setup", etc.

More Info:
https://github.com/pypa/setuptools/blob/682b6511ac67e021b542e74ce30e13fe52bc2da9/setuptools/command/easy_install.py#L2243
https://setuptools.readthedocs.io/en/latest/history.html#id627
https://bitbucket.org/tarek/distribute/issues/143
https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-vista/cc709628(v=ws.10)?redirectedfrom=MSDN