### PR TITLE
add more types to main.py

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,9 +1,11 @@
-0.15.1.4
+dev
 
 - Improved error reporting during venv metadata inspection.
 - [bugfix] Fixed incompatibility with pypy as venv interpreter (#372).
 - [bugfix] Replaced implicit dependency on setuptools with an explicit dependency on packaging (#339).
 - [refactor] Moved all commands to separate files within the commands module (#255).
+- [bugfix] Do not abort early when injecting multiple dependencies
+- [dev] Add more type annotations
 
 0.15.1.3
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -209,7 +209,7 @@ def run_post_install_actions(
     include_dependencies: bool,
     *,
     force: bool,
-):
+) -> None:
     package_metadata = venv.package_metadata[package]
 
     if not package_metadata.app_paths and not include_dependencies:

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -21,7 +21,7 @@ def inject(
     include_apps: bool,
     include_dependencies: bool,
     force: bool,
-):
+) -> None:
     if not venv_dir.exists() or not next(venv_dir.iterdir()):
         raise PipxError(
             textwrap.dedent(

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -10,7 +10,7 @@ import re
 import sys
 import textwrap
 import urllib.parse
-from typing import Dict, List
+from typing import Dict, List, Generator
 
 import argcomplete  # type: ignore
 from .colors import bold, green
@@ -242,8 +242,8 @@ def add_include_dependencies(parser: argparse.ArgumentParser):
 
 def autocomplete_list_of_installed_packages(
     venv_container: VenvContainer, *args, **kwargs
-) -> List[str]:
-    return list(str(p.name) for p in sorted(venv_container.iter_venv_dirs()))
+) -> Generator[str, None, None]:
+    return (str(p.name) for p in sorted(venv_container.iter_venv_dirs()))
 
 
 def _add_install(subparsers: argparse._SubParsersAction):
@@ -274,7 +274,7 @@ def _add_install(subparsers: argparse._SubParsersAction):
 
 
 def _add_inject(
-    subparsers: argparse._SubParsersAction, package_choices: List[str],
+    subparsers: argparse._SubParsersAction, package_choices: Generator[str, None, None],
 ):
     p = subparsers.add_parser(
         "inject",
@@ -283,6 +283,7 @@ def _add_inject(
     )
     p.add_argument(
         "package",
+        metavar="package",
         help="Name of the existing pipx-managed Virtual Environment to inject into",
         choices=package_choices,
     )
@@ -307,13 +308,17 @@ def _add_inject(
     p.add_argument("--verbose", action="store_true")
 
 
-def _add_upgrade(subparsers: argparse._SubParsersAction, package_choices: List[str]):
+def _add_upgrade(
+    subparsers: argparse._SubParsersAction, package_choices: Generator[str, None, None]
+):
     p = subparsers.add_parser(
         "upgrade",
         help="Upgrade a package",
         description="Upgrade a package in a pipx-managed Virtual Environment by running 'pip install --upgrade PACKAGE'",
     )
-    p.add_argument("package", choices=package_choices)
+    p.add_argument(
+        "package", metavar="package", choices=package_choices,
+    )
     p.add_argument(
         "--force",
         "-f",
@@ -342,13 +347,17 @@ def _add_upgrade_all(subparsers: argparse._SubParsersAction,):
     p.add_argument("--verbose", action="store_true")
 
 
-def _add_uninstall(subparsers: argparse._SubParsersAction, package_choices: List[str]):
+def _add_uninstall(
+    subparsers: argparse._SubParsersAction, package_choices: Generator[str, None, None]
+):
     p = subparsers.add_parser(
         "uninstall",
         help="Uninstall a package",
         description="Uninstalls a pipx-managed Virtual Environment by deleting it and any files that point to its apps.",
     )
-    p.add_argument("package", choices=package_choices)
+    p.add_argument(
+        "package", metavar="package", choices=package_choices,
+    )
     p.add_argument("--verbose", action="store_true")
 
 
@@ -456,7 +465,9 @@ def _add_run(subparsers: argparse._SubParsersAction,):
     p.usage = re.sub(r"\.\.\.", "app ...", p.usage)
 
 
-def _add_runpip(subparsers: argparse._SubParsersAction, package_choices: List[str]):
+def _add_runpip(
+    subparsers: argparse._SubParsersAction, package_choices: Generator[str, None, None]
+):
     p = subparsers.add_parser(
         "runpip",
         help="Run pip in an existing pipx-managed Virtual Environment",
@@ -464,6 +475,7 @@ def _add_runpip(subparsers: argparse._SubParsersAction, package_choices: List[st
     )
     p.add_argument(
         "package",
+        metavar="package",
         help="Name of the existing pipx-managed Virtual Environment to run pip in",
         choices=package_choices,
     )

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -46,10 +46,11 @@ class VenvContainer:
     def iter_venv_dirs(self) -> Generator[Path, None, None]:
         """Iterate venv directories in this container.
         """
-        for entry in self._root.iterdir():
-            if not entry.is_dir():
-                continue
-            yield entry
+        if self._root.is_dir():
+            for entry in self._root.iterdir():
+                if not entry.is_dir():
+                    continue
+                yield entry
 
     def get_venv_dir(self, package: str) -> Path:
         """Return the expected venv path for given `package`.


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->

It was noted in https://github.com/pipxproject/pipx/pull/382 that there are some missing types in `main.py`. This PR adds more types, and also adds a try/except around the `inject` command so that it will try to inject all dependencies and not abort immediately if one fails.

Note: these type annotations needed to be in comments
```
    autocomplete_list_of_installed_packages,  # type: functools.partial[List[str]]
```
 because, while mypy was fine with it, it was invalid python syntax. It resulted in this Python error :roll_eyes:  
```
  File "src/pipx/main.py", line 313, in <module>
    autocomplete_list_of_installed_packages: functools.partial[List[str]],
TypeError: 'type' object is not subscriptable
```

Still TODO (in another PR):
* The `completer` attribute is added in by argcomplete, which does not have type stubs, so mypy thinks it is an error. Need to fix this somehow.