### PR TITLE
Improve support for suffixed packages

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 dev
 
 - [docs] Update license
+- [bugfix] Fixed regression in list, inject and upgrade commands when suffixed packages are used.
 
 
 0.15.5.1

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -58,6 +58,7 @@ def install(
             include_dependencies=include_dependencies,
             include_apps=True,
             is_main_package=True,
+            suffix=suffix or "",
         )
         run_post_install_actions(
             venv,
@@ -66,7 +67,6 @@ def install(
             venv_dir,
             include_dependencies,
             force=force,
-            suffix=suffix,
         )
     except (Exception, KeyboardInterrupt):
         print("")

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -35,6 +35,7 @@ class PackageInfo(NamedTuple):
     apps_of_dependencies: List[str]
     app_paths_of_dependencies: Dict[str, List[Path]]
     package_version: str
+    suffix: str = ""
 
 
 class PipxMetadata:
@@ -100,11 +101,18 @@ class PipxMetadata:
         }
 
     def from_dict(self, input_dict: Dict[str, Any]) -> None:
-        self.main_package = PackageInfo(**input_dict["main_package"])
+        main_package_data = input_dict["main_package"]
+        if main_package_data["package"] != self.venv_dir.name:
+            # handle older suffixed packages gracefully
+            main_package_data["suffix"] = self.venv_dir.name.replace(
+                main_package_data["package"], ""
+            )
+
+        self.main_package = PackageInfo(**main_package_data)
         self.python_version = input_dict["python_version"]
         self.venv_args = input_dict["venv_args"]
         self.injected_packages = {
-            name: PackageInfo(**data)
+            f"{name}{data.get('suffix', '')}": PackageInfo(**data)
             for (name, data) in input_dict["injected_packages"].items()
         }
 

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -39,6 +39,9 @@ class PackageInfo(NamedTuple):
 
 
 class PipxMetadata:
+    # Only change this if file format changes
+    __METADATA_VERSION__: str = "0.2"
+
     def __init__(self, venv_dir: Path, read: bool = True):
         self.venv_dir = venv_dir
         # We init this instance with reasonable fallback defaults for all
@@ -61,9 +64,6 @@ class PipxMetadata:
         self.python_version: Optional[str] = None
         self.venv_args: List[str] = []
         self.injected_packages: Dict[str, PackageInfo] = {}
-
-        # Only change this if file format changes
-        self._pipx_metadata_version: str = "0.1"
 
         if read:
             self.read()
@@ -97,7 +97,7 @@ class PipxMetadata:
             "injected_packages": {
                 name: data._asdict() for (name, data) in self.injected_packages.items()
             },
-            "pipx_metadata_version": self._pipx_metadata_version,
+            "pipx_metadata_version": self.__METADATA_VERSION__,
         }
 
     def from_dict(self, input_dict: Dict[str, Any]) -> None:

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -1,3 +1,5 @@
+import pytest  # type: ignore
+
 from helpers import run_pipx_cli
 
 
@@ -11,9 +13,23 @@ def test_spec(pipx_temp_env, capsys):
     assert not run_pipx_cli(["inject", "pycowsay", "pylint==2.3.1"])
 
 
-def test_include_apps(pipx_temp_env, capsys):
-    assert not run_pipx_cli(["install", "pycowsay"])
-    assert run_pipx_cli(["inject", "pycowsay", "black", "--include-deps"])
+@pytest.mark.parametrize("with_suffix,", [(False,), (True,)])
+def test_include_apps(pipx_temp_env, capsys, with_suffix):
+    install_args = []
+    suffix = ""
+
+    if with_suffix:
+        suffix = "_x"
+        install_args = [f"--suffix={suffix}"]
+
+    assert not run_pipx_cli(["install", "pycowsay", *install_args])
+    assert run_pipx_cli(["inject", f"pycowsay{suffix}", "black", "--include-deps"])
+
+    if suffix:
+        assert run_pipx_cli(
+            ["inject", "pycowsay", "black", "--include-deps", "--include-apps"]
+        )
+
     assert not run_pipx_cli(
-        ["inject", "pycowsay", "black", "--include-deps", "--include-apps"]
+        ["inject", f"pycowsay{suffix}", "black", "--include-deps", "--include-apps"]
     )

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -22,3 +22,12 @@ def test_missing_interpreter(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["list"])
     captured = capsys.readouterr()
     assert "package pycowsay has invalid interpreter" in captured.out
+
+
+def test_list_suffix(pipx_temp_env, monkeypatch, capsys):
+    suffix = "_x"
+    assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])
+    assert not run_pipx_cli(["list"])
+
+    captured = capsys.readouterr()
+    assert f"package pycowsay 0.0.0.1 (pycowsay{suffix})," in captured.out

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -63,14 +63,17 @@ BLACK_PACKAGE_REF = PackageInfo(
 
 
 def test_pipx_metadata_file_create(tmp_path):
-    pipx_metadata = PipxMetadata(tmp_path)
+    venv_dir = tmp_path / TEST_PACKAGE1.package
+    venv_dir.mkdir()
+
+    pipx_metadata = PipxMetadata(venv_dir)
     pipx_metadata.main_package = TEST_PACKAGE1
     pipx_metadata.python_version = "3.4.5"
     pipx_metadata.venv_args = ["--system-site-packages"]
     pipx_metadata.injected_packages = {"injected": TEST_PACKAGE2}
     pipx_metadata.write()
 
-    pipx_metadata2 = PipxMetadata(tmp_path)
+    pipx_metadata2 = PipxMetadata(venv_dir)
 
     for attribute in [
         "venv_dir",

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -5,3 +5,12 @@ def test_upgrade(pipx_temp_env, capsys):
     assert run_pipx_cli(["upgrade", "pycowsay"])
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["upgrade", "pycowsay"])
+
+
+def test_upgrade_suffix(pipx_temp_env, capsys):
+    name = "pycowsay"
+    suffix = "_a"
+
+    assert not run_pipx_cli(["install", name, f"--suffix={suffix}"])
+    assert run_pipx_cli(["upgrade", f"{name}"])
+    assert not run_pipx_cli(["upgrade", f"{name}{suffix}"])


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
This change allows for safe listing and upgrade of packages installed with a suffix. As part of this change, a new metadata property "suffix" has been introduced.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```sh
pipx install --suffix=_test pycowsay
pipx upgrade pycowsay_test
pipx inject pycowsay_test pip
pipx list
pipx uninstall pycowsay_test
```
