### PR TITLE
List injected versions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,5 @@
 dev
+- Add version after each injected package name for `pipx list --include-injected`
 - Change metadata recorded from version-specified install to allow upgrades in future.  Adds pipx dependency on `packaging` package.
 - [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.
 - [feature] `ensurepath` now also ensures that pip user binary path containing pipx itself is in user's PATH if pipx was installed using `pip install --user`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,5 @@
 dev
-- Add version after each injected package name for `pipx list --include-injected`
+- Version of each injected package is now listed after name for `pipx list --include-injected`
 - Change metadata recorded from version-specified install to allow upgrades in future.  Adds pipx dependency on `packaging` package.
 - [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.
 - [feature] `ensurepath` now also ensures that pip user binary path containing pipx itself is in user's PATH if pipx was installed using `pip install --user`.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -177,7 +177,7 @@ def get_package_summary(
         new_install,
         exposed_binary_names,
         unavailable_binary_names,
-        venv.pipx_metadata.injected_packages.keys() if include_injected else None,
+        venv.pipx_metadata.injected_packages if include_injected else None,
     )
 
 
@@ -234,7 +234,7 @@ def _get_list_output(
     if injected_package_names:
         output.append("    Injected Packages:")
         for name in injected_package_names:
-            output.append(f"      - {name}")
+            output.append(f"      - {name} {injected_package_names[name].package_version}")
     return "\n".join(output)
 
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `docs/changelog.md`

## Summary of changes
When listing injected packages using `pipx list --include-injected`, now the version of the injected package is listed after its name.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx install pycowsay
pipx inject pycowsay cowsay
pipx list --include-injected
```
In the current pipx, the name only `cowsay` is displayed, in this PR, `cowsay 2.0.3` is displayed.