### PR TITLE
hide cursor while pipx is running

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ dev
 - [bugfix] Replaced implicit dependency on setuptools with an explicit dependency on packaging (#339).
 - [refactor] Moved all commands to separate files within the commands module (#255).
 - [bugfix] Continue reinstalling packages after failure
+- [bugfix] Hide cursor while pipx runs
 
 0.15.1.3
 

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -48,7 +48,6 @@ def animate(
         "animate_at_beginning_of_line": animate_at_beginning_of_line,
     }
 
-    hide_cursor()
     t = Thread(target=print_animation, kwargs=thread_kwargs)
     t.start()
 
@@ -57,7 +56,6 @@ def animate(
     finally:
         event.set()
         clear_line()
-        show_cursor()
         sys.stderr.write("\r")
         sys.stdout.write("\r")
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -20,6 +20,7 @@ from . import constants
 from .util import PipxError, mkdir
 from .venv import VenvContainer
 from .version import __version__
+from .animate import hide_cursor, show_cursor
 
 
 def print_version() -> None:
@@ -563,6 +564,7 @@ def check_args(parsed_pipx_args: argparse.Namespace):
 def cli() -> int:
     """Entry point from command line"""
     try:
+        hide_cursor()
         parser = get_command_parser()
         argcomplete.autocomplete(parser)
         parsed_pipx_args = parser.parse_args()
@@ -577,6 +579,8 @@ def cli() -> int:
         return 1
     except KeyboardInterrupt:
         return 1
+    finally:
+        show_cursor()
 
 
 if __name__ == "__main__":

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -2,7 +2,6 @@ import time
 
 import pipx.animate
 from pipx.animate import (
-    HIDE_CURSOR,
     CLEAR_LINE,
     EMOJI_ANIMATION_FRAMES,
     NONEMOJI_ANIMATION_FRAMES,
@@ -14,7 +13,7 @@ from pipx.animate import (
 def check_animate_output(
     capsys, test_string, frame_strings, frame_period, frames_to_test
 ):
-    expected_string = f"{HIDE_CURSOR}" + "".join(frame_strings)
+    expected_string = "".join(frame_strings)
 
     chars_to_test = 1 + len("".join(frame_strings[:frames_to_test]))
 


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
Instead of hiding/showing the cursor each time an animation is started/finished, just hide it for the entire time pipx runs, then show it when it finishes. This stops it from showing up and disappearing in the middle of multiple operations, which looks unpolished.