### PR TITLE
[WIP] Remove pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ from pathlib import Path  # noqa E402
 from typing import List  # noqa E402
 import ast  # noqa E402
 import re  # noqa E402
+import runpy
 
 CURDIR = Path(__file__).parent
 
@@ -26,12 +27,8 @@ with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
 
 
 def get_version():
-    main_file = CURDIR / "src" / "pipx" / "main.py"
-    _version_re = re.compile(r"__version__\s+=\s+(?P<version>.*)")
-    with open(main_file, "r", encoding="utf8") as f:
-        match = _version_re.search(f.read())
-        version = match.group("version") if match is not None else '"unknown"'
-    return str(ast.literal_eval(version))
+    namespace = runpy.run_path(CURDIR / "src" / "pipx" / "version.py")
+    return namespace["__version__"]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,16 @@ from pathlib import Path  # noqa E402
 from typing import List  # noqa E402
 import ast  # noqa E402
 import re  # noqa E402
-import runpy
+import runpy  # noqa E402
 
 CURDIR = Path(__file__).parent
 
-REQUIRED = ["userpath", "argcomplete>=1.9.4, <2.0", "packaging"]  # type: List[str]
+REQUIRED = [
+    "userpath",
+    "argcomplete>=1.9.4, <2.0",
+    "packaging",
+    "importlib_metadata; python_version < '3.8'",
+]  # type: List[str]
 
 with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
     README = f.read()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
 
 
 def get_version():
-    namespace = runpy.run_path(CURDIR / "src" / "pipx" / "version.py")
+    namespace = runpy.run_path(str(CURDIR / "src" / "pipx" / "version.py"))
     return namespace["__version__"]
 
 

--- a/src/pipx/__init__.py
+++ b/src/pipx/__init__.py
@@ -1,4 +1,7 @@
 import sys
+from .version import __version__, __version_info__
+
+__all__ = ["__version__", "__version_info__"]
 
 if sys.version_info < (3, 6, 0):
     sys.exit(

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -20,23 +20,7 @@ from . import commands
 from . import constants
 from .util import PipxError, mkdir
 from .venv import VenvContainer
-
-__version__ = "0.15.1.3"
-
-
-def simple_parse_version(s, segments=4) -> Tuple[Union[int, str], ...]:
-
-    _, out, subver, *_ = packaging.version.Version(s)._key  # type: ignore
-
-    if isinstance(subver, tuple):
-        while len(out) < segments:
-            out += (0,)
-        out += subver
-
-    return out
-
-
-__version_info__ = simple_parse_version(__version__)
+from .version import __version__, __version_info__
 
 
 def print_version() -> None:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -13,7 +13,6 @@ import textwrap
 import urllib.parse
 from typing import Dict, List, Tuple, Union
 
-import packaging.version  # type: ignore
 import argcomplete  # type: ignore
 from .colors import bold, green
 from . import commands

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -11,7 +11,7 @@ import re
 import sys
 import textwrap
 import urllib.parse
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List
 
 import argcomplete  # type: ignore
 from .colors import bold, green
@@ -19,7 +19,7 @@ from . import commands
 from . import constants
 from .util import PipxError, mkdir
 from .venv import VenvContainer
-from .version import __version__, __version_info__
+from .version import __version__
 
 
 def print_version() -> None:

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -4,12 +4,12 @@ import json
 import sys
 import os
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Iterator
 
 try:
-    from importlib import metadata
+    from importlib import metadata  # type: ignore
 except ImportError:
-    import importlib_metadata as metadata
+    import importlib_metadata as metadata  # type: ignore
 
 
 WINDOWS = os.name == "nt"

--- a/src/pipx/version.py
+++ b/src/pipx/version.py
@@ -1,0 +1,3 @@
+__version_info__ = (0, 15, 1, 3)
+__version__ = ".".join(str(i) for i in __version_info__)
+

--- a/src/pipx/version.py
+++ b/src/pipx/version.py
@@ -1,3 +1,2 @@
 __version_info__ = (0, 15, 1, 3)
 __version__ = ".".join(str(i) for i in __version_info__)
-

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,20 +11,6 @@ from pipx import main
 assert_not_in_virtualenv()
 
 
-@pytest.mark.parametrize(
-    "ver_str,expected",
-    [
-        ["0.14.0.0", (0, 14)],
-        ["0.14.0.0b0", (0, 14, 0, 0, "b", 0)],
-        ["0.14", (0, 14)],
-        ["0.14b0", (0, 14, 0, 0, "b", 0)],
-        ["1.1.1.1", (1, 1, 1, 1)],
-    ],
-)
-def test_simple_parse_version(ver_str, expected):
-    assert main.simple_parse_version(ver_str) == expected
-
-
 def test_help_text(monkeypatch, capsys):
     mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
     with mock.patch.object(sys, "exit", mock_exit), pytest.raises(


### PR DESCRIPTION
See #339 .

Below py38, this depends on a backport of `importlib.metadata` (`importlib_metadata`).

Mypy refuses to look whichever arm is functional for the given python version, so both have to be ignored (see https://github.com/python/mypy/issues/1153 ). However, it also refuses to accept any imports from the module. Not sure how to get around that.

I think I captured the spirit of what venv_metadata_inspector was doing before, although it's a bit hairy. Plenty of comments in there - would love for someone with more experience in packaging internals to set me straight if I've missed anything!