### PR TITLE
Rely on packaging to parse the version.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,6 @@
+0.15.1.4
+- [bugfix] Replaced implicit dependency on setuptools with an explicit dependency on packaging (#339).
+
 0.15.1.3
 
 - [bugfix] On Windows, pipx now lists correct Windows apps (#217)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import re  # noqa E402
 
 CURDIR = Path(__file__).parent
 
-REQUIRED = ["userpath", "argcomplete>=1.9.4, <2.0"]  # type: List[str]
+REQUIRED = ["userpath", "argcomplete>=1.9.4, <2.0", "packaging"]  # type: List[str]
 
 with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
     README = f.read()

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -13,7 +13,7 @@ import textwrap
 import urllib.parse
 from typing import Dict, List, Tuple, Union
 
-import packaging.version
+import packaging.version  # type: ignore
 import argcomplete  # type: ignore
 from .colors import bold, green
 from . import commands

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -6,7 +6,6 @@
 import argparse
 import functools
 import logging
-from pkg_resources import parse_version
 import shlex
 import re
 import sys
@@ -14,6 +13,7 @@ import textwrap
 import urllib.parse
 from typing import Dict, List, Tuple, Union
 
+import packaging.version
 import argcomplete  # type: ignore
 from .colors import bold, green
 from . import commands
@@ -25,7 +25,8 @@ __version__ = "0.15.1.3"
 
 
 def simple_parse_version(s, segments=4) -> Tuple[Union[int, str], ...]:
-    _, out, subver, *_ = parse_version(s)._key  # type: ignore
+
+    _, out, subver, *_ = packaging.version.Version(s)._key  # type: ignore
 
     if isinstance(subver, tuple):
         while len(out) < segments:


### PR DESCRIPTION
Fixes #339.