### PR TITLE
New list option `--include-injected` shows injected packages in main apps

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ dev
 - [refactor] Moved all commands to separate files within the commands module (#255).
 - [bugfix] Continue reinstalling packages after failure
 - [bugfix] Hide cursor while pipx runs
+- [feature] `list` now has a new option `--include_injected` to show the injected packages in the main apps
 
 0.15.1.3
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,9 +1,13 @@
 dev
 
+- [feature] `list` now has a new option `--include-injected` to show the injected packages in the main apps
+
 0.15.3.1
+
 - [bugfix] Workaround multiprocessing issues on certain platforms (#229)
 
 0.15.3.0
+
 - [feature] Use symlinks on Windows when symlinks are available
 
 0.15.2.0
@@ -15,7 +19,6 @@ dev
 - [bugfix] Hide cursor while pipx runs
 - [feature] Add environment variable `USE_EMOJI` to allow enabling/disabling emojies (#376)
 - [refactor] Moved all commands to separate files within the commands module (#255).
-- [feature] `list` now has a new option `--include-injected` to show the injected packages in the main apps
 
 0.15.1.3
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -311,12 +311,13 @@ optional arguments:
 
 ```
 pipx list --help
-usage: pipx list [-h] [--verbose]
+usage: pipx list [-h] [--include-injected] [--verbose]
 
 List packages and apps installed with pipx
 
 optional arguments:
-  -h, --help  show this help message and exit
+  -h, --help          show this help message and exit
+  --include-injected  show the injected packages in the main apps
   --verbose
 
 ```

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -182,7 +182,7 @@ def _get_list_output(
             f"    - {red(name)} (symlink missing or pointing to unexpected location)"
         )
     if injected_package_names:
-        output.append(f"    {bold('Injected Packages')}")
+        output.append("    Injected Packages:")
         for name in injected_package_names:
             output.append(f"      - {name}")
     return "\n".join(output)

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -8,7 +8,7 @@ import userpath  # type: ignore
 
 from pathlib import Path
 from shutil import which
-from typing import List
+from typing import Collection, List, Optional
 
 from pipx import constants
 from pipx.colors import bold, red
@@ -87,7 +87,11 @@ def _symlink_package_apps(
 
 
 def get_package_summary(
-    path: Path, *, package: str = None, new_install: bool = False
+    path: Path,
+    *,
+    package: str = None,
+    new_install: bool = False,
+    include_injected: bool = False,
 ) -> str:
     venv = Venv(path)
     python_path = venv.python_path.resolve()
@@ -125,6 +129,7 @@ def get_package_summary(
         new_install,
         exposed_binary_names,
         unavailable_binary_names,
+        venv.pipx_metadata.injected_packages.keys() if include_injected else None,
     )
 
 
@@ -158,6 +163,7 @@ def _get_list_output(
     new_install: bool,
     exposed_binary_names: List[str],
     unavailable_binary_names: List[str],
+    injected_package_names: Optional[Collection[str]] = None,
 ) -> str:
     output = []
     output.append(
@@ -175,6 +181,10 @@ def _get_list_output(
         output.append(
             f"    - {red(name)} (symlink missing or pointing to unexpected location)"
         )
+    if injected_package_names:
+        output.append(f"    {bold('Injected Packages')}")
+        for name in injected_package_names:
+            output.append(f"      - {name}")
     return "\n".join(output)
 
 

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -10,6 +10,7 @@ except ImportError:
     from multiprocessing.dummy import Pool
 else:
     from multiprocessing import Pool
+from functools import partial
 
 from pipx import constants
 from pipx.colors import bold
@@ -18,7 +19,7 @@ from pipx.emojies import sleep
 from pipx.venv import VenvContainer
 
 
-def list_packages(venv_container: VenvContainer):
+def list_packages(venv_container: VenvContainer, include_injected: bool):
     dirs = list(sorted(venv_container.iter_venv_dirs()))
     if not dirs:
         print(f"nothing has been installed with pipx {sleep}")
@@ -30,5 +31,7 @@ def list_packages(venv_container: VenvContainer):
     venv_container.verify_shared_libs()
 
     with Pool() as p:
-        for package_summary in p.map(get_package_summary, dirs):
+        for package_summary in p.map(
+            partial(get_package_summary, include_injected=include_injected), dirs
+        ):
             print(package_summary)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -177,7 +177,7 @@ def run_pipx_command(args: argparse.Namespace):  # noqa: C901
             venv_dir, package, pip_args, verbose, upgrading_all=False, force=args.force
         )
     elif args.command == "list":
-        return commands.list_packages(venv_container)
+        return commands.list_packages(venv_container, args.include_injected)
     elif args.command == "uninstall":
         return commands.uninstall(venv_dir, package, constants.LOCAL_BIN_DIR, verbose)
     elif args.command == "uninstall-all":
@@ -387,6 +387,11 @@ def _add_list(subparsers):
         "list",
         help="List installed packages",
         description="List packages and apps installed with pipx",
+    )
+    p.add_argument(
+        "--include-injected",
+        action="store_true",
+        help="show the injected packages in the main apps",
     )
     p.add_argument("--verbose", action="store_true")
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -395,7 +395,7 @@ def _add_list(subparsers):
     p.add_argument(
         "--include-injected",
         action="store_true",
-        help="show the injected packages in the main apps",
+        help="Show packages injected into the main app's environment",
     )
     p.add_argument("--verbose", action="store_true")
 


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->

The main reason for this pull request is to have the ability to see the injected packages without having to examine the underlying `pipx_metadata.json` file stored in each virtual environment. The name is a work in progress so I would like to get some suggestions about what to do with that.

If there is anything else that could be a cause for concern, please let me know. Thank you.