### PR TITLE
Avoid Debian-patched pip in the shared venv

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,7 @@ dev
 - [bugfix] Hide cursor while pipx runs
 - [feature] Add environment variable `USE_EMOJI` to allow enabling/disabling emojies (#376)
 - [refactor] Moved all commands to separate files within the commands module (#255).
+- [bugfix] Ignore system shared libraries when installing shared libraries pip, wheel, and setuptools. This also fixes an incompatibility with Debian/Ubuntu's version of pip (#386).
 
 0.15.1.3
 

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -32,7 +32,12 @@ class _SharedLibs:
         if not self.is_valid:
             with animate("creating shared libraries", not verbose):
                 run([DEFAULT_PYTHON, "-m", "venv", "--clear", self.root])
-            self.upgrade(pip_args, verbose)
+            # Note: -I is needed here to replace the patched Debian pip with
+            # the upstream one, even when the Debian pip version matches the
+            # current upstream pip version.  Otherwise there's a flood of
+            # bug reports about things not working, like
+            # https://github.com/pipxproject/pipx/issues/386
+            self.upgrade(["-I"] + pip_args, verbose)
 
     @property
     def is_valid(self):

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -32,12 +32,9 @@ class _SharedLibs:
         if not self.is_valid:
             with animate("creating shared libraries", not verbose):
                 run([DEFAULT_PYTHON, "-m", "venv", "--clear", self.root])
-            # Note: -I is needed here to replace the patched Debian pip with
-            # the upstream one, even when the Debian pip version matches the
-            # current upstream pip version.  Otherwise there's a flood of
-            # bug reports about things not working, like
-            # https://github.com/pipxproject/pipx/issues/386
-            self.upgrade(["-I"] + pip_args, verbose)
+            # ignore installed packages to ensure no unexpected patches from the OS vendor
+            # are used
+            self.upgrade(["--ignore-installed"] + pip_args, verbose)
 
     @property
     def is_valid(self):


### PR DESCRIPTION
Should fix #386.

This fix should be more lightweight than #387, and it is simpler than #388.  It tries to find an acceptable middle ground between explicitly supporting Debian's changes to their pip and causing pain to users in order to make a statement.

This patch needs testing.  I haven't come up with a test plan yet (I don't want to mess up my currently-working actual pipx setup), but I'll try to do something with docker.
