### PR TITLE
Dev: Add a global-exclude for vim swap files.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ prune scripts
 
 global-exclude *.py[cod]
 global-exclude __pycache__
+global-exclude .*.swp


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
This is for pipx development.

Recently I made the mistake of including a `.*.swp` file (vim swap file) in a release sent to pypi (#345).  This PR is adding a global-exclude to MANIFEST.in so that won't happen again.