### PR TITLE
Make `ensurepath` also ensure pip-user-installed pipx script is in path

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 - [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.
+- [feature] `ensurepath` now also ensures that pip user binary path containing pipx itself is in user's PATH if pipx was installed using `pip install --user`.
 
 0.15.4.0
 - [feature] `list` now has a new option `--include-injected` to show the injected packages in the main apps

--- a/makefile
+++ b/makefile
@@ -1,7 +1,10 @@
-.PHONY: test docs develop build publish publish_docs
+.PHONY: test docs develop build publish publish_docs lint
 
 develop:
 	pipx run --spec=git+https://github.com/cs01/nox.git@5ea70723e9e6 nox -s develop
+
+lint:
+	pipx run --spec=git+https://github.com/cs01/nox.git@5ea70723e9e6 nox -s lint
 
 test:
 	# TODO use `pipx run nox` when nox supports venv creation (and thus

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ develop:
 	pipx run --spec=git+https://github.com/cs01/nox.git@5ea70723e9e6 nox -s develop
 
 lint:
-	pipx run --spec=git+https://github.com/cs01/nox.git@5ea70723e9e6 nox -s lint
+	pipx run nox -s lint
 
 test:
 	# TODO use `pipx run nox` when nox supports venv creation (and thus

--- a/src/pipx/commands/__init__.py
+++ b/src/pipx/commands/__init__.py
@@ -1,4 +1,4 @@
-from .ensure_path import ensure_path
+from .ensure_path import ensure_pipx_paths
 from .inject import inject
 from .install import install
 from .list_packages import list_packages
@@ -20,5 +20,5 @@ __all__ = [
     "reinstall_all",
     "list_packages",
     "run_pip",
-    "ensure_path",
+    "ensure_pipx_paths",
 ]

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 import site
+import sys
 import textwrap
 from typing import Tuple, Optional
 
@@ -117,6 +118,7 @@ def ensure_pipx_paths(force: bool):
             + "\n"
         )
     elif not need_shell_restart:
+        sys.stdout.flush()
         logging.warning(
             textwrap.fill(
                 "All pipx binary directories have been added to PATH. "

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -114,7 +114,7 @@ def ensure_pipx_paths(force: bool):
         logging.warning(
             textwrap.fill(
                 "All pipx binary directories have been added to PATH. "
-                "If you are sure you want add them again, try again with "
+                "If you are sure you want to proceed, try again with "
                 "the '--force' flag."
             )
             + "\n"

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -112,7 +112,7 @@ def ensure_pipx_paths(force: bool):
             )
             + "\n"
         )
-    else:
+    elif not (need_shell_restart_pipx or need_shell_restart_bindir):
         logging.warning(
             textwrap.fill(
                 "All pipx binary directories have been added to PATH. "
@@ -125,7 +125,7 @@ def ensure_pipx_paths(force: bool):
     if need_shell_restart_pipx or need_shell_restart_bindir:
         print(
             textwrap.fill(
-                "You likely need to open a new terminal or re-login for "
+                "You will need to open a new terminal or re-login for "
                 "the PATH changes to take effect."
             )
             + "\n"

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -81,8 +81,8 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
         print(
             wrap_indent(
                 f"{location_str} has been been added to PATH, but you "
-                "need to open a new terminal or re-login for the PATH "
-                "changes to take effect."
+                "need to open a new terminal or re-login for this PATH "
+                "change to take effect."
             )
         )
     else:

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -34,6 +34,9 @@ def get_pipx_user_bin_path() -> Optional[Path]:
     #   Windows:
     #       scripts in <userbase>/Python<XY>/Scripts
     #       modules in <userbase>/Python<XY>/site-packages
+
+    pipx_bin_path = None
+
     script_path = Path(__file__).resolve()
     userbase_path = Path(site.getuserbase()).resolve()
     try:
@@ -47,7 +50,6 @@ def get_pipx_user_bin_path() -> Optional[Path]:
             userbase_path / "bin" / "pipx",
             Path(site.getusersitepackages()).resolve().parent / "Scripts" / "pipx.exe",
         )
-        pipx_bin_path = None
         for test_path in test_paths:
             if test_path.exists():
                 pipx_bin_path = test_path.parent

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -61,7 +61,7 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
     Returns True if location was added to PATH
     """
     location_str = str(location)
-    path_appended = False
+    path_added = False
     need_shell_restart = userpath.need_shell_restart(location_str)
     in_current_path = userpath.in_current_path(location_str)
 
@@ -72,7 +72,7 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
                 f"Success! Added {location_str} to the PATH environment variable."
             )
         )
-        path_appended = True
+        path_added = True
         need_shell_restart = userpath.need_shell_restart(location_str)
     elif not in_current_path and need_shell_restart:
         print(
@@ -85,7 +85,7 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
     else:
         print(wrap_indent(f"{location_str} is already in PATH."))
 
-    return (path_appended, need_shell_restart)
+    return (path_added, need_shell_restart)
 
 
 def ensure_pipx_paths(force: bool):

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -1,8 +1,10 @@
 import logging
 from pathlib import Path
+import site
 
 import userpath  # type: ignore
 from pipx.emojies import stars
+from pipx import constants
 
 
 def ensure_path(location: Path, *, force: bool):
@@ -40,3 +42,19 @@ def ensure_path(location: Path, *, force: bool):
     )
     print()
     print(f"{post_install_message} {stars}")
+
+
+def ensure_pipx_paths(force: bool):
+    ensure_path(constants.LOCAL_BIN_DIR, force=force)
+
+    script_path = Path(__file__).resolve()
+    pip_user_path = Path(site.getuserbase()).resolve()
+    try:
+        _ = script_path.relative_to(pip_user_path)
+    except ValueError:
+        pip_user_installed = False
+    else:
+        pip_user_installed = True
+
+    if pip_user_installed:
+        ensure_path(pip_user_path / "bin", force=force)

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -39,6 +39,8 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
 
 
 def ensure_pipx_paths(force: bool):
+    # NOTE: using this method to detect pip user-installed pipx will return
+    #   False if pipx was installed as editable using `pip install -e`
     script_path = Path(__file__).resolve()
     pip_user_path = Path(site.getuserbase()).resolve()
     try:
@@ -53,7 +55,7 @@ def ensure_pipx_paths(force: bool):
     (path_added1, need_shell_restart1) = ensure_path(
         constants.LOCAL_BIN_DIR, force=force
     )
-    if pip_user_installed:
+    if pip_user_installed and (pip_user_path / "bin").exists():
         (path_added2, need_shell_restart2) = ensure_path(
             pip_user_path / "bin", force=force
         )

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -29,7 +29,7 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
                 (
                     f"The directory `{location_str}` is already in PATH.\n"
                     "    If you are sure you want add it again, try again with "
-                    "the '--force' flag.\n\n"
+                    "the '--force' flag."
                 )
             )
         else:
@@ -49,8 +49,6 @@ def ensure_pipx_paths(force: bool):
         pip_user_installed = False
     else:
         pip_user_installed = True
-    # DEBUG DELETEME
-    print(f"pip_user_installed={pip_user_installed}")
 
     (path_added1, need_shell_restart1) = ensure_path(
         constants.LOCAL_BIN_DIR, force=force
@@ -64,14 +62,14 @@ def ensure_pipx_paths(force: bool):
 
     if path_added1 or path_added2:
         print(
-            "Consider adding shell completions for pipx. "
-            "Run 'pipx completions' for instructions.\n"
+            "\nConsider adding shell completions for pipx.\n"
+            "Run 'pipx completions' for instructions."
         )
 
     if need_shell_restart1 or need_shell_restart2:
         print(
-            "You likely need to open a new terminal or re-login for "
-            "the changes to take effect.\n"
+            "\nYou likely need to open a new terminal or re-login for "
+            "the changes to take\neffect."
         )
 
-    print(f"Otherwise pipx is ready to go! {stars}")
+    print(f"\nOtherwise pipx is ready to go! {stars}")

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -57,6 +57,8 @@ def ensure_pipx_paths(force: bool):
         (path_added2, need_shell_restart2) = ensure_path(
             pip_user_path / "bin", force=force
         )
+    else:
+        (path_added2, need_shell_restart2) = (False, False)
 
     if path_added1 or path_added2:
         print(

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -27,17 +27,24 @@ def get_pipx_user_bin_path() -> Optional[Path]:
     """
     # NOTE: using this method to detect pip user-installed pipx will return
     #   None if pipx was installed as editable using `pip install --user -e`
+
+    # https://docs.python.org/3/install/index.html#inst-alt-install-user
+    #   Linux + Mac:
+    #       scripts in <userbase>/bin
+    #   Windows:
+    #       scripts in <userbase>/Python<XY>/Scripts
+    #       modules in <userbase>/Python<XY>/site-packages
     script_path = Path(__file__).resolve()
-    pip_user_path = Path(site.getuserbase()).resolve()
+    userbase_path = Path(site.getuserbase()).resolve()
     try:
-        _ = script_path.relative_to(pip_user_path)
+        _ = script_path.relative_to(userbase_path)
     except ValueError:
         pip_user_installed = False
     else:
         pip_user_installed = True
     if pip_user_installed:
         test_paths = (
-            pip_user_path / "bin" / "pipx",
+            userbase_path / "bin" / "pipx",
             Path(site.getusersitepackages()).resolve().parent / "Scripts" / "pipx.exe",
         )
         pipx_bin_path = None

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -95,7 +95,7 @@ def ensure_pipx_paths(force: bool):
 
     pipx_user_bin_path = get_pipx_user_bin_path()
     if pipx_user_bin_path is not None:
-        ensure_paths.append(pipx_user_bin_path)
+        bin_paths.append(pipx_user_bin_path)
 
     path_added = False
     need_shell_restart = False

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -480,8 +480,10 @@ def _add_ensurepath(subparsers):
     p = subparsers.add_parser(
         "ensurepath",
         help=(
-            "Ensure directory where pipx stores apps is on your "
-            "PATH environment variable. Note that running this may modify "
+            "Ensure directory where pipx stores apps is in your "
+            "PATH environment variable. Also if pipx was installed via "
+            "`pip install --user`, ensure pipx itself is in your PATH. "
+            "Note that running this may modify "
             "your shell's configuration file(s) such as '~/.bashrc'."
         ),
     )
@@ -491,7 +493,7 @@ def _add_ensurepath(subparsers):
         action="store_true",
         help=(
             "Add text to your shell's config file even if it looks like your "
-            f"PATH already has {str(constants.LOCAL_BIN_DIR)}"
+            "PATH already contains pipx binary path(s)."
         ),
     )
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -204,7 +204,7 @@ def run_pipx_command(args: argparse.Namespace):  # noqa: C901
         return commands.run_pip(package, venv_dir, args.pipargs, args.verbose)
     elif args.command == "ensurepath":
         try:
-            return commands.ensure_path(constants.LOCAL_BIN_DIR, force=args.force)
+            return commands.ensure_pipx_paths(force=args.force)
         except Exception as e:
             raise PipxError(e)
     elif args.command == "completions":

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -493,7 +493,7 @@ def _add_ensurepath(subparsers):
         action="store_true",
         help=(
             "Add text to your shell's config file even if it looks like your "
-            "PATH already contains pipx binary path(s)."
+            "PATH already contains paths to pipx and pipx-install apps."
         ),
     )
 


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
Fixes #427 

This PR changes `pipx ensurepath` to test to see if pipx has been installed using `pipx install --user` and if it has, then ensure that the path to the pipx script itself is in the user's PATH along with pipx's packages bin directory.

It reports on a per-path basis the status ("successfully added", "already added", "needs shell restart").  It also prints summary messages after all paths have been handled similar to the previous `ensurepath`.