### PR TITLE
pin black version at 19.10b0

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -25,7 +25,7 @@ nox.options.reuse_existing_virtualenvs = True
 
 doc_dependencies = [".", "jinja2", "mkdocs", "mkdocs-material"]
 lint_dependencies = [
-    "black",
+    "black==19.10b0",
     "flake8",
     "flake8-bugbear",
     "mypy",

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -1,9 +1,10 @@
 from pathlib import Path
+
 import pytest  # type: ignore
 
-from helpers import assert_not_in_virtualenv, run_pipx_cli
 import pipx.constants
-from pipx.pipx_metadata_file import PipxMetadata, PackageInfo
+from helpers import assert_not_in_virtualenv, run_pipx_cli
+from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
 from pipx.util import PipxError
 
 assert_not_in_virtualenv()
@@ -57,7 +58,7 @@ BLACK_PACKAGE_REF = PackageInfo(
     app_paths=[Path("black/bin/black")],  # Placeholder, not real path
     apps_of_dependencies=[],
     app_paths_of_dependencies={},
-    package_version="19.10b3",
+    package_version="19.10b0",
 )
 
 
@@ -149,7 +150,7 @@ def test_package_inject(monkeypatch, tmp_path, pipx_temp_env):
     pipx_venvs_dir = pipx.constants.PIPX_HOME / "venvs"
 
     run_pipx_cli(["install", "pycowsay"])
-    run_pipx_cli(["inject", "pycowsay", "black"])
+    run_pipx_cli(["inject", "pycowsay", "black==19.10b0"])
     assert (pipx_venvs_dir / "pycowsay" / "pipx_metadata.json").is_file()
 
     pipx_metadata = PipxMetadata(pipx_venvs_dir / "pycowsay")


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
[] I have added an entry to `docs/changelog.md`

## Summary of changes
Black is currently entering a new cycle of development where its formatted output of our python files is changing.

This PR pins the version of black in Lint to be 19.10b0, to be upgraded later when we make a conscious decision to do so.  (And possibly after some of the churn of black v20.* has calmed down.)

It also fixes a test that made an assumption that the most recent black version was at v19.10b0.  For the test now black is specifically injected at v19.10b0.

In the future we can choose to upgrade our black version by both changing it inside of `noxfile.py` and `.pre-commit-config.yml` together.  As well as fixing any formatting that changes.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
