### PR TITLE
Fix regression with install of local path with extras

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 graft src
 include *.md pipx_demo.gif logo.png LICENSE
 
-exclude .isort.cfg .pre-commit-config.yaml get-pipx.py makefile generate_docs.py .flake8 mkdocs.yml noxfile.py .coveragerc
+exclude testdata .isort.cfg .pre-commit-config.yaml get-pipx.py makefile generate_docs.py .flake8 mkdocs.yml noxfile.py .coveragerc
 prune templates
 prune tests
 prune docs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
 graft src
 include *.md pipx_demo.gif logo.png LICENSE
 
-exclude testdata .isort.cfg .pre-commit-config.yaml get-pipx.py makefile generate_docs.py .flake8 mkdocs.yml noxfile.py .coveragerc
+exclude .isort.cfg .pre-commit-config.yaml get-pipx.py makefile generate_docs.py .flake8 mkdocs.yml noxfile.py .coveragerc
+recursive-exclude testdata
 prune templates
 prune tests
 prune docs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ graft src
 include *.md pipx_demo.gif logo.png LICENSE
 
 exclude .isort.cfg .pre-commit-config.yaml get-pipx.py makefile generate_docs.py .flake8 mkdocs.yml noxfile.py .coveragerc
-recursive-exclude testdata
+recursive-exclude testdata *
 prune templates
 prune tests
 prune docs

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+dev
+
+- [bugfix] Fixed regression of 0.15.5.0 which erroneously made installing from a local path with package extras not possible.
+
 0.15.5.0
 
 - pipx now parses package specification before install.   It removes (with warning) the `--editable` install option for any package specification that is not a local path.   It also removes (with warning) any environment markers.

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -4,6 +4,7 @@
 #   <URL>
 #   <pypi_package_name>
 #   <pypi_package_name><version_specifier>
+#   <local_path>
 
 import logging
 import re

--- a/testdata/test_package_specifier/local_extras/repeatme/main.py
+++ b/testdata/test_package_specifier/local_extras/repeatme/main.py
@@ -1,0 +1,17 @@
+import sys
+
+try:
+    import pycowsay.main
+
+    has_pycowsay = True
+except ImportError:
+    has_pycowsay = False
+
+
+def main():
+    print(f"You said:\n    {' '.join(sys.argv[1:])}")
+
+    if has_pycowsay:
+        print()
+        print("In cow, you said:")
+        pycowsay.main.main()

--- a/testdata/test_package_specifier/local_extras/setup.py
+++ b/testdata/test_package_specifier/local_extras/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(
+    name="repeatme",
+    version=0.1,
+    description="Repeat arguments.",
+    packages=["repeatme"],
+    extras_require={"cow": ["pycowsay==0.0.0.1"]},
+    entry_points={"console_scripts": ["repeatme=repeatme.main:main"]},
+)

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -8,6 +8,8 @@ from pipx.package_specifier import (
 )
 from pipx.util import PipxError
 
+TEST_DATA_PATH = "./testdata/test_package_specifier"
+
 
 # TODO: Make sure git+ works with tests, correct in test_install as well
 @pytest.mark.parametrize(
@@ -106,6 +108,34 @@ def test_parse_specifier_for_metadata(
             "src/pipx",
             ["--editable"],
             str(Path("src/pipx").resolve()),
+            ["--editable"],
+            None,
+        ),
+        (
+            TEST_DATA_PATH + "/local_extras",
+            [],
+            str(Path(TEST_DATA_PATH + "/local_extras").resolve),
+            [],
+            None,
+        ),
+        (
+            TEST_DATA_PATH + "/local_extras[cow]",
+            [],
+            str(Path(TEST_DATA_PATH + "/local_extras").resolve) + "[cow]",
+            [],
+            None,
+        ),
+        (
+            TEST_DATA_PATH + "/local_extras",
+            ["--editable"],
+            str(Path(TEST_DATA_PATH + "/local_extras").resolve),
+            ["--editable"],
+            None,
+        ),
+        (
+            TEST_DATA_PATH + "/local_extras[cow]",
+            ["--editable"],
+            str(Path(TEST_DATA_PATH + "/local_extras").resolve) + "[cow]",
             ["--editable"],
             None,
         ),


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[x] I have added an entry to `docs/changelog.md`

## Summary of changes
Fix regression with 0.15.5.0 which erroneously disallowed installation from local paths with package extras.

Fixes #475 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
From pipx git clone main directory:
```
pipx '.[pdf]'
```
There is no `pdf` extra, but this PR code merely gives a warning that there is no `pdf` extra and continues to install pipx.

Existing pipx code gives instead the following (wrong) error:
```
Unable to parse package spec: .[pdf]
```
