### PR TITLE
Userpath version require

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 - [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.
+- [bugfix] Requiring userpath v1.4.1 or later so ensure Windows bug is fixed for `ensurepath` (#437)
 
 0.15.4.0
 - [feature] `list` now has a new option `--include-injected` to show the injected packages in the main apps

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import re  # noqa E402
 
 CURDIR = Path(__file__).parent
 
-REQUIRED = ["userpath", "argcomplete>=1.9.4, <2.0"]  # type: List[str]
+REQUIRED = ["userpath>=1.4.1", "argcomplete>=1.9.4, <2.0"]  # type: List[str]
 
 
 def get_version():


### PR DESCRIPTION
<!---
Thank you for your soon-to-be pull request. Before you submit this, please
double check to make sure that you've added an entry to docs/changelog.md.
-->
Fixes #437.

Require userpath v1.4.1 or later to fix Windows bug that wrote the wrong type to the Registry.