### PR TITLE
README: fix how to upgrade pipx with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ python3 -m pip install --user pipx
 python3 -m pipx ensurepath
 ```
 
-Upgrade pipx with `python3 -m pip install -U pipx`.
+Upgrade pipx with `python3 -m pip install --user -U pipx`.
 
 Shell completions are available by following the instructions printed with this command:
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ pipx's default virtual environment location is `~/.local/pipx`. This can be over
 
 ## Upgrade pipx
 ```
-python3 -m pip install -U pipx
+python3 -m pip install --user -U pipx
 ```
 
 ### Note: Upgrading pipx from a pre-0.15.0.0 version to 0.15.0.0 or later


### PR DESCRIPTION
Adding `--user` is important as this option is passed a few lines above to install pipx.