### PR TITLE
Remove markdown<3.2 requirement.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -29,9 +29,7 @@ else:
 
 nox.options.reuse_existing_virtualenvs = True
 
-# can remove "markdown>=3.1,<3.2" when mkdocs-material no longer requires
-#   Markdown<3.2, otherwise doc builds fail
-doc_dependencies = [".", "jinja2", "mkdocs", "mkdocs-material", "markdown>=3.1,<3.2"]
+doc_dependencies = [".", "jinja2", "mkdocs", "mkdocs-material"]
 lint_dependencies = ["black", "flake8", "flake8-bugbear", "mypy", "check-manifest"]
 
 


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
OK, I just backed out my workaround from #358, because now mkdocs-material REQUIRES Markdown>3.2 and our docs build fail again.

Luckily they also fixed their Markdown<3.2 problems which necessitated the original workaround (obviously).