### PR TITLE
a pip in every virtual env, like the good ol' days

### DIFF
--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -122,7 +122,7 @@ class Venv:
 
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
         with animate("creating virtual environment", self.do_animation):
-            cmd = [self.python, "-m", "venv", "--without-pip"]
+            cmd = [self.python, "-m", "venv"]
             run(cmd + venv_args + [str(self.root)])
         shared_libs.create(pip_args, self.verbose)
         pipx_pth = get_site_packages(self.python_path) / PIPX_SHARED_PTH


### PR DESCRIPTION
This is a minimal change that also fixes #386, and is an alternative to #388.

If this is the preferred path, then there's more to remove (the shared_libs logic is unnecessary if I'm understanding correctly).

Not that in comparison with the solution in #388, where the cowsay virtual environment was 156K, this change makes the cowsay virtualenv 2.4M - since 2.3M worth of wheels get copied into every environment.