### PR TITLE
`pipx install`: use `PIP_USER=0` to override `PIP_USER=1` or `user=true` in pip.conf

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 dev
 - [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.
-- [bugfix] For `pipx install`, fixed crash if user has `PIP_USER=1` or `user=true` in pip.conf. (#110)
+- [bugfix] For `pipx install`, fixed failure to install if user has `PIP_USER=1` or `user=true` in pip.conf. (#110)
 - [bugfix] Requiring userpath v1.4.1 or later so ensure Windows bug is fixed for `ensurepath` (#437)
 
 0.15.4.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 dev
 - [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.
-- [bugfix] For `pipx install`, fixed crash by if user has `PIP_USER=1` or `user=true` in pip.conf.
+- [bugfix] For `pipx install`, fixed crash if user has `PIP_USER=1` or `user=true` in pip.conf. (#110)
 - [bugfix] Requiring userpath v1.4.1 or later so ensure Windows bug is fixed for `ensurepath` (#437)
 
 0.15.4.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 - [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.
+- [bugfix] For `pipx install`, fix crash by using `PIP_USER=0` to override `PIP_USER=1` or `user=true` in pip.conf.
 
 0.15.4.0
 - [feature] `list` now has a new option `--include-injected` to show the injected packages in the main apps

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 dev
 - [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.
-- [bugfix] For `pipx install`, fix crash by using `PIP_USER=0` to override `PIP_USER=1` or `user=true` in pip.conf.
+- [bugfix] For `pipx install`, fixed crash by if user has `PIP_USER=1` or `user=true` in pip.conf.
 - [bugfix] Requiring userpath v1.4.1 or later so ensure Windows bug is fixed for `ensurepath` (#437)
 
 0.15.4.0

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -106,6 +106,8 @@ def run_subprocess(
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
     # Make sure that Python writes output in UTF-8
     env["PYTHONIOENCODING"] = "utf-8"
+    # Make sure we install package to venv, not userbase dir
+    env["PIP_USER"] = "0"
 
     if log_cmd_str is None:
         log_cmd_str = " ".join(str(c) for c in cmd)


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
Fixes #110 

Set `PIP_USER=0` in `run_subprocess()` so that both pip.conf or user environment variables will be overridden to make sure we can actually install pipx packages to our venvs, and not to the userbase directory.

Environment variables override everything in pip except pip command-line options.  Users could still send in a malicious `--user` switch using `pipx install --pip-args`, but I think at that point they are really trying to hurt themselves and and we aren't responsible.
