### PR TITLE
Docs: Clarify what PIPX_BIN_DIR is for.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,7 +22,7 @@ python3 -m pipx ensurepath
 ```
 
 ### Installation Options
-pipx's default binary location is `~/.local/bin`. This can be overriden with the environment variable `PIPX_BIN_DIR`.
+The default binary location for pipx-installed apps is `~/.local/bin`. This can be overriden with the environment variable `PIPX_BIN_DIR`.
 
 pipx's default virtual environment location is `~/.local/pipx`. This can be overridden with the environment variable `PIPX_HOME`.
 


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->

Change wording of Installation doc to clarify that `PIPX_BIN_DIR` is for apps installed by pipx, not the pipx binary itself.

Ref: https://github.com/pipxproject/pipx/issues/431#issuecomment-647446042