### PR TITLE
Parse package specifier before install

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,5 @@
 dev
+- pipx now parses package specification before install.   It removes (with warning) the `--editable` install option for any package specification that is not a local path.   It also removes (with warning) any environment markers.
 - Disabled animation when we cannot determine terminal size or if the number of columns is too small. (Fixes #444)
 - Version of each injected package is now listed after name for `pipx list --include-injected`
 - Change metadata recorded from version-specified install to allow upgrades in future.  Adds pipx dependency on `packaging` package.

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -234,7 +234,9 @@ def _get_list_output(
     if injected_package_names:
         output.append("    Injected Packages:")
         for name in injected_package_names:
-            output.append(f"      - {name} {injected_package_names[name].package_version}")
+            output.append(
+                f"      - {name} {injected_package_names[name].package_version}"
+            )
     return "\n".join(output)
 
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -234,10 +234,8 @@ def _get_list_output(
         )
     if injected_packages:
         output.append("    Injected Packages:")
-        for name in injected_package_names:
-            output.append(
-                f"      - {name} {injected_package_names[name].package_version}"
-            )
+        for name in injected_packages:
+            output.append(f"      - {name} {injected_packages[name].package_version}")
     return "\n".join(output)
 
 

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -10,6 +10,7 @@ from shutil import which
 from typing import List
 
 from pipx import constants
+from pipx.commands.common import package_name_from_spec
 from pipx.constants import TEMP_VENV_EXPIRATION_THRESHOLD_DAYS
 from pipx.emojies import hazard
 from pipx.util import (
@@ -115,12 +116,15 @@ def _download_and_run(
     venv = Venv(venv_dir, python=python, verbose=verbose)
     venv.create_venv(venv_args, pip_args)
 
-    # venv.pipx_metadata.main_package.package contains package name if it is
-    #   pre-existing, otherwise is None to instruct venv.install_package to
-    #   determine package name.
+    if venv.pipx_metadata.main_package.package is not None:
+        package = venv.pipx_metadata.main_package.package
+    else:
+        package = package_name_from_spec(
+            package_or_url, python, pip_args=pip_args, verbose=verbose
+        )
 
     venv.install_package(
-        package=venv.pipx_metadata.main_package.package,
+        package=package,
         package_or_url=package_or_url,
         pip_args=pip_args,
         include_dependencies=False,

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -108,7 +108,8 @@ def parse_specifier_for_install(
                 )
             if parsed_package.valid_pep508.marker:
                 logging.warning(
-                    "Ignoring environment markers in package specification."
+                    "Ignoring environment markers in package specification: "
+                    f"{parsed_package.valid_pep508.marker}"
                 )
     elif parsed_package.valid_url is not None:
         package_or_url = parsed_package.valid_url

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -111,7 +111,7 @@ def parse_specifier_for_install(
                 package_or_url = package_or_url + str(
                     parsed_package.valid_pep508.specifier
                 )
-            if parsed_package.valid_pep508.markers:
+            if parsed_package.valid_pep508.marker:
                 logging.warning(
                     "Ignoring environment markers in package specification."
                 )

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -109,9 +109,10 @@ def parse_specifier_for_install(
                 )
             if parsed_package.valid_pep508.marker:
                 logging.warning(
-                    f"{hazard}  Ignoring environment markers in package specification "
-                    f"({parsed_package.valid_pep508.marker}). Use pipx options "
-                    "to specify this type of information."
+                    f"{hazard}  Ignoring environment markers "
+                    f"({parsed_package.valid_pep508.marker}) in package "
+                    "specification. Use pipx options to specify this type of "
+                    "information."
                 )
     elif parsed_package.valid_url is not None:
         package_or_url = parsed_package.valid_url

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -6,6 +6,7 @@
 #   <pypi_package_name><version_specifier>
 
 import logging
+import textwrap
 from pathlib import Path
 from typing import List, NamedTuple, Optional, Set, Tuple
 
@@ -109,10 +110,13 @@ def parse_specifier_for_install(
                 )
             if parsed_package.valid_pep508.marker:
                 logging.warning(
-                    f"{hazard}  Ignoring environment markers "
-                    f"({parsed_package.valid_pep508.marker}) in package "
-                    "specification. Use pipx options to specify this type of "
-                    "information."
+                    textwrap.fill(
+                        f"{hazard}  Ignoring environment markers "
+                        f"({parsed_package.valid_pep508.marker}) in package "
+                        "specification. Use pipx options to specify this type of "
+                        "information.",
+                        subsequent_indent="    ",
+                    )
                 )
     elif parsed_package.valid_url is not None:
         package_or_url = parsed_package.valid_url
@@ -123,9 +127,12 @@ def parse_specifier_for_install(
 
     if "--editable" in pip_args and not parsed_package.valid_local_path:
         logging.warning(
-            f"{hazard}  Ignoring --editable install option. pipx disallows it "
-            "for anything but a local path, to avoid having to create a new "
-            "src/ directory."
+            textwrap.fill(
+                f"{hazard}  Ignoring --editable install option. pipx disallows it "
+                "for anything but a local path, to avoid having to create a new "
+                "src/ directory.",
+                subsequent_indent="    ",
+            )
         )
         pip_args.remove("--editable")
 

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -42,7 +42,7 @@ def _parse_specifier(package_spec: str) -> ParsedPackage:
         package_req = Requirement(package_spec)
     except InvalidRequirement:
         # not a valid PEP508 package specification
-        valid_pep508 = None
+        pass
     else:
         # valid PEP508 package specification
         valid_pep508 = package_req
@@ -55,7 +55,8 @@ def _parse_specifier(package_spec: str) -> ParsedPackage:
         try:
             package_req = Requirement("notapackagename @ " + package_spec)
         except InvalidRequirement:
-            valid_url = None
+            # not a valid url
+            pass
         else:
             valid_url = package_spec
 

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -111,6 +111,10 @@ def parse_specifier_for_install(
                 package_or_url = package_or_url + str(
                     parsed_package.valid_pep508.specifier
                 )
+            if parsed_package.valid_pep508.markers:
+                logging.warning(
+                    "Ignoring environment markers in package specification."
+                )
     elif parsed_package.valid_url is not None:
         package_or_url = parsed_package.valid_url
     elif parsed_package.valid_local_path is not None:

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -7,7 +7,7 @@
 
 import logging
 from pathlib import Path
-from typing import List, NamedTuple, Optional, Tuple
+from typing import List, NamedTuple, Optional, Tuple, Set
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
@@ -80,6 +80,13 @@ def _parse_specifier(package_spec: str) -> ParsedPackage:
     )
 
 
+def _extras_to_str(extras: Set):
+    if extras is None:
+        return ""
+    else:
+        return "[" + ",".join(sorted(extras)) + "]"
+
+
 def package_is_local_path(package_spec: str) -> bool:
     return _parse_specifier(package_spec).valid_local_path is not None
 
@@ -99,13 +106,7 @@ def parse_specifier_for_install(
             package_or_url = parsed_package.valid_pep508.url
         else:
             package_or_url = canonicalize_name(parsed_package.valid_pep508.name)
-            if parsed_package.valid_pep508.extras:
-                package_or_url = (
-                    package_or_url
-                    + "["
-                    + ",".join(sorted(parsed_package.valid_pep508.extras))
-                    + "]"
-                )
+            package_or_url += _extras_to_str(parsed_package.valid_pep508.extras)
             if parsed_package.valid_pep508.specifier:
                 package_or_url = package_or_url + str(
                     parsed_package.valid_pep508.specifier
@@ -140,13 +141,7 @@ def parse_specifier_for_metadata(package_spec: str) -> str:
             package_or_url = parsed_package.valid_pep508.url
         else:
             package_or_url = canonicalize_name(parsed_package.valid_pep508.name)
-            if parsed_package.valid_pep508.extras:
-                package_or_url = (
-                    package_or_url
-                    + "["
-                    + ",".join(sorted(parsed_package.valid_pep508.extras))
-                    + "]"
-                )
+            package_or_url += _extras_to_str(parsed_package.valid_pep508.extras)
     elif parsed_package.valid_url is not None:
         package_or_url = parsed_package.valid_url
     elif parsed_package.valid_local_path is not None:

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -122,7 +122,7 @@ def parse_specifier_for_install(
 
     if "--editable" in pip_args and not parsed_package.valid_local_path:
         logging.warning(
-            "{hazard}  Ignoring --editable install option. pipx disallows it "
+            f"{hazard}  Ignoring --editable install option. pipx disallows it "
             "for anything but a local path.  For URLs its effect is to create a new "
             "src/ subdirectory in the pipx-managed venv directory which is not "
             "very useful."

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -123,9 +123,8 @@ def parse_specifier_for_install(
     if "--editable" in pip_args and not parsed_package.valid_local_path:
         logging.warning(
             f"{hazard}  Ignoring --editable install option. pipx disallows it "
-            "for anything but a local path.  For URLs its effect is to create a new "
-            "src/ subdirectory in the pipx-managed venv directory which is not "
-            "very useful."
+            "for anything but a local path, to avoid having to create a new "
+            "src/ directory for a URL specification."
         )
         pip_args.remove("--editable")
 

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -109,7 +109,7 @@ def parse_specifier_for_install(
                 )
             if parsed_package.valid_pep508.marker:
                 logging.warning(
-                    f"{hazard} Ignoring environment markers in package specification: "
+                    f"{hazard}  Ignoring environment markers in package specification: "
                     f"'{parsed_package.valid_pep508.marker}'  Use pipx options "
                     "instead."
                 )
@@ -122,7 +122,7 @@ def parse_specifier_for_install(
 
     if "--editable" in pip_args and not parsed_package.valid_local_path:
         logging.warning(
-            "{hazard} Ignoring --editable install option. pipx disallows it "
+            "{hazard}  Ignoring --editable install option. pipx disallows it "
             "for anything but a local path.  For URLs its effect is to create a new "
             "src/ subdirectory in the pipx-managed venv directory which is not "
             "very useful."

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -12,6 +12,7 @@ from typing import List, NamedTuple, Optional, Set, Tuple
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 
+from pipx.emojies import hazard
 from pipx.util import PipxError
 
 
@@ -108,8 +109,9 @@ def parse_specifier_for_install(
                 )
             if parsed_package.valid_pep508.marker:
                 logging.warning(
-                    "Ignoring environment markers in package specification: "
-                    f"{parsed_package.valid_pep508.marker}"
+                    f"{hazard} Ignoring environment markers in package specification: "
+                    f"'{parsed_package.valid_pep508.marker}'  Use pipx options "
+                    "instead."
                 )
     elif parsed_package.valid_url is not None:
         package_or_url = parsed_package.valid_url
@@ -120,7 +122,10 @@ def parse_specifier_for_install(
 
     if "--editable" in pip_args and not parsed_package.valid_local_path:
         logging.warning(
-            "Ignoring --editable install option, pipx disallows it for a non-local path."
+            "{hazard} Ignoring --editable install option. pipx disallows it "
+            "for anything but a local path.  For URLs its effect is to create a new "
+            "src/ subdirectory in the pipx-managed venv directory which is not "
+            "very useful."
         )
         pip_args.remove("--editable")
 

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -124,7 +124,7 @@ def parse_specifier_for_install(
         logging.warning(
             f"{hazard}  Ignoring --editable install option. pipx disallows it "
             "for anything but a local path, to avoid having to create a new "
-            "src/ directory for a URL specification."
+            "src/ directory."
         )
         pip_args.remove("--editable")
 

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -81,7 +81,7 @@ def _parse_specifier(package_spec: str) -> ParsedPackage:
 
 
 def _extras_to_str(extras: Set):
-    if extras is None:
+    if not extras:
         return ""
     else:
         return "[" + ",".join(sorted(extras)) + "]"

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -92,7 +92,7 @@ def parse_specifier_for_install(
 
     Specifically:
     * Strip any markers (e.g. python_version > 3.4)
-    * Ensure --editable is removed for use with non-local path
+    * Ensure --editable is removed for any package_spec not a local path
     * Convert local paths to absolute paths
     """
     parsed_package = _parse_specifier(package_spec)

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -7,7 +7,7 @@
 
 import logging
 from pathlib import Path
-from typing import List, NamedTuple, Optional, Tuple, Set
+from typing import List, NamedTuple, Optional, Set, Tuple
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
@@ -81,10 +81,10 @@ def _parse_specifier(package_spec: str) -> ParsedPackage:
 
 
 def _extras_to_str(extras: Set):
-    if not extras:
-        return ""
-    else:
+    if extras:
         return "[" + ",".join(sorted(extras)) + "]"
+    else:
+        return ""
 
 
 def package_is_local_path(package_spec: str) -> bool:

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -120,7 +120,7 @@ def parse_specifier_for_install(
 
     if "--editable" in pip_args and not parsed_package.valid_local_path:
         logging.warning(
-            "Removing --editable install option, it is disallowed for a non-local path."
+            "Ignoring --editable install option, pipx disallows it for a non-local path."
         )
         pip_args.remove("--editable")
 

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -22,18 +22,12 @@ class ParsedPackage(NamedTuple):
 
 
 def _parse_specifier(package_spec: str) -> ParsedPackage:
-    """Parse package_spec as would be given to pip/pipx
-
-    For ParsedPackage.package_or_url:
-    * Strip any version specifiers (e.g. package == 1.5.4)
-    * Strip any markers (e.g. python_version > 3.4)
-    * Convert local paths to absolute paths
+    """Parse package_spec as would be given to pipx
     """
     # NOTE: If package_spec is valid pypi name, pip will always treat it as a
     #       pypi package, not checking for local path.
     #       We replicate pypi precedence here (only non-valid-pypi names
     #       initiate check for local path, e.g. './package-name')
-
     valid_pep508 = None
     valid_url = None
     valid_local_path = None
@@ -47,7 +41,7 @@ def _parse_specifier(package_spec: str) -> ParsedPackage:
         # valid PEP508 package specification
         valid_pep508 = package_req
 
-    # NOTE: packaging currently (2020-07-19) does basic syntax checks on the URL.
+    # NOTE: packaging currently (2020-07-19) only does basic syntax checks on URL.
     #   Some examples of what it will not catch:
     #       - invalid RCS string (e.g. "gat+https://...")
     #       - non-existent scheme (e.g. "zzzzz://...")
@@ -94,11 +88,12 @@ def package_is_local_path(package_spec: str) -> bool:
 def parse_specifier_for_install(
     package_spec: str, pip_args: List[str]
 ) -> Tuple[str, List[str]]:
-    """Return package_or_url suitable for pipx install
+    """Return package_or_url and pip_args suitable for pip install
 
     Specifically:
     * Strip any markers (e.g. python_version > 3.4)
-    * Ensure --editable is not used with non-local path
+    * Ensure --editable is removed for use with non-local path
+    * Convert local paths to absolute paths
     """
     parsed_package = _parse_specifier(package_spec)
     if parsed_package.valid_pep508 is not None:

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -111,7 +111,7 @@ def parse_specifier_for_install(
                 logging.warning(
                     f"{hazard}  Ignoring environment markers in package specification "
                     f"({parsed_package.valid_pep508.marker}). Use pipx options "
-                    "instead."
+                    "to specify this type of information."
                 )
     elif parsed_package.valid_url is not None:
         package_or_url = parsed_package.valid_url

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -109,8 +109,8 @@ def parse_specifier_for_install(
                 )
             if parsed_package.valid_pep508.marker:
                 logging.warning(
-                    f"{hazard}  Ignoring environment markers in package specification: "
-                    f"'{parsed_package.valid_pep508.marker}'  Use pipx options "
+                    f"{hazard}  Ignoring environment markers in package specification "
+                    f"({parsed_package.valid_pep508.marker}). Use pipx options "
                     "instead."
                 )
     elif parsed_package.valid_url is not None:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -6,7 +6,7 @@ from typing import Dict, Generator, List, NamedTuple, Optional, Set
 
 from pipx.animate import animate
 from pipx.constants import DEFAULT_PYTHON, PIPX_SHARED_PTH
-from pipx.package_specifier import parse_specifier_for_metadata
+from pipx.package_specifier import package_is_local_path, parse_specifier_for_metadata
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
 from pipx.shared_libs import shared_libs
 from pipx.util import (
@@ -173,6 +173,12 @@ class Venv:
             # If no package name is supplied, install only main package
             #   first in order to see what its name is
             package = self.install_package_no_deps(package_or_url, pip_args)
+
+        if "--editable" in pip_args and not package_is_local_path(package_or_url):
+            logging.warning(
+                "Removing --editable, it is disallowed for a non-local package."
+            )
+            pip_args.remove("--editable")
 
         try:
             with animate(

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -176,7 +176,7 @@ class Venv:
 
         if "--editable" in pip_args and not package_is_local_path(package_or_url):
             logging.warning(
-                "Removing --editable, it is disallowed for a non-local package."
+                "Removing --editable install option, it is disallowed for a non-local path."
             )
             pip_args.remove("--editable")
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -169,17 +169,18 @@ class Venv:
         include_apps: bool,
         is_main_package: bool,
     ) -> None:
-
         if pip_args is None:
             pip_args = []
+
+        # check syntax and clean up spec and pip_args
+        (package_or_url, pip_args) = parse_specifier_for_install(
+            package_or_url, pip_args
+        )
+
         if package is None:
             # If no package name is supplied, install only main package
             #   first in order to see what its name is
             package = self.install_package_no_deps(package_or_url, pip_args)
-
-        (package_or_url, pip_args) = parse_specifier_for_install(
-            package_or_url, pip_args
-        )
 
         try:
             with animate(

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -6,7 +6,10 @@ from typing import Dict, Generator, List, NamedTuple, Optional, Set
 
 from pipx.animate import animate
 from pipx.constants import DEFAULT_PYTHON, PIPX_SHARED_PTH
-from pipx.package_specifier import package_is_local_path, parse_specifier_for_metadata
+from pipx.package_specifier import (
+    parse_specifier_for_install,
+    parse_specifier_for_metadata,
+)
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
 from pipx.shared_libs import shared_libs
 from pipx.util import (
@@ -174,11 +177,9 @@ class Venv:
             #   first in order to see what its name is
             package = self.install_package_no_deps(package_or_url, pip_args)
 
-        if "--editable" in pip_args and not package_is_local_path(package_or_url):
-            logging.warning(
-                "Removing --editable install option, it is disallowed for a non-local path."
-            )
-            pip_args.remove("--editable")
+        (package_or_url, pip_args) = parse_specifier_for_install(
+            package_or_url, pip_args
+        )
 
         try:
             with animate(

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -2,7 +2,7 @@ import json
 import logging
 import pkgutil
 from pathlib import Path
-from typing import Dict, Generator, List, NamedTuple, Optional, Set
+from typing import Dict, Generator, List, NamedTuple, Set
 
 from pipx.animate import animate
 from pipx.constants import DEFAULT_PYTHON, PIPX_SHARED_PTH
@@ -162,7 +162,7 @@ class Venv:
 
     def install_package(
         self,
-        package: Optional[str],  # if None, will be determined in this function
+        package: str,
         package_or_url: str,
         pip_args: List[str],
         include_dependencies: bool,
@@ -176,11 +176,6 @@ class Venv:
         (package_or_url, pip_args) = parse_specifier_for_install(
             package_or_url, pip_args
         )
-
-        if package is None:
-            # If no package name is supplied, install only main package
-            #   first in order to see what its name is
-            package = self.install_package_no_deps(package_or_url, pip_args)
 
         try:
             with animate(

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -227,7 +227,7 @@ class Venv:
         installed_packages = self.list_installed_packages() - old_package_set
         if len(installed_packages) == 1:
             package = installed_packages.pop()
-            logging.info(f"Determined package name: '{package}'")
+            logging.info(f"Determined package name: {package}")
         else:
             logging.info(f"old_package_set = {old_package_set}")
             logging.info(f"install_packages = {installed_packages}")

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -64,3 +64,22 @@ def test_parse_specifier_for_metadata(
         print(f"package_spec_in = {package_spec_in}")
         with pytest.raises(PipxError, match=r"^Unable to parse package spec"):
             package_or_url = parse_specifier_for_metadata(package_spec_in)
+
+
+@pytest.mark.parametrize(
+    "package_spec_in,pip_args_in,package_spec_expected,pip_args_expected",
+    [
+        ('pipx==0.15.0;python_version>="3.6"', [], "pipx==0.15.0", []),
+        (
+            "git+https://github.com/cs01/nox.git@5ea70723e9e6",
+            ["--editable"],
+            "git+https://github.com/cs01/nox.git@5ea70723e9e6",
+            [],
+        ),
+        ("src/pipx", ["--editable"], str(Path("src/pipx").resolve()), ["--editable"]),
+    ],
+)
+def test_parse_specifier_for_install(
+    package_spec_in, pip_args_in, package_spec_expected, pip_args_expected
+):
+    pass

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -79,7 +79,7 @@ def test_parse_specifier_for_metadata(
             [],
             "pipx==0.15.0",
             [],
-            "Ignoring environment markers",
+            'Ignoring environment markers in package specification: python_version>="3.6"',
         ),
         (
             "pipx==0.15.0",

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -79,7 +79,7 @@ def test_parse_specifier_for_metadata(
             [],
             "pipx==0.15.0",
             [],
-            'Ignoring environment markers in package specification: python_version >= "3.6"',
+            "Ignoring environment markers in package specification: 'python_version >= \"3.6\"'",
         ),
         (
             "pipx==0.15.0",

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -79,7 +79,7 @@ def test_parse_specifier_for_metadata(
             [],
             "pipx==0.15.0",
             [],
-            "Ignoring environment markers in package specification: 'python_version >= \"3.6\"'",
+            'Ignoring environment markers in package specification (python_version >= "3.6")',
         ),
         (
             "pipx==0.15.0",

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -79,7 +79,7 @@ def test_parse_specifier_for_metadata(
             [],
             "pipx==0.15.0",
             [],
-            'Ignoring environment markers (python_version >= "3.6") in package specification.',
+            'Ignoring environment markers (python_version >= "3.6") in package',
         ),
         (
             "pipx==0.15.0",

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -79,7 +79,7 @@ def test_parse_specifier_for_metadata(
             [],
             "pipx==0.15.0",
             [],
-            'Ignoring environment markers in package specification: python_version>="3.6"',
+            'Ignoring environment markers in package specification: python_version >= "3.6"',
         ),
         (
             "pipx==0.15.0",

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -79,7 +79,7 @@ def test_parse_specifier_for_metadata(
             [],
             "pipx==0.15.0",
             [],
-            'Ignoring environment markers in package specification (python_version >= "3.6")',
+            'Ignoring environment markers (python_version >= "3.6") in package specification.',
         ),
         (
             "pipx==0.15.0",

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -70,10 +70,17 @@ def test_parse_specifier_for_metadata(
     "package_spec_in,pip_args_in,package_spec_expected,pip_args_expected",
     [
         ('pipx==0.15.0;python_version>="3.6"', [], "pipx==0.15.0", []),
+        ('pipx==0.15.0;python_version>="3.6"', ["--editable"], "pipx==0.15.0", []),
         (
             "git+https://github.com/cs01/nox.git@5ea70723e9e6",
             ["--editable"],
             "git+https://github.com/cs01/nox.git@5ea70723e9e6",
+            [],
+        ),
+        (
+            "https://github.com/ambv/black/archive/18.9b0.zip",
+            ["--editable"],
+            "https://github.com/ambv/black/archive/18.9b0.zip",
             [],
         ),
         ("src/pipx", ["--editable"], str(Path("src/pipx").resolve()), ["--editable"]),

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest  # type: ignore
 
-from pipx.package_specifier import parse_specifier_for_metadata
+from pipx.package_specifier import (
+    parse_specifier_for_install,
+    parse_specifier_for_metadata,
+)
 from pipx.util import PipxError
 
 
@@ -67,26 +70,57 @@ def test_parse_specifier_for_metadata(
 
 
 @pytest.mark.parametrize(
-    "package_spec_in,pip_args_in,package_spec_expected,pip_args_expected",
+    "package_spec_in,pip_args_in,package_spec_expected,pip_args_expected,warning_str",
     [
-        ('pipx==0.15.0;python_version>="3.6"', [], "pipx==0.15.0", []),
-        ('pipx==0.15.0;python_version>="3.6"', ["--editable"], "pipx==0.15.0", []),
+        ('pipx==0.15.0;python_version>="3.6"', [], "pipx==0.15.0", [], None),
+        ("pipx==0.15.0", ["--editable"], "pipx==0.15.0", [], "Ignoring --editable",),
+        (
+            'pipx==0.15.0;python_version>="3.6"',
+            [],
+            "pipx==0.15.0",
+            [],
+            "Ignoring environment markers",
+        ),
+        (
+            "pipx==0.15.0",
+            ["--no-cache-dir", "--editable"],
+            "pipx==0.15.0",
+            ["--no-cache-dir"],
+            "Ignoring --editable",
+        ),
         (
             "git+https://github.com/cs01/nox.git@5ea70723e9e6",
             ["--editable"],
             "git+https://github.com/cs01/nox.git@5ea70723e9e6",
             [],
+            "Ignoring --editable",
         ),
         (
             "https://github.com/ambv/black/archive/18.9b0.zip",
             ["--editable"],
             "https://github.com/ambv/black/archive/18.9b0.zip",
             [],
+            "Ignoring --editable",
         ),
-        ("src/pipx", ["--editable"], str(Path("src/pipx").resolve()), ["--editable"]),
+        (
+            "src/pipx",
+            ["--editable"],
+            str(Path("src/pipx").resolve()),
+            ["--editable"],
+            None,
+        ),
     ],
 )
 def test_parse_specifier_for_install(
-    package_spec_in, pip_args_in, package_spec_expected, pip_args_expected
+    caplog,
+    package_spec_in,
+    pip_args_in,
+    package_spec_expected,
+    pip_args_expected,
+    warning_str,
 ):
-    pass
+    [package_or_url_out, pip_args_out] = parse_specifier_for_install(
+        package_spec_in, pip_args_in
+    )
+    if warning_str is not None:
+        assert warning_str in caplog.text

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-import os
 import logging
-import sys
+import os
 import subprocess
+import sys
 from unittest import mock
 
 import pytest  # type: ignore
-
 from helpers import run_pipx_cli
 
 import pipx.main
@@ -123,4 +122,4 @@ def test_package_determination(
     run_pipx_cli(["run", "--verbose", "--spec", package_or_url, "--"] + app_appargs)
 
     assert "Cannot determine package name" not in caplog.text
-    assert f"Determined package name: '{package}'" in caplog.text
+    assert f"Determined package name: {package}" in caplog.text


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[x] I have added an entry to `docs/changelog.md`

## Summary of changes
Fixes #438 .

This parses a package specifier before install.

It removes the `--editable` option for any package specification that is not a local path, and gives a warning that it is doing so.
It removes any environment markers from the package specification and gives a warning that it is doing so.
I also refactored `package_specifier.py` a bit.
And a bunch of tests were added for the new functionality.

I started this PR as a fix for a pip error within pipx that was complicated enough that there might be user confusion.  (See #438).  Once I was parsing the package specifier, I also decided to remove the environment markers that cause errors in pipx operation, and anyway seemed to me not a fit for pipx's use-case.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
### Test 1
```
pipx install -e pylint
```
This PR gives a warning that pipx is removing the `--editable` option.  The current dev version of pipx would just pass-through a pip error.

### Test 2
```
pipx install --editable git+https://github.com/raxod502/diary-manager
```
This PR gives a warning that pipx is removing the `--editable` option.  The current dev version of pipx would just pass-through an even more complicated pip error.

### Test 3
```
pipx install 'pylint;python_version=="3.6"'
```
Current dev pipx gives cryptic error:
```
Internal error with venv metadata inspection.

Unable to install pylint from spec 'pylint;python_version=="3.6"'.
Check the name or spec for errors, and verify that it can be installed with pip.
```
This PR pipx gives warning it is ignoring markers and proceeds normally (without error!) to install pylint.