### PR TITLE
Add markdown max version for mkdocs-material.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,9 @@ else:
     nox.options.sessions = ["tests", "lint", "docs"]
 
 
-doc_dependencies = [".", "jinja2", "mkdocs", "mkdocs-material"]
+# can remove "markdown>=3.1,<3.2" when mkdocs-material no longer requires
+#   Markdown<3.2, otherwise doc builds fail
+doc_dependencies = [".", "jinja2", "mkdocs", "mkdocs-material", "markdown>=3.1,<3.2"]
 lint_dependencies = ["black", "flake8", "flake8-bugbear", "mypy", "check-manifest"]
 
 


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
Can't wait for that advanced pip version resolution! :smile:

Our nox docs session is now failing because of a version conflict.  It installs the latest Markdown version (3.2), which then conflicts with mkdocs-material which has a requirement `Markdown<3.2`.

This PR has a workaround to force install of Markdown<3.2 until mkdocs-material will accept the latest Markdown version.