### PR TITLE
Remove venv check

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,6 @@ from pipx import main
 
 def assert_not_in_virtualenv():
     assert not hasattr(sys, "real_prefix"), "Tests cannot run under virtualenv"
-    assert getattr(sys, "base_prefix", sys.prefix) != sys.prefix, "Tests require venv"
 
 
 def run_pipx_cli(pipx_args: List[str]):


### PR DESCRIPTION
## Summary of changes
venv is available through the standard library since 3.3, since you require 3.6+ for your package, it will always be true, so just remove assertion.

https://www.python.org/dev/peps/pep-0405/

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
