### PR TITLE
Change version to 0.15.5.0.dev

### DIFF
--- a/src/pipx/version.py
+++ b/src/pipx/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 15, 5, 0)
+__version_info__ = (0, 15, 5, 0, "dev")
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[] I have added an entry to `docs/changelog.md`

## Summary of changes
Added a ".dev" suffix to the version, based on the last release.

This allows us to know using `pipx --version` if we are using the github unreleased version of the last released version.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
(venv) birchtree:pipx pipx --version
0.15.5.0.dev
```
