### PR TITLE
Use `source` instead of `.` (#429)

### DIFF
--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -71,7 +71,7 @@ tcsh:
     eval `register-python-argcomplete --shell tcsh pipx`
 
 fish:
-    register-python-argcomplete --shell fish pipx | .
+    register-python-argcomplete --shell fish pipx | source
 
 """
 )


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->

I fixed #429.