### PR TITLE
Update CI python version from 3.7 to 3.8, README fix

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -56,9 +56,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
         include:
           - os: windows-latest
-            python-version: 3.7
+            python-version: 3.8
           - os: macos-latest
-            python-version: 3.7
+            python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 </p>
 
 <p align="center">
-<a href="https://github.com/pipxproject/pipx/actions?query=workflow%3ATest"><img src="https://github.com/pipxproject/pipx/workflows/Test/badge.svg?branch=master"></a>
-<a href="https://badge.fury.io/py/pipx"><img src="https://badge.fury.io/py/pipx.svg" alt="PyPI version" height="18"></a>
+<a href="https://github.com/pipxproject/pipx/actions?query=workflow%3ATest"><img src="https://github.com/pipxproject/pipx/workflows/Test/badge.svg?branch=master" alt="Test CI" ></a>
+<a href="https://badge.fury.io/py/pipx"><img src="https://badge.fury.io/py/pipx.svg" alt="PyPI version"></a>
 </p>
 
 **Documentation**: https://pipxproject.github.io/pipx/


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[] I have added an entry to `docs/changelog.md`

I didn't add a changelog entry since this was an internal testing issue and not affecting pipx itself.  (But I can if it's needed.)

## Summary of changes

I bumped the python version to 3.8 of all tests that only use one python version (doc, lint, macos tests, windows tests), since that's the current stable python version.

I also fixed the badges on `README.md` so their height matches each other, and gave an `alt` tag to the Test badge.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
