### PR TITLE
Update installation instructions with macOS homebrew specifics

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,8 +14,6 @@ brew install pipx
 pipx ensurepath
 ```
 
-Upgrade pipx with `brew update && brew upgrade pipx`.
-
 Otherwise, install via pip:
 
 ```
@@ -29,6 +27,15 @@ pipx's default binary location is `~/.local/bin`. This can be overriden with the
 pipx's default virtual environment location is `~/.local/pipx`. This can be overridden with the environment variable `PIPX_HOME`.
 
 ## Upgrade pipx
+
+On macOS:
+
+```
+brew update && brew upgrade pipx
+```
+
+Otherwise, upgrade via pip:
+
 ```
 python3 -m pip install --user -U pipx
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,17 @@ pipx works on macOS, linux, and Windows.
 
 ## Install pipx
 
-Assuming you have `pip` installed for python3, run:
+On macOS:
+
+```
+brew install pipx
+pipx ensurepath
+```
+
+Upgrade pipx with `brew update && brew upgrade pipx`.
+
+Otherwise, install via pip:
+
 ```
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
Via #208, I see that `docs/installation.md` does not have the same macOS install and upgrade instructions that `README.md` does.  This PR is to fix that by integrating macOS homebrew instructions into `docs/installation.md`.