### PR TITLE
fix get_version(); cast path object to str

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
 
 
 def get_version():
-    version_file = CURDIR / "src" / "pipx" / "version.py"
-    namespace = run_path(version_file)
+    version_file = CURDIR.joinpath("src", "pipx", "version.py").resolve()
+    namespace = run_path(str(version_file))
     return namespace["__version__"]
 
 


### PR DESCRIPTION
Failed to install from HEAD.

Looks like `io.open_code()` is expecting a string not pathlib.Path object.

```shell
❯ python3 setup.py develop
version_file=PosixPath('src/pipx/version.py')
Traceback (most recent call last):
  File "setup.py", line 38, in <module>
    version=get_version(),
  File "setup.py", line 32, in get_version
    namespace = run_path(version_file)
  File "/home/demo/.pyenv/versions/3.8.1/lib/python3.8/runpy.py", line 262, in run_path
    code, fname = _get_code_from_file(run_name, path_name)
  File "/home/demo/.pyenv/versions/3.8.1/lib/python3.8/runpy.py", line 232, in _get_code_from_file
    with io.open_code(fname) as f:
TypeError: open_code() argument 'path' must be str, not PosixPath
```