### PR TITLE
Fix github tests (interpreter mismatch nox<->github workflow)

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -26,7 +26,7 @@ jobs:
         pip install nox
     - name: Lint
       run: |
-        nox --non-interactive --session lint
+        nox --error-on-missing-interpreters --non-interactive --session lint
 
   docs:
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
         pip install nox
     - name: Verify Docs
       run: |
-        nox --non-interactive --session docs
+        nox --error-on-missing-interpreters --non-interactive --session docs
 
   tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -20,10 +20,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install native-venv version of nox
+    - name: Install nox
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/cs01/nox.git@5ea70723e9e6#egg=nox
+        pip install nox
     - name: Lint
       run: |
         nox --non-interactive --session lint
@@ -40,10 +40,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install native-venv version of nox
+    - name: Install nox
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/cs01/nox.git@5ea70723e9e6#egg=nox
+        pip install nox
     - name: Verify Docs
       run: |
         nox --non-interactive --session docs

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def lint(session):
     session.install(*lint_dependencies)
     files = [str(Path("src") / "pipx"), "tests"] + [
@@ -72,7 +72,7 @@ def lint(session):
     session.run("python", "setup.py", "check", "--metadata", "--strict")
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def docs(session):
     session.install(*doc_dependencies)
     session.run("python", "generate_docs.py")
@@ -85,7 +85,7 @@ def develop(session):
     session.install("-e", ".")
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def build(session):
     session.install("setuptools")
     session.install("wheel")
@@ -118,7 +118,7 @@ def get_branch():
     )
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def publish(session):
     if has_changes():
         session.error("All changes must be committed or removed before publishing")
@@ -131,13 +131,13 @@ def publish(session):
     publish_docs(session)
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def watch_docs(session):
     session.install(*doc_dependencies)
     session.run("mkdocs", "serve")
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def publish_docs(session):
     session.install(*doc_dependencies)
     session.run("python", "generate_docs.py")

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.7")
 def lint(session):
     session.install(*lint_dependencies)
     files = [str(Path("src") / "pipx"), "tests"] + [

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def lint(session):
     session.install(*lint_dependencies)
     files = [str(Path("src") / "pipx"), "tests"] + [

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from shutil import which
 from tempfile import TemporaryDirectory
-from typing import Collection, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import userpath  # type: ignore
 
@@ -17,6 +17,7 @@ from pipx.emojies import hazard, stars
 from pipx.package_specifier import valid_pypi_name
 from pipx.util import WINDOWS, PipxError, mkdir, rmdir
 from pipx.venv import Venv
+from pipx.pipx_metadata_file import PackageInfo
 
 
 def expose_apps_globally(
@@ -213,7 +214,7 @@ def _get_list_output(
     new_install: bool,
     exposed_binary_names: List[str],
     unavailable_binary_names: List[str],
-    injected_package_names: Optional[Collection[str]] = None,
+    injected_packages: Optional[Dict[str, PackageInfo]] = None,
 ) -> str:
     output = []
     output.append(
@@ -231,10 +232,10 @@ def _get_list_output(
         output.append(
             f"    - {red(name)} (symlink missing or pointing to unexpected location)"
         )
-    if injected_package_names:
+    if injected_packages:
         output.append("    Injected Packages:")
-        for name in injected_package_names:
-            output.append(f"      - {name} {injected_package_names[name].package_version}")
+        for name in injected_packages:
+            output.append(f"      - {name} {injected_packages[name].package_version}")
     return "\n".join(output)
 
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[] I have added an entry to `docs/changelog.md`

## Summary of changes
Ever since the commit of #450, `lint` and `docs` were not running.  The reason is because the github workflow was updated to use python 3.8, but in the `noxfile` python 3.7 was still specified.  Since nox couldn't find python3.7, it just skipped those sessions. (!)

This PR:
* Updates `noxfile` to use python 3.8 for all non-test sessions.
* Adds the `--error-on-missing-interpreters` switch in the github workflow's invocation of nox, so that in the future if there is a missing interpreter problem the test will fail instead of being skipped.
* Fixes black and mypy errors in `commands/common.py` that went undetected because lint wasn't running.
* Uses plain nox (not native-venv nox) for lint and docs sessions in the github workflow.

An example of a previous github workflow where lint did not run (was skipped with no error) because nox couldn't find python 3.7:
https://github.com/pipxproject/pipx/runs/912198799

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
