### PR TITLE
Add configuration for isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+# can be merged into pyproject.toml at a later date
+[settings]
+profile=black
+known_first_party=helpers

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 graft src
 include *.md pipx_demo.gif logo.png LICENSE
 
-exclude .pre-commit-config.yaml get-pipx.py makefile generate_docs.py .flake8 mkdocs.yml noxfile.py .coveragerc
+exclude .isort.cfg .pre-commit-config.yaml get-pipx.py makefile generate_docs.py .flake8 mkdocs.yml noxfile.py .coveragerc
 prune templates
 prune tests
 prune docs


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[] I have added an entry to `docs/changelog.md`

## Summary of changes
Adds config for isort
* uses `profile=black` for black-compatible formatting
* adds `helpers` (e.g. in `tests/test_install.py`) to known_first_party imports so isort places it in the right block of imports

This is one step to making #257 work.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
