### PR TITLE
Handle pre-0.15.0.0 missing metadata

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,5 @@
 dev
+- [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.
 
 0.15.4.0
 - [feature] `list` now has a new option `--include-injected` to show the injected packages in the main apps

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -124,6 +124,12 @@ def get_package_summary(
         package = path.name
     if not python_path.is_file():
         return f"   package {red(bold(package))} has invalid interpreter {str(python_path)}"
+    if not venv.package_metadata:
+        return (
+            f"   package {red(bold(package))} has missing internal pipx metadata.\n"
+            f"       It was likely installed using a pipx version before 0.15.0.0.\n"
+            f"       Please uninstall and install this package, or reinstall-all to fix."
+        )
 
     package_metadata = venv.package_metadata[package]
 

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -5,6 +5,7 @@ from typing import List
 
 
 from pipx import constants
+from pipx.colors import bold, red
 from pipx.commands.common import expose_apps_globally
 from pipx.emojies import sleep
 from pipx.util import PipxError
@@ -30,18 +31,19 @@ def upgrade(
 
     venv = Venv(venv_dir, verbose=verbose)
 
-    package_metadata = venv.package_metadata[package]
-    if package_metadata.package_or_url is not None:
+    if venv.package_metadata:
+        package_metadata = venv.package_metadata[package]
         package_or_url = package_metadata.package_or_url
         old_version = package_metadata.package_version
         include_apps = package_metadata.include_apps
         include_dependencies = package_metadata.include_dependencies
     else:
-        # fallback if no metadata
-        package_or_url = package
-        old_version = ""
-        include_apps = True
-        include_dependencies = False
+        print(
+            f"Not upgrading {red(bold(package))}.  It has missing internal pipx metadata.\n"
+            f"    It was likely installed using a pipx version before 0.15.0.0.\n"
+            f"    Please uninstall and install this package, or reinstall-all to fix."
+        )
+        return 0
 
     if package == "pipx":
         package_or_url = "pipx"

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -31,19 +31,19 @@ def upgrade(
 
     venv = Venv(venv_dir, verbose=verbose)
 
-    if venv.package_metadata:
-        package_metadata = venv.package_metadata[package]
-        package_or_url = package_metadata.package_or_url
-        old_version = package_metadata.package_version
-        include_apps = package_metadata.include_apps
-        include_dependencies = package_metadata.include_dependencies
-    else:
+    if not venv.package_metadata:
         print(
             f"Not upgrading {red(bold(package))}.  It has missing internal pipx metadata.\n"
             f"    It was likely installed using a pipx version before 0.15.0.0.\n"
             f"    Please uninstall and install this package, or reinstall-all to fix."
         )
         return 0
+
+    package_metadata = venv.package_metadata[package]
+    package_or_url = package_metadata.package_or_url
+    old_version = package_metadata.package_version
+    include_apps = package_metadata.include_apps
+    include_dependencies = package_metadata.include_dependencies
 
     if package == "pipx":
         package_or_url = "pipx"

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -40,6 +40,9 @@ def upgrade(
         return 0
 
     package_metadata = venv.package_metadata[package]
+    if package_metadata.package_or_url is None:
+        raise PipxError(f"Internal Error: package {package} has corrupt pipx metadata.")
+
     package_or_url = package_metadata.package_or_url
     old_version = package_metadata.package_version
     include_apps = package_metadata.include_apps


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
Fixes #411 

Handled missing metadata in `pipx upgrade`, `pipx upgrade-all` and `pipx list`, which were the only cases I could find that could fail with stack trace error upon empty `venv.package_metadata`.

Warning message for upgrade of package with missing metadata:
<img width="643" alt="Screen Shot 2020-05-28 at 8 45 04 PM" src="https://user-images.githubusercontent.com/12565784/83219021-1ddae200-a124-11ea-9297-c78712c9b3b4.png">

Warning message for package with missing metadata during `list`:
<img width="605" alt="Screen Shot 2020-05-28 at 6 26 14 PM" src="https://user-images.githubusercontent.com/12565784/83210910-b8312a80-a110-11ea-9fa2-c9fb19649772.png">