### PR TITLE
Use importlib.metadata

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,6 @@
-0.15.1.4
+0.15.2.0
+
+- Rely on importlib.metadata for package metadata.
 - [bugfix] Replaced implicit dependency on setuptools with an explicit dependency on packaging (#339).
 
 0.15.1.3

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import re  # noqa E402
 
 CURDIR = Path(__file__).parent
 
-REQUIRED = ["userpath", "argcomplete>=1.9.4, <2.0", "packaging"]  # type: List[str]
+REQUIRED = ["userpath", "argcomplete>=1.9.4, <2.0", "packaging", "importlib_metadata; python_version < '3.8'"]  # type: List[str]
 
 with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
     README = f.read()

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,12 @@ import re  # noqa E402
 
 CURDIR = Path(__file__).parent
 
-REQUIRED = ["userpath", "argcomplete>=1.9.4, <2.0", "packaging", "importlib_metadata; python_version < '3.8'"]  # type: List[str]
+REQUIRED = [
+    "userpath",
+    "argcomplete>=1.9.4, <2.0",
+    "packaging",
+    "importlib_metadata; python_version < '3.8'",
+]  # type: List[str]
 
 with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
     README = f.read()

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -80,7 +80,7 @@ class _SharedLibs:
                         "setuptools",
                         "wheel",
                         "packaging",
-                        "importlib_metadata; python_version<'3.8'",
+                        "importlib_metadata",
                     ]
                 )
                 self.has_been_updated_this_run = True

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -79,6 +79,8 @@ class _SharedLibs:
                         "pip",
                         "setuptools",
                         "wheel",
+                        "packaging",
+                        "importlib_metadata; python_version<'3.8'",
                     ]
                 )
                 self.has_been_updated_this_run = True

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 try:
-    from importlib import metadata
+    from importlib import metadata  # type: ignore
 except ImportError:
-    import importlib_metadata as metadata
+    import importlib_metadata as metadata  # type: ignore
 
-from packaging.requirements import Requirement
+from packaging.requirements import Requirement  # type: ignore
 
 try:
     WindowsError
@@ -25,8 +25,8 @@ def get_package_dependencies(package: str) -> List[Requirement]:
     try:
         return [
             req
-            for req in map(Requirement, metadata.requires(package) or [])
-            if not req.marker or req.marker.evaluate({'extra': extras})
+            for req in map(Requirement, metadata.requires(package) or [])  # type: ignore
+            if not req.marker or req.marker.evaluate({"extra": extras})
         ]
     except Exception:
         return []
@@ -34,13 +34,13 @@ def get_package_dependencies(package: str) -> List[Requirement]:
 
 def get_package_version(package: str) -> Optional[str]:
     try:
-        return metadata.version(package)
+        return metadata.version(package)  # type: ignore
     except Exception:
         return None
 
 
 def get_apps(req: Requirement, bin_path: Path) -> List[str]:
-    dist = metadata.distribution(req.name)
+    dist = metadata.distribution(req.name)  # type: ignore
 
     apps = set()
     sections = {"console_scripts", "gui_scripts"}
@@ -64,7 +64,7 @@ def get_apps(req: Requirement, bin_path: Path) -> List[str]:
             pass
 
     # not sure what is found here
-    inst_files = dist.read_text("installed-files.txt") or ''
+    inst_files = dist.read_text("installed-files.txt") or ""
     for line in inst_files.splitlines():
         entry = line.split(",")[0]  # noqa: T484
         path = dist.locate_file(entry)  # type: ignore

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -21,11 +21,12 @@ else:
 
 
 def get_package_dependencies(package: str) -> List[Requirement]:
+    extras = Requirement(package).extras
     try:
         return [
             req
-            for req in map(Requirement, metadata.requires(package))
-            if req.marker.evaluate()
+            for req in map(Requirement, metadata.requires(package) or [])
+            if not req.marker or req.marker.evaluate({'extra': extras})
         ]
     except Exception:
         return []

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -10,6 +10,8 @@ try:
 except ImportError:
     import importlib_metadata as metadata
 
+import packaging.requirements  # type: ignore
+
 try:
     WindowsError
 except NameError:
@@ -32,8 +34,8 @@ def get_package_version(package: str) -> Optional[str]:
         return None
 
 
-def get_apps(package: str, bin_path: Path) -> List[str]:
-    dist = metadata.distribution(package)
+def get_apps(req: str, bin_path: Path) -> List[str]:
+    dist = metadata.distribution(packaging.requirements.Requirement(req).name)
 
     apps = set()
     sections = {"console_scripts", "gui_scripts"}
@@ -51,7 +53,7 @@ def get_apps(package: str, bin_path: Path) -> List[str]:
     # "scripts" entry in setup.py is found here (test w/ awscli)
     for path in dist.files:
         try:
-            if path.parent.samefile(bin_path):
+            if path.locate().parent.samefile(bin_path):
                 apps.add(path.name)
         except FileNotFoundError:
             pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest  # type: ignore
 
-from pipx import constants
+from pipx import constants, shared_libs
 
 
 @pytest.fixture
@@ -17,6 +17,8 @@ def pipx_temp_env(tmp_path, monkeypatch):
     bin_dir = Path(tmp_path) / "otherdir" / "pipxbindir"
 
     monkeypatch.setattr(constants, "PIPX_SHARED_LIBS", shared_dir)
+    shared_libs.PIPX_SHARED_LIBS = shared_dir
+    shared_libs.shared_libs.__init__()
     monkeypatch.setattr(constants, "PIPX_HOME", home_dir)
     monkeypatch.setattr(constants, "LOCAL_BIN_DIR", bin_dir)
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")


### PR DESCRIPTION
Working on #339, I discovered this use of the deprecated `pkg_resources` module. This change adds a dependency on `importlib_metadata` for python 3.7 and earlier and uses the stdlib version on Python 3.8 and later.

I haven't tested this behavior, so I could use some help validating that it does what's expected.