### PR TITLE
Log pipx version at info level (#423)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@ dev
 - [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.
 - [bugfix] For `pipx install`, fixed failure to install if user has `PIP_USER=1` or `user=true` in pip.conf. (#110)
 - [bugfix] Requiring userpath v1.4.1 or later so ensure Windows bug is fixed for `ensurepath` (#437)
+- [feature] log pipx version (#423)
 
 0.15.4.0
 - [feature] `list` now has a new option `--include-injected` to show the injected packages in the main apps

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -543,6 +543,7 @@ def setup(args):
     else:
         logging.basicConfig(level=logging.WARNING, format="%(message)s")
 
+    logging.info(f"pipx version is {__version__}")
     mkdir(constants.PIPX_LOCAL_VENVS)
     mkdir(constants.LOCAL_BIN_DIR)
     mkdir(constants.PIPX_VENV_CACHEDIR)


### PR DESCRIPTION
Log pipx version at info level, ensuring it is in the logs when running verbosely.

closes #423

