### PR TITLE
Publish docs automatic workflow

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,6 +1,6 @@
 name: Publish docs via GitHub Pages
 on:
-  workflow_dispatch: ''
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,24 @@
+# https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#manually-running-a-workflow
+# https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
+
+name: Publish Docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Person to greet'
+        required: true
+        default: 'Mona the Octocat'
+      home:
+        description: 'location'
+        required: false
+
+jobs:
+  say_hello:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo "Hello ${{ github.event.inputs.name }}!"
+        echo "- in ${{ github.event.inputs.home }}!"
+    

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,34 +1,31 @@
-# https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#manually-running-a-workflow
-# https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
-
-name: Publish Docs
-
+name: Publish docs via GitHub Pages
 on:
   [workflow_dispatch]
 
 jobs:
-  build_publish_docs:
+  build:
+    name: Deploy docs
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.8]
 
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install nox
-      run: |
-        python -m pip install --upgrade pip
-        pip install nox
-    - name: Build and Publish Docs
-      steps:
-        - name: Build Docs
-          run: |
-            nox --error-on-missing-interpreters --non-interactive --session docs
-        - name: Publish Docs
-          if: ${{ success() }}
-          run: |
-            nox --error-on-missing-interpreters --non-interactive --session publish_docs
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install nox
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox
+      - name: Build Docs
+        run: |
+          nox --error-on-missing-interpreters --non-interactive --session docs
+      - name: Deploy docs
+        if: ${{ success() }}
+        uses: mhausenblas/mkdocs-deploy-gh-pages@1.13
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -4,21 +4,31 @@
 name: Publish Docs
 
 on:
-  workflow_dispatch:
-    inputs:
-      name:
-        description: 'Person to greet'
-        required: true
-        default: 'Mona the Octocat'
-      home:
-        description: 'location'
-        required: false
+  [workflow_dispatch]
 
 jobs:
-  say_hello:
+  build_publish_docs:
     runs-on: ubuntu-latest
-    steps:
-    - run: |
-        echo "Hello ${{ github.event.inputs.name }}!"
-        echo "- in ${{ github.event.inputs.home }}!"
-    
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade pip
+        pip install nox
+    - name: Build and Publish Docs
+      steps:
+        - name: Build Docs
+          run: |
+            nox --error-on-missing-interpreters --non-interactive --session docs
+        - name: Publish Docs
+          if: ${{ success() }}
+          run: |
+            nox --error-on-missing-interpreters --non-interactive --session publish_docs

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,6 +1,8 @@
 name: Publish docs via GitHub Pages
 on:
-  [workflow_dispatch]
+  workflow_dispatch: ''
+  release:
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[] I have added an entry to `docs/changelog.md`

## Summary of changes
Closes #333 

This rebuilds and publishes our docs whenever there is a published release.  It can also manually be initiated whenever somebody activates this action from the "Actions" tab, Select "Publish docs via GitHub Pages" and use the pulldown "Run workflow".

**NOTE** the action used here does a rebase in the `gh-pages` branch, so the result is that there is only one commit on the `gh-pages` branch.  All history in the `gh-pages` branch is gone after it executes.

I've tested this in a mock pipx repo and it seems to work well, both with the release trigger and with the manual trigger.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
