### PR TITLE
Fix `venv_metadata_inspector.py` error handling/reporting

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 0.15.1.4
-- Improve error reporting during venv metadata inspection
-- [bugfix] Fix incompatibility with pypy as venv interpreter
+- Improved error reporting during venv metadata inspection.
+- [bugfix] Fixed incompatibility with pypy as venv interpreter (#372).
 - [bugfix] Replaced implicit dependency on setuptools with an explicit dependency on packaging (#339).
 
 0.15.1.3

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,6 @@
 0.15.1.4
+- Improve error reporting during venv metadata inspection
+- [bugfix] Fix incompatibility with pypy as venv interpreter
 - [bugfix] Replaced implicit dependency on setuptools with an explicit dependency on packaging (#339).
 
 0.15.1.3

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -75,15 +75,11 @@ else:
         return bin_path, python_path
 
 
-def get_script_output(interpreter: Path, script: str, *args: Union[str, Path]) -> str:
-    proc = run_subprocess([interpreter, "-c", script, *args], capture_stderr=False)
-    return proc.stdout
-
-
 def get_site_packages(python: Path) -> Path:
-    output = get_script_output(
-        python, "import sysconfig; print(sysconfig.get_path('purelib'))"
-    )
+    output = run_subprocess(
+        [python, "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"],
+        capture_stderr=False,
+    ).stdout
     path = Path(output.strip())
     path.mkdir(parents=True, exist_ok=True)
     return path

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -89,7 +89,7 @@ def run_subprocess(
     cmd: Sequence[Union[str, Path]],
     capture_stdout: bool = True,
     capture_stderr: bool = True,
-    log_cmd_str: Optional[str] = None
+    log_cmd_str: Optional[str] = None,
 ) -> subprocess.CompletedProcess:
     """Run arbitrary command as subprocess, capturing stderr and stout"""
     env = dict(os.environ)

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Sequence, Tuple, Union
+from typing import List, Sequence, Tuple, Union, Optional
 
 from pipx.constants import WINDOWS
 
@@ -89,6 +89,7 @@ def run_subprocess(
     cmd: Sequence[Union[str, Path]],
     capture_stdout: bool = True,
     capture_stderr: bool = True,
+    log_cmd_str: Optional[str] = None
 ) -> subprocess.CompletedProcess:
     """Run arbitrary command as subprocess, capturing stderr and stout"""
     env = dict(os.environ)
@@ -106,8 +107,9 @@ def run_subprocess(
     # Make sure that Python writes output in UTF-8
     env["PYTHONIOENCODING"] = "utf-8"
 
-    cmd_str = " ".join(str(c) for c in cmd)
-    logging.info(f"running {cmd_str}")
+    if log_cmd_str is None:
+        log_cmd_str = " ".join(str(c) for c in cmd)
+    logging.info(f"running {log_cmd_str}")
     # windows cannot take Path objects, only strings
     cmd_str_list = [str(c) for c in cmd]
     return subprocess.run(

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -13,7 +13,6 @@ from pipx.shared_libs import shared_libs
 from pipx.util import (
     PipxError,
     full_package_description,
-    get_script_output,
     get_site_packages,
     get_venv_paths,
     rmdir,
@@ -21,6 +20,7 @@ from pipx.util import (
     run_subprocess,
     valid_pypi_name,
 )
+from pipx.venv_metadata_inspector import __file__ as VENV_METADATA_INSPECTOR_FILE
 
 
 class VenvContainer:
@@ -61,14 +61,6 @@ class VenvMetadata(NamedTuple):
     app_paths_of_dependencies: Dict[str, List[Path]]
     package_version: str
     python_version: str
-
-
-venv_metadata_inspector_raw = pkgutil.get_data("pipx", "venv_metadata_inspector.py")
-assert venv_metadata_inspector_raw is not None, (
-    "pipx could not find required file venv_metadata_inspector.py. "
-    "Please report this error at https://github.com/pipxproject/pipx. Exiting."
-)
-VENV_METADATA_INSPECTOR = venv_metadata_inspector_raw.decode("utf-8")
 
 
 class Venv:
@@ -241,15 +233,23 @@ class Venv:
 
     def get_venv_metadata_for_package(self, package: str) -> VenvMetadata:
         data = json.loads(
-            get_script_output(
-                self.python_path, VENV_METADATA_INSPECTOR, package, self.bin_path
-            )
+            run_subprocess(
+                [
+                    self.python_path,
+                    VENV_METADATA_INSPECTOR_FILE,
+                    package,
+                    self.bin_path,
+                ],
+                capture_stderr=False,
+            ).stdout
         )
+
         venv_metadata_traceback = data.pop("exception_traceback", None)
         if venv_metadata_traceback is not None:
             logging.info(
                 f"venv_metadata_inspector.py Traceback:\n{venv_metadata_traceback}"
             )
+
         data["app_paths"] = [Path(p) for p in data["app_paths"]]
         for dep in data["app_paths_of_dependencies"]:
             data["app_paths_of_dependencies"][dep] = [

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -245,7 +245,7 @@ class Venv:
 
         venv_metadata_traceback = data.pop("exception_traceback", None)
         if venv_metadata_traceback is not None:
-            logging.error("Pipx internal error with venv metadata inspection.")
+            logging.error("Internal error with venv metadata inspection.")
             logging.info(
                 f"venv_metadata_inspector.py Traceback:\n{venv_metadata_traceback}"
             )

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -249,6 +249,15 @@ class Venv:
                     self.bin_path,
                 ],
                 capture_stderr=False,
+                log_cmd_str=" ".join(
+                    [
+                        str(self.python_path),
+                        "-c",
+                        "<contents of venv_metadata_inspector.py>",
+                        package,
+                        str(self.bin_path),
+                    ]
+                ),
             ).stdout
         )
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -245,6 +245,11 @@ class Venv:
                 self.python_path, VENV_METADATA_INSPECTOR, package, self.bin_path
             )
         )
+        venv_metadata_traceback = data.pop("exception_traceback", None)
+        if venv_metadata_traceback is not None:
+            logging.info(
+                f"venv_metadata_inspector.py Traceback:\n{venv_metadata_traceback}"
+            )
         data["app_paths"] = [Path(p) for p in data["app_paths"]]
         for dep in data["app_paths_of_dependencies"]:
             data["app_paths_of_dependencies"][dep] = [

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -245,7 +245,7 @@ class Venv:
 
         venv_metadata_traceback = data.pop("exception_traceback", None)
         if venv_metadata_traceback is not None:
-            logging.info(
+            logging.warning(
                 f"venv_metadata_inspector.py Traceback:\n{venv_metadata_traceback}"
             )
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -245,7 +245,8 @@ class Venv:
 
         venv_metadata_traceback = data.pop("exception_traceback", None)
         if venv_metadata_traceback is not None:
-            logging.warning(
+            logging.error("Pipx internal error with venv metadata inspection.")
+            logging.info(
                 f"venv_metadata_inspector.py Traceback:\n{venv_metadata_traceback}"
             )
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import pkgutil
 import re
 import urllib.parse
 from pathlib import Path

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import pkgutil
 import re
 import urllib.parse
 from pathlib import Path
@@ -19,7 +20,14 @@ from pipx.util import (
     run_subprocess,
     valid_pypi_name,
 )
-from pipx.venv_metadata_inspector import __file__ as VENV_METADATA_INSPECTOR_FILE
+
+
+venv_metadata_inspector_raw = pkgutil.get_data("pipx", "venv_metadata_inspector.py")
+assert venv_metadata_inspector_raw is not None, (
+    "pipx could not find required file venv_metadata_inspector.py. "
+    "Please report this error at https://github.com/pipxproject/pipx. Exiting."
+)
+VENV_METADATA_INSPECTOR = venv_metadata_inspector_raw.decode("utf-8")
 
 
 class VenvContainer:
@@ -235,7 +243,8 @@ class Venv:
             run_subprocess(
                 [
                     self.python_path,
-                    VENV_METADATA_INSPECTOR_FILE,
+                    "-c",
+                    VENV_METADATA_INSPECTOR,
                     package,
                     self.bin_path,
                 ],

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+import traceback
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -165,9 +166,11 @@ if __name__ == "__main__":
                 {
                     "apps": [],
                     "app_paths": [],
+                    "apps_of_dependencies": [],
                     "app_paths_of_dependencies": {},
                     "package_version": None,
                     "python_version": None,
+                    "exception_traceback": traceback.format_exc().rstrip(),
                 }
             )
         )


### PR DESCRIPTION
<!--- 
Thank you for your soon-to-be pull request. Before you submit this, please      
double check to make sure that you've added an entry to docs/changelog.md.      
-->                                                                             
This fixes a bug with bad empty json data returned during a caught exception in `venv_metadata_inspector`.  It also captures and communicates the traceback of an Exception that occurred in `venv_metadata_inspector.py` to the caller.  It is inspired by #378 and the difficulty of assessing what was going wrong inside of `venv_metadata_inspector.py`.
                                                                                
Changes                                                                         
* `venv_metadata_inspector.py` now returns proper empty data json (added required key `"apps_of_dependencies"`
* Pass string of traceback for a caught Exception in `venv_metadata_inspector.py` in returned json
* ~~Change invocation of `venv_metadata_inspector.py`: instead of passing file text to `python -c` use filename passed to `python`.  This prevents entire text of `venv_metadata_inspector.py` from showing up in pipx verbose output.~~
* `venv.get_venv_metadata_for_package()` logs a warning ("Internal error [...]") and logs info of `venv_metadata_inspector.py` traceback string.
* Removed `pipx.utils.get_script_output()` because it was only used in one place in `utils.py`.
* Added extra changelog for #373