### PR TITLE
Add pre-commit support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/#installation for installation instructions
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.2.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: check-added-large-files
+  #- id: trailing-whitespace
+  #- id: check-yaml
+- repo: https://github.com/timothycrosley/isort
+  rev: 5.4.2
+  hooks:
+  - id: isort
+    args: ['--profile','black']
+- repo: https://github.com/psf/black
+  rev: 19.10b0
+  hooks:
+  - id: black
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.3
+  hooks:
+  - id: flake8
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.782
+  hooks:
+  - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/#installation for installation instructions
 # See https://pre-commit.com/hooks.html for more hooks
+#
+# use `git commit --no-verify` to disable git hooks for this commit
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v3.2.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 graft src
 include *.md pipx_demo.gif logo.png LICENSE
 
-exclude get-pipx.py makefile generate_docs.py .flake8 mkdocs.yml noxfile.py .coveragerc
+exclude .pre-commit-config.yaml get-pipx.py makefile generate_docs.py .flake8 mkdocs.yml noxfile.py .coveragerc
 prune templates
 prune tests
 prune docs


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[] I have added an entry to `docs/changelog.md`

## Summary of changes
I've been using this pre-commit with the config file in this PR for a while now and really like it.  I'd like to make it part of the repo.

If you don't install pre-commit hooks into your git repo, this file will have no effect on you.

If you do install pre-commit and its hooks, this config will do our lint tests (and more) before each commit:
* Run isort
* Run black
* Run flake8
* Run mypy

If it finds problems it will abort the commit.  In the case of black and isort it will additionally fix the problems by running those utilities to modify the code!

I really like being notified, and/or fixing the problems **before** I commit, instead of being notified after the fact by our Lint test.

The only downside I can think of is for this PR is that it adds another dot-file to the repo.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
