### PR TITLE
Use persistent github cache for pip cache

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -66,8 +66,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Upgrade pip
-      run: python -m pip install --upgrade pip
     - name: Get pip cache dir
       id: pip-cache
       run: |
@@ -77,6 +75,8 @@ jobs:
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-pip${{ matrix.python-version }}
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip
     # macOS: Install wheel to allow wheel-building for nox and regex
     # Build regex wheel into pip cache, so future pipx installs don't compile.
     # This avoids future compile errors in nox tests because of missing

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -68,6 +68,15 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: Persistent pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip
     # macos: Install wheel to allow wheel-building for nox and regex
     # Build regex wheel into pip cache, so future pipx installs don't compile.
     # This avoids future compile errors in nox tests because of missing

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -70,7 +70,7 @@ jobs:
       id: pip-cache
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
-    - name: Persistent Github pip cache
+    - name: Persistent github pip cache
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -70,7 +70,7 @@ jobs:
       id: pip-cache
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
-    - name: Persistent github pip cache
+    - name: Persistent Github pip cache
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -72,12 +72,12 @@ jobs:
       id: pip-cache
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
-    - name: Persistent pip cache
+    - name: Persistent Github pip cache
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip
-    # macos: Install wheel to allow wheel-building for nox and regex
+        key: ${{ runner.os }}-pip${{ matrix.python-version }}
+    # macOS: Install wheel to allow wheel-building for nox and regex
     # Build regex wheel into pip cache, so future pipx installs don't compile.
     # This avoids future compile errors in nox tests because of missing
     #   header files.

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -82,7 +82,7 @@ jobs:
     # This avoids future compile errors in nox tests because of missing
     #   header files.
     - name: Install wheel and build wheel for regex to pip cache
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ runner.os == 'macOS' }}
       run: |
         python -m pip install wheel
         python -m pip install regex


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[] I have added an entry to `docs/changelog.md`

## Summary of changes
This uses the persistent github workflow cache to preserve the pip cache between test workflows.  It speeds up operation by not needing to rebuild or download wheels once they are already in the pip cache.

It's hard to quantify how much time this saves because the normal variation in test times for any given workflow test is already large.  It looks like from my testing (sample size N=6) that the biggest help is with the macOS target.  The macOS "build regex wheel" step can take anywhere from 25 seconds to 2 minutes normally, and with this PR takes 4 seconds reliably.  

Second in impact is the Windows target, which looks like it's saving something like 1 minute in total.

In addition, the normal pipx tests that require many installs of big python packages seem to save something like 30 seconds over the whole test for the remaining OS tests.

One remaining question: all of the internet examples for generating a cache key for github workflow caches involve hashing `requirements.txt`.  Since we don't really have that, and the cache is supporting many different python packages, I dispensed with hashing any file altogether and just made a persistent cache key only based on the OS and python version.  (e.g. a cache key would be `Linux-pip3.8`).  I assume this is ok, as pip will take care of expiring its own cache items.  But I'm happy to be educated otherwise if I'm wrong. 

Another minor change I did was to use `runner.os` instead of `matrix.os` to check for macOS so that we could use an OS-version-independent string.

Refs:
https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows
https://github.com/actions/cache/blob/master/examples.md#python---pip


## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
