### PR TITLE
Disable animation if terminal width is reported as 0 or small

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,5 @@
 dev
+- Fixed bug where pipx would crash if terminal size reported 0 columns.
 - Version of each injected package is now listed after name for `pipx list --include-injected`
 - Change metadata recorded from version-specified install to allow upgrades in future.  Adds pipx dependency on `packaging` package.
 - [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,5 @@
 dev
-- Fixed bug where pipx would crash if terminal size reported 0 columns.
+- Disabled animation when we cannot determine terminal size or if the number of columns is too small. (Fixes #444)
 - Version of each injected package is now listed after name for `pipx list --include-injected`
 - Change metadata recorded from version-specified install to allow upgrades in future.  Adds pipx dependency on `packaging` package.
 - [bugfix] Prevent python error in case where package has no pipx metadata and advise user how to fix.

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,10 +1,8 @@
-import os
 import subprocess
 import sys
 from pathlib import Path
 
 import nox  # type: ignore
-
 
 # NOTE: these tests require nox to create virtual environments
 # with venv. nox currently uses virtualenv. pipx
@@ -15,12 +13,7 @@ import nox  # type: ignore
 # until this is fixed in nox. See
 # https://github.com/theacodes/nox/issues/199
 
-
-travis_python_version = os.environ.get("TRAVIS_PYTHON_VERSION")
-if travis_python_version:
-    python = [travis_python_version]
-else:
-    python = ["3.6", "3.7", "3.8"]
+python = ["3.6", "3.7", "3.8"]
 
 if sys.platform == "win32":
     # docs fail on Windows, even if `chcp.com 65001` is used

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -69,17 +69,22 @@ def print_animation(
     period: float,
     animate_at_beginning_of_line: bool,
 ):
-    (term_cols, _) = shutil.get_terminal_size(fallback=(9999, 24))
+    default_term_cols = 9999
+    (term_cols, _) = shutil.get_terminal_size(fallback=(default_term_cols, 24))
     event.wait(delay)
     while not event.wait(0):
         for s in symbols:
             if animate_at_beginning_of_line:
                 max_message_len = term_cols - len(f"{s} ... ")
+                if max_message_len <= 0:
+                    max_message_len = default_term_cols - len(f"{s} ... ")
                 cur_line = f"{s} {message:.{max_message_len}}"
                 if len(message) > max_message_len:
                     cur_line += "..."
             else:
                 max_message_len = term_cols - len("... ")
+                if max_message_len <= 0:
+                    max_message_len = default_term_cols - len("... ")
                 cur_line = f"{message:.{max_message_len}}{s}"
 
             clear_line()

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -16,11 +16,12 @@ EMOJI_ANIMATION_FRAMES = ["⣷", "⣯", "⣟", "⡿", "⢿", "⣻", "⣽", "⣾"
 NONEMOJI_ANIMATION_FRAMES = ["", ".", "..", "..."]
 EMOJI_FRAME_PERIOD = 0.1
 NONEMOJI_FRAME_PERIOD = 1
+MINIMUM_COLS_ALLOW_ANIMATION = 16
 
 
 def _env_supports_animation():
     (term_cols, _) = shutil.get_terminal_size(fallback=(0, 0))
-    return stderr_is_tty and term_cols > 16
+    return stderr_is_tty and term_cols > MINIMUM_COLS_ALLOW_ANIMATION
 
 
 @contextmanager

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -29,7 +29,8 @@ def animate(
 ) -> Generator[None, None, None]:
 
     if not do_animation or not _env_supports_animation():
-        # no op
+        # No animation, just a single print of message
+        print(f"{message}...")
         yield
         return
 

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -69,22 +69,17 @@ def print_animation(
     period: float,
     animate_at_beginning_of_line: bool,
 ):
-    default_term_cols = 9999
-    (term_cols, _) = shutil.get_terminal_size(fallback=(default_term_cols, 24))
+    (term_cols, _) = shutil.get_terminal_size(fallback=(9999, 24))
     event.wait(delay)
     while not event.wait(0):
         for s in symbols:
             if animate_at_beginning_of_line:
                 max_message_len = term_cols - len(f"{s} ... ")
-                if max_message_len <= 0:
-                    max_message_len = default_term_cols - len(f"{s} ... ")
                 cur_line = f"{s} {message:.{max_message_len}}"
                 if len(message) > max_message_len:
                     cur_line += "..."
             else:
                 max_message_len = term_cols - len("... ")
-                if max_message_len <= 0:
-                    max_message_len = default_term_cols - len("... ")
                 cur_line = f"{message:.{max_message_len}}{s}"
 
             clear_line()

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -20,7 +20,7 @@ NONEMOJI_FRAME_PERIOD = 1
 
 def _env_supports_animation():
     (term_cols, _) = shutil.get_terminal_size(fallback=(0, 0))
-    return sys.stderr.isatty() and term_cols > 10
+    return stderr_is_tty and term_cols > 10
 
 
 @contextmanager

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -20,7 +20,7 @@ NONEMOJI_FRAME_PERIOD = 1
 
 def _env_supports_animation():
     (term_cols, _) = shutil.get_terminal_size(fallback=(0, 0))
-    return stderr_is_tty and term_cols > 10
+    return stderr_is_tty and term_cols > 16
 
 
 @contextmanager

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -18,12 +18,17 @@ EMOJI_FRAME_PERIOD = 0.1
 NONEMOJI_FRAME_PERIOD = 1
 
 
+def _env_supports_animation():
+    (term_cols, _) = shutil.get_terminal_size(fallback=(0, 0))
+    return sys.stderr.isatty() and term_cols > 10
+
+
 @contextmanager
 def animate(
     message: str, do_animation: bool, *, delay: float = 0
 ) -> Generator[None, None, None]:
 
-    if not do_animation or not stderr_is_tty:
+    if not do_animation or not _env_supports_animation():
         # no op
         yield
         return

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -33,8 +33,7 @@ def check_animate_output(
     with pipx.animate.animate(test_string, do_animation=True):
         time.sleep(frame_period * (frames_to_test - 1) + extra_animate_time)
     # Wait before capturing stderr to ensure animate thread is finished
-    #   and to capture all its characters. If some are left over they can cause
-    #   false fail in the next call of check_animate_output()
+    #   and to capture all its characters.
     time.sleep(extra_after_thread_time)
     captured = capsys.readouterr()
 
@@ -43,11 +42,6 @@ def check_animate_output(
         print(
             "Not enough captured characters--Likely need to increase extra_animate_time"
         )
-    if (
-        captured.err[: len(frame_strings[0])]
-        != expected_string[: len(frame_strings[0])]
-    ):
-        print("Error in first frame--Might need to increase extra_after_thread_time")
     print(f"captured characters: {len(captured.err)}")
     print(f"chars_to_test: {chars_to_test}")
     for i in range(0, chars_to_test, 40):

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -83,10 +83,9 @@ def test_line_lengths_emoji(capsys, monkeypatch, env_columns, expected_message):
     monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
     monkeypatch.setattr(pipx.animate, "emoji_support", True)
 
-    frames_to_test = 4
-
     monkeypatch.setenv("COLUMNS", str(env_columns))
 
+    frames_to_test = 4
     frame_strings = [
         f"{CLEAR_LINE}\r{x} {expected_message}" for x in EMOJI_ANIMATION_FRAMES
     ]
@@ -95,27 +94,31 @@ def test_line_lengths_emoji(capsys, monkeypatch, env_columns, expected_message):
     )
 
 
-def test_line_lengths_no_emoji(capsys, monkeypatch):
+@pytest.mark.parametrize(
+    "env_columns,expected_message",
+    [
+        (43, f"{TEST_STRING_40_CHAR:.{43-4}}"),
+        (44, f"{TEST_STRING_40_CHAR}"),
+        (45, f"{TEST_STRING_40_CHAR}"),
+    ],
+)
+def test_line_lengths_no_emoji(capsys, monkeypatch, env_columns, expected_message):
     # emoji_support and stderr_is_tty is set only at import animate.py
     # since we are already after that, we must override both here
     monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
     monkeypatch.setattr(pipx.animate, "emoji_support", False)
 
+    monkeypatch.setenv("COLUMNS", str(env_columns))
+
     frames_to_test = 2
+    frame_strings = [
+        f"{CLEAR_LINE}\r{expected_message}{x}" for x in NONEMOJI_ANIMATION_FRAMES
+    ]
 
-    # 40-char test_string counts columns e.g.: "0204060810 ... 363840"
-    test_string = "".join([f"{x:02}" for x in range(2, 41, 2)])
-
-    columns_to_test = [43, 44, 45]
-    expected_message = [f"{test_string:.{43-4}}", f"{test_string}", f"{test_string}"]
-
-    for i, columns in enumerate(columns_to_test):
-        monkeypatch.setenv("COLUMNS", str(columns))
-
-        frame_strings = [
-            f"{CLEAR_LINE}\r{expected_message[i]}{x}" for x in NONEMOJI_ANIMATION_FRAMES
-        ]
-
-        check_animate_output(
-            capsys, test_string, frame_strings, NONEMOJI_FRAME_PERIOD, frames_to_test
-        )
+    check_animate_output(
+        capsys,
+        TEST_STRING_40_CHAR,
+        frame_strings,
+        NONEMOJI_FRAME_PERIOD,
+        frames_to_test,
+    )

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -1,6 +1,6 @@
 import time
 
-import pytest
+import pytest  # type: ignore
 
 import pipx.animate
 from pipx.animate import (

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -121,9 +121,11 @@ def test_line_lengths_no_emoji(
     )
 
 
-@pytest.mark.parametrize("env_columns", [0, 8, 16])
-def test_env_no_animate(capsys, monkeypatch, env_columns):
-    monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
+@pytest.mark.parametrize(
+    "env_columns,stderr_is_tty", [(0, True), (8, True), (16, True), (17, False)]
+)
+def test_env_no_animate(capsys, monkeypatch, env_columns, stderr_is_tty):
+    monkeypatch.setattr(pipx.animate, "stderr_is_tty", stderr_is_tty)
     monkeypatch.setenv("COLUMNS", str(env_columns))
 
     frames_to_test = 4

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -64,14 +64,14 @@ def test_delay_suppresses_output(capsys, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "env_columns,expected_message",
+    "env_columns,expected_frame_message",
     [
         (45, f"{TEST_STRING_40_CHAR:.{45-6}}..."),
         (46, f"{TEST_STRING_40_CHAR}"),
         (47, f"{TEST_STRING_40_CHAR}"),
     ],
 )
-def test_line_lengths_emoji(capsys, monkeypatch, env_columns, expected_message):
+def test_line_lengths_emoji(capsys, monkeypatch, env_columns, expected_frame_message):
     # emoji_support and stderr_is_tty is set only at import animate.py
     # since we are already after that, we must override both here
     monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
@@ -81,7 +81,7 @@ def test_line_lengths_emoji(capsys, monkeypatch, env_columns, expected_message):
 
     frames_to_test = 4
     frame_strings = [
-        f"{CLEAR_LINE}\r{x} {expected_message}" for x in EMOJI_ANIMATION_FRAMES
+        f"{CLEAR_LINE}\r{x} {expected_frame_message}" for x in EMOJI_ANIMATION_FRAMES
     ]
     check_animate_output(
         capsys, TEST_STRING_40_CHAR, frame_strings, EMOJI_FRAME_PERIOD, frames_to_test
@@ -89,14 +89,16 @@ def test_line_lengths_emoji(capsys, monkeypatch, env_columns, expected_message):
 
 
 @pytest.mark.parametrize(
-    "env_columns,expected_message",
+    "env_columns,expected_frame_message",
     [
         (43, f"{TEST_STRING_40_CHAR:.{43-4}}"),
         (44, f"{TEST_STRING_40_CHAR}"),
         (45, f"{TEST_STRING_40_CHAR}"),
     ],
 )
-def test_line_lengths_no_emoji(capsys, monkeypatch, env_columns, expected_message):
+def test_line_lengths_no_emoji(
+    capsys, monkeypatch, env_columns, expected_frame_message
+):
     # emoji_support and stderr_is_tty is set only at import animate.py
     # since we are already after that, we must override both here
     monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
@@ -106,7 +108,7 @@ def test_line_lengths_no_emoji(capsys, monkeypatch, env_columns, expected_messag
 
     frames_to_test = 2
     frame_strings = [
-        f"{CLEAR_LINE}\r{expected_message}{x}" for x in NONEMOJI_ANIMATION_FRAMES
+        f"{CLEAR_LINE}\r{expected_frame_message}{x}" for x in NONEMOJI_ANIMATION_FRAMES
     ]
 
     check_animate_output(

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -121,7 +121,6 @@ def test_line_lengths_no_emoji(
     )
 
 
-# def test_env_no_animate(capsys, monkeypatch, env_columns, expected_message):
 @pytest.mark.parametrize("env_columns", [0, 8, 16])
 def test_env_no_animate(capsys, monkeypatch, env_columns):
     monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -24,8 +24,9 @@ def check_animate_output(
     extra_animate_time=0.4,
     extra_after_thread_time=0.1,
 ):
-    # NOTE: extra_animate_time <= 0.3 failed on macos
-    #       extra_after_thread_time <= 0.0 failed on macos
+    # github workflow history (2020-07-27):
+    #     extra_animate_time <= 0.3 failed on macos
+    #     extra_after_thread_time <= 0.0 failed on macos
     expected_string = "".join(frame_strings)
 
     chars_to_test = 1 + len("".join(frame_strings[:frames_to_test]))
@@ -121,7 +122,7 @@ def test_line_lengths_no_emoji(
 
 
 # def test_env_no_animate(capsys, monkeypatch, env_columns, expected_message):
-@pytest.mark.parametrize("env_columns", [0, 5, 10])
+@pytest.mark.parametrize("env_columns", [0, 8, 16])
 def test_env_no_animate(capsys, monkeypatch, env_columns):
     monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
     monkeypatch.setenv("COLUMNS", str(env_columns))

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -118,3 +118,23 @@ def test_line_lengths_no_emoji(
         NONEMOJI_FRAME_PERIOD,
         frames_to_test,
     )
+
+
+# def test_env_no_animate(capsys, monkeypatch, env_columns, expected_message):
+@pytest.mark.parametrize("env_columns", [0, 5, 10])
+def test_env_no_animate(capsys, monkeypatch, env_columns):
+    monkeypatch.setattr(pipx.animate, "stderr_is_tty", True)
+    monkeypatch.setenv("COLUMNS", str(env_columns))
+
+    frames_to_test = 4
+    expected_string = f"{TEST_STRING_40_CHAR}...\n"
+    extra_animate_time = 0.4
+    extra_after_thread_time = 0.1
+
+    with pipx.animate.animate(TEST_STRING_40_CHAR, do_animation=True):
+        time.sleep(EMOJI_FRAME_PERIOD * (frames_to_test - 1) + extra_animate_time)
+    time.sleep(extra_after_thread_time)
+    captured = capsys.readouterr()
+
+    assert captured.out == expected_string
+    assert captured.err == ""

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -88,7 +88,7 @@ def test_line_lengths_emoji(capsys, monkeypatch, env_columns, expected_message):
     monkeypatch.setenv("COLUMNS", str(env_columns))
 
     frame_strings = [
-        f"{CLEAR_LINE}\r{x} {expected_message[i]}" for x in EMOJI_ANIMATION_FRAMES
+        f"{CLEAR_LINE}\r{x} {expected_message}" for x in EMOJI_ANIMATION_FRAMES
     ]
     check_animate_output(
         capsys, TEST_STRING_40_CHAR, frame_strings, EMOJI_FRAME_PERIOD, frames_to_test

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -4,21 +4,19 @@ import pytest  # type: ignore
 from pipx import shared_libs
 
 
-now = time.time()
-
-
 @pytest.mark.parametrize(
-    "mtime,needs_upgrade",
+    "mtime_minus_now,needs_upgrade",
     [
-        (now - shared_libs.SHARED_LIBS_MAX_AGE_SEC - 20 * 60, True),
-        (now - shared_libs.SHARED_LIBS_MAX_AGE_SEC + 20 * 60, False),
+        (-shared_libs.SHARED_LIBS_MAX_AGE_SEC - 5 * 60, True),
+        (-shared_libs.SHARED_LIBS_MAX_AGE_SEC + 5 * 60, False),
     ],
 )
-def test_auto_update_shared_libs(capsys, pipx_temp_env, mtime, needs_upgrade):
+def test_auto_update_shared_libs(capsys, pipx_temp_env, mtime_minus_now, needs_upgrade):
+    now = time.time()
     shared_libs.shared_libs.create([], verbose=True)
     shared_libs.shared_libs.has_been_updated_this_run = False
 
     access_time = now  # this can be anything
-    os.utime(shared_libs.shared_libs.pip_path, (access_time, mtime))
+    os.utime(shared_libs.shared_libs.pip_path, (access_time, mtime_minus_now + now))
 
     assert shared_libs.shared_libs.needs_upgrade is needs_upgrade


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[x] I have added an entry to `docs/changelog.md`

## Summary of changes
Fixes bug #444 .

Some terminal / interactive programs and mixtures cause the terminal columns to be reported by `shutil.get_terminal_size` as 0.  I was able to find some examples online talking about the interactive shell inside of emacs doing this sometimes.  

In general, if the terminal columns are smaller than our continuation characters, the animate thread will crash with a python stack trace, and this is unacceptable.

This PR prevents the thread crash from happening.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
env COLUMNS=2 pipx install pycowsay
```
For current pipx the animate thread crashes with a `ValueError` and a stacktrace.  For pipx with this PR patch it executes successfully.
