### PR TITLE
upgrade: do not enforce package spec for pipx package

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@ dev
 
 - [docs] Update license
 - [bugfix] Fixed regression in list, inject and upgrade commands when suffixed packages are used.
+- [bugfix] Do not reset package url during upgrade when main package is `pipx`
 
 
 0.15.5.1

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -50,9 +50,6 @@ def upgrade(
     include_apps = package_metadata.include_apps
     include_dependencies = package_metadata.include_dependencies
 
-    if package == "pipx":
-        package_or_url = "pipx"
-
     # Upgrade shared libraries (pip, setuptools and wheel)
     venv.upgrade_packaging_libraries(pip_args)
 


### PR DESCRIPTION
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

## Test plan
Tested by running
```
pipx install --suffix @master 'pipx @ git+https://github.com/pipxproject/pipx.git'
pipx upgrade pipx@master
```
