### PR TITLE
Remove remaining shebangs

### DIFF
--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
 
 """The command line interface to pipx"""
@@ -6,21 +5,21 @@
 import argparse
 import functools
 import logging
-import shlex
 import re
+import shlex
 import sys
 import textwrap
 import urllib.parse
 from typing import Dict, List
 
 import argcomplete  # type: ignore
+
+from . import commands, constants
+from .animate import hide_cursor, show_cursor
 from .colors import bold, green
-from . import commands
-from . import constants
 from .util import PipxError, mkdir
 from .venv import VenvContainer
 from .version import __version__
-from .animate import hide_cursor, show_cursor
 
 
 def print_version() -> None:

--- a/src/pipx/venv_metadata_inspector.py
+++ b/src/pipx/venv_metadata_inspector.py
@@ -1,11 +1,8 @@
-#!/usr/bin/env python3
-
 import json
 import sys
 import traceback
 from pathlib import Path
 from typing import Dict, List, Optional
-
 
 try:
     WindowsError

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from helpers import run_pipx_cli
 
 

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from helpers import run_pipx_cli
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3,8 +3,8 @@ import sys
 from unittest import mock
 
 import pytest  # type: ignore
-from helpers import assert_not_in_virtualenv, run_pipx_cli, which_python
 
+from helpers import assert_not_in_virtualenv, run_pipx_cli, which_python
 from pipx import constants
 
 assert_not_in_virtualenv()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python3
-
 import os
 import sys
 from unittest import mock
 
 import pytest  # type: ignore
-
 from helpers import assert_not_in_virtualenv, run_pipx_cli, which_python
+
 from pipx import constants
 
 assert_not_in_virtualenv()

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,5 +1,4 @@
 from helpers import run_pipx_cli
-
 from pipx import constants, util
 
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3
 from helpers import run_pipx_cli
+
 from pipx import constants, util
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,8 +2,8 @@ import sys
 from unittest import mock
 
 import pytest  # type: ignore
-from helpers import assert_not_in_virtualenv, run_pipx_cli
 
+from helpers import assert_not_in_virtualenv, run_pipx_cli
 from pipx import main
 
 assert_not_in_virtualenv()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python3
-
 import sys
 from unittest import mock
 
 import pytest  # type: ignore
-
 from helpers import assert_not_in_virtualenv, run_pipx_cli
+
 from pipx import main
 
 assert_not_in_virtualenv()

--- a/tests/test_reinstall_all.py
+++ b/tests/test_reinstall_all.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import sys
 
 from helpers import run_pipx_cli

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5,9 +5,9 @@ import sys
 from unittest import mock
 
 import pytest  # type: ignore
-from helpers import run_pipx_cli
 
 import pipx.main
+from helpers import run_pipx_cli
 
 
 def test_help_text(pipx_temp_env, monkeypatch, capsys):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import logging
 import os
 import subprocess

--- a/tests/test_runpip.py
+++ b/tests/test_runpip.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from helpers import run_pipx_cli
 
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,5 +1,4 @@
 from helpers import run_pipx_cli
-
 from pipx import constants, util
 
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3
 from helpers import run_pipx_cli
+
 from pipx import constants, util
 
 

--- a/tests/test_uninstall_all.py
+++ b/tests/test_uninstall_all.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from helpers import run_pipx_cli
 
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from helpers import run_pipx_cli
 
 

--- a/tests/test_upgrade_all.py
+++ b/tests/test_upgrade_all.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from helpers import run_pipx_cli
 
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[] I have added an entry to `docs/changelog.md`

## Summary of changes
I removed the remaining shebangs at the top of a couple of python files in `src/pipx` and `tests`.  None of these files were executable anyway, so it was not possible to need the shebangs.

I also let isort alphabetize the imports.  Someone might take a look at the lines that start with `from helpers ` (e.g. in `test_install.py`).  isort seems to place `helpers` with the 3rd-party libraries and not with the "local folder" imports.  I wasn't sure if that made sense or not so I left it in.  Theoretically isort is supposed to group imports into the following blocks: FUTURE, STDLIB, THIRDPARTY, FIRSTPARTY, LOCALFOLDER.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
