### PR TITLE
Handle debundled pip._vendor, fixes #386

### DIFF
--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 from typing import List
 import time
 import datetime

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -6,7 +6,7 @@ import datetime
 
 from pipx.animate import animate
 from pipx.constants import DEFAULT_PYTHON, PIPX_SHARED_LIBS, WINDOWS
-from pipx.util import get_site_packages, get_venv_paths, run
+from pipx.util import get_pth_block, get_venv_paths, run
 
 SHARED_LIBS_MAX_AGE_SEC = datetime.timedelta(days=30).total_seconds()
 
@@ -18,15 +18,15 @@ class _SharedLibs:
         self.pip_path = self.bin_path / ("pip" if not WINDOWS else "pip.exe")
         # i.e. bin_path is ~/.local/pipx/shared/bin
         # i.e. python_path is ~/.local/pipx/shared/python
-        self._site_packages = None
+        self._pth_block = None
         self.has_been_updated_this_run = False
 
     @property
-    def site_packages(self) -> Path:
-        if self._site_packages is None:
-            self._site_packages = get_site_packages(self.python_path)
+    def pth_block(self) -> str:
+        if self._pth_block is None:
+            self._pth_block = get_pth_block(self.python_path)
 
-        return self._site_packages
+        return self._pth_block
 
     def create(self, pip_args: List[str], verbose: bool = False):
         if not self.is_valid:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -84,6 +84,19 @@ def get_site_packages(python: Path) -> Path:
     path.mkdir(parents=True, exist_ok=True)
     return path
 
+def get_pth_block(python: Path) -> str:
+    """Some distrbutions (Debian, Redhat) break up pip's _vendor directory
+    into its constituent wheels, in which case we want to ensure that the pth
+    file we write in each virtual environment points to these shared
+    environment wheels.
+    """
+    return run_subprocess(
+        [python, "-c",
+         "import sys; l=len(sys.path); import pip._vendor as v; "
+         "print('\\n'.join(sys.path[:-l])) if v.DEBUNDLED else None;"
+         "import sysconfig; print(sysconfig.get_path('purelib'))"],
+        capture_stderr=False,
+    ).stdout
 
 def run_subprocess(
     cmd: Sequence[Union[str, Path]],

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -84,6 +84,7 @@ def get_site_packages(python: Path) -> Path:
     path.mkdir(parents=True, exist_ok=True)
     return path
 
+
 def get_pth_block(python: Path) -> str:
     """Some distrbutions (Debian, Redhat) break up pip's _vendor directory
     into its constituent wheels, in which case we want to ensure that the pth
@@ -91,12 +92,16 @@ def get_pth_block(python: Path) -> str:
     environment wheels.
     """
     return run_subprocess(
-        [python, "-c",
-         "import sys; l=len(sys.path); import pip._vendor as v; "
-         "print('\\n'.join(sys.path[:-l])) if v.DEBUNDLED else None;"
-         "import sysconfig; print(sysconfig.get_path('purelib'))"],
+        [
+            python,
+            "-c",
+            "import sys; l=len(sys.path); import pip._vendor as v; "
+            "print('\\n'.join(sys.path[:-l])) if v.DEBUNDLED else None;"
+            "import sysconfig; print(sysconfig.get_path('purelib'))",
+        ],
         capture_stderr=False,
     ).stdout
+
 
 def run_subprocess(
     cmd: Sequence[Union[str, Path]],

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -135,7 +135,7 @@ class Venv:
         # https://docs.python.org/3/library/site.html
         # A path configuration file is a file whose name has the form 'name.pth'.
         # its contents are additional items (one per line) to be added to sys.path
-        pipx_pth.write_text(f"{shared_libs.site_packages}\n", encoding="utf-8")
+        pipx_pth.write_text(f"{shared_libs.pth_block}", encoding="utf-8")
 
         self.pipx_metadata.venv_args = venv_args
         self.pipx_metadata.python_version = self.get_python_version()


### PR DESCRIPTION
Some distrbutions (Debian, <s>Redhat</s>) break up pip's _vendor directory
into its constituent wheels, in which case we want to ensure that
the pth file we write in each virtual environment points to these
shared environment wheels.

*Edit*: if I understood the Redhat patches, they do something different

This will fix #386 
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->