### PR TITLE
expanded pipx code from single markdown

### DIFF
--- a/docs/programs-to-try.md
+++ b/docs/programs-to-try.md
@@ -1,22 +1,148 @@
+## Programs 
+
 Here are some programs you can try out. If you've never used the program before, make sure you add the `--help` flag so it doesn't do something you don't expect. If you decide you want to install, you can run `pipx install PACKAGE` instead.
 
+### ansible
+
+IT automation
+
 ```
-pipx install ansible  # IT automation
-pipx run asciinema  # Record and share your terminal sessions, the right way.
-pipx run black  # uncompromising Python code formatter
-pipx run --spec=babel pybabel --help  # internationalizing and localizing Python applications
-pipx run --spec=chardet chardetect --help  # detect file encoding
-pipx run cookiecutter  # creates projects from project templates
-pipx run create-python-package  # easily create and publish new Python packages
-pipx run flake8  # tool for style guide enforcement
-pipx run gdbgui  # browser-based gdb debugger
-pipx run hexsticker  # create hexagon stickers automatically
-pipx run ipython  # powerful interactive Python shell
-pipx run jupyter  # web-based notebook environment for interactive computing
-pipx run pipenv  # python dependency/environment management
-pipx run poetry  # python dependency/environment/packaging management
-pipx run pylint  # source code analyzer
-pipx run pyinstaller  # bundles a Python application and all its dependencies into a single package
-pipx run pyxtermjs  # fully functional terminal in the browser  
-pipx install shell-functools  # Functional programming tools for the shell
+pipx install ansible
+```
+
+### asciinema
+
+Record and share your terminal sessions, the right way.
+
+```
+pipx run asciinema
+```
+
+### black
+
+uncompromising Python code formatter
+
+```
+pipx run black
+```
+
+### pybabel
+
+internationalizing and localizing Python applications
+
+```
+pipx run --spec=babel pybabel --help
+```
+
+### chardetect
+
+detect file encoding
+
+```
+pipx run --spec=chardet chardetect --help
+```
+
+### cookiecutter
+
+creates projects from project templates
+
+```
+pipx run cookiecutter
+```
+
+### create-python-package
+
+easily create and publish new Python packages
+
+```
+pipx run create-python-package
+```
+
+### flake8
+
+tool for style guide enforcement
+
+```
+pipx run flake8
+```
+
+### gdbgui
+
+browser-based gdb debugger
+
+```
+pipx run gdbgui
+```
+
+
+### hexsticker
+
+create hexagon stickers automatically
+
+```
+pipx run hexsticker
+```
+
+### ipython
+
+powerful interactive Python shell
+
+```
+pipx run ipython
+```
+
+### jupyter
+
+web-based notebook environment for interactive computing
+
+```
+pipx run jupyter
+```
+
+### pipenv
+
+python dependency/environment management
+
+```
+pipx run pipenv
+```
+
+### poetry
+
+python dependency/environment/packaging management
+
+```
+pipx run poetry
+```
+
+### pylint
+
+source code analyzer
+
+```
+pipx run pylint
+```
+
+### pyinstaller
+
+bundles a Python application and all its dependencies into a single package
+
+```
+pipx run pyinstaller
+```
+
+### pyxtermjs
+
+fully functional terminal in the browser  
+
+```
+pipx run pyxtermjs
+```
+
+### shell-functools
+
+Functional programming tools for the shell
+
+```
+pipx install shell-functools
 ```


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
## Sample code Separated to Single Markdown Items

- Separated sample package installs/ runs to single markdown items. Easier to copy from the documentation.
- If you ever enable `toc.permalink` for MKDocs, separating each code will have nice anchor links for each sample package and could potentially help search results.

PS: I checked the `changelog.md` file for any documentation update logs, but couldn't find any. That's why I am not adding an entry, but let me know otherwise.