### PR TITLE
Remove dependency on packaging library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,25 +13,23 @@ if sys.version_info < (3, 6, 0):
 import io  # noqa E402
 import os  # noqa E402
 from pathlib import Path  # noqa E402
+from runpy import run_path  # noqa E402
 from typing import List  # noqa E402
 import ast  # noqa E402
 import re  # noqa E402
 
 CURDIR = Path(__file__).parent
 
-REQUIRED = ["userpath", "argcomplete>=1.9.4, <2.0", "packaging"]  # type: List[str]
+REQUIRED = ["userpath", "argcomplete>=1.9.4, <2.0"]  # type: List[str]
 
 with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
     README = f.read()
 
 
 def get_version():
-    main_file = CURDIR / "src" / "pipx" / "main.py"
-    _version_re = re.compile(r"__version__\s+=\s+(?P<version>.*)")
-    with open(main_file, "r", encoding="utf8") as f:
-        match = _version_re.search(f.read())
-        version = match.group("version") if match is not None else '"unknown"'
-    return str(ast.literal_eval(version))
+    version_file = CURDIR / "src" / "pipx" / "version.py"
+    namespace = run_path(version_file)
+    return namespace["__version__"]
 
 
 setup(

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -11,32 +11,15 @@ import re
 import sys
 import textwrap
 import urllib.parse
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List
 
-import packaging.version  # type: ignore
 import argcomplete  # type: ignore
 from .colors import bold, green
 from . import commands
 from . import constants
 from .util import PipxError, mkdir
 from .venv import VenvContainer
-
-__version__ = "0.15.1.3"
-
-
-def simple_parse_version(s, segments=4) -> Tuple[Union[int, str], ...]:
-
-    _, out, subver, *_ = packaging.version.Version(s)._key  # type: ignore
-
-    if isinstance(subver, tuple):
-        while len(out) < segments:
-            out += (0,)
-        out += subver
-
-    return out
-
-
-__version_info__ = simple_parse_version(__version__)
+from .version import __version__
 
 
 def print_version() -> None:

--- a/src/pipx/version.py
+++ b/src/pipx/version.py
@@ -1,0 +1,2 @@
+__version_info__ = (0, 15, 1, 3)
+__version__ = ".".join(str(i) for i in __version_info__)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,20 +11,6 @@ from pipx import main
 assert_not_in_virtualenv()
 
 
-@pytest.mark.parametrize(
-    "ver_str,expected",
-    [
-        ["0.14.0.0", (0, 14)],
-        ["0.14.0.0b0", (0, 14, 0, 0, "b", 0)],
-        ["0.14", (0, 14)],
-        ["0.14b0", (0, 14, 0, 0, "b", 0)],
-        ["1.1.1.1", (1, 1, 1, 1)],
-    ],
-)
-def test_simple_parse_version(ver_str, expected):
-    assert main.simple_parse_version(ver_str) == expected
-
-
 def test_help_text(monkeypatch, capsys):
     mock_exit = mock.Mock(side_effect=ValueError("raised in test to exit early"))
     with mock.patch.object(sys, "exit", mock_exit), pytest.raises(


### PR DESCRIPTION
From these two comments I understand a PR removing the dependency on [packaging] would be welcome:

- <https://github.com/pipxproject/pipx/pull/361#issuecomment-583654680>
- <https://github.com/pipxproject/pipx/issues/339#issuecomment-583532860>

@clbarnes had already done a lot of work here, I only put together this short PR to make a small step forward.

I am enthusiastic `pipx` user and I maintain a [few packages] in the Alpine Linux distribution. I would like to see `pipx` packaged for Alpine Linux. As a first step I've been taking a look at the dependencies and a couple of PRs came to mind. This seemed to be a straightforward place to start.

[packaging]: https://pypi.org/project/packaging/
[few packages]: https://pkgs.alpinelinux.org/packages?name=&branch=edge&arch=x86_64&maintainer=Keith+Maxwell

<details>
<summary>Local testing</summary>

Clone the "pipx" source and start a container with access to that directory:

```sh
git clone git@github.com:pipxproject/pipx.git &&
cd pipx &&
podman run -ti -v .:/srv:z fedora:31
```

Inside the container run the tests:

```sh
cd /srv
dnf install --assumeyes python3-pip git
python3 -m pip install --upgrade pip
python3 -m pip install git+https://github.com/cs01/nox.git@5ea70723e9e6 nox
python3 -m pip install -e .
python3 src/pipx --version
pipx --version
rm -rf .nox  # to clear other runs (different Python versions or distributions)
nox -l
nox -s tests-3.7
```

To get output like:

```
✂
========================== 69 passed, 1 skipped in 225.59s (0:03:45) =====================================
nox > Session tests-3.7 was successful.
✂
nox > Session cover was successful.
nox > Ran multiple sessions:
nox > * tests-3.7: success
nox > * cover: success
```
Also run the linting:

```
$ nox --non-interactive --session "lint"
✂
Success: no issues found in 40 source files
✂
```

</details>

<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->