### PR TITLE
Suffix-related bugfixes and tests and some refactoring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,9 @@ repos:
   rev: 3.8.3
   hooks:
   - id: flake8
+    additional_dependencies: [
+        'flake8-bugbear==20.1.4'
+    ]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.782
   hooks:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 dev
 
 - [docs] Update license
-- [bugfix] Fixed regression in list, inject and upgrade commands when suffixed packages are used.
+- [bugfix] Fixed regression in list, inject, upgrade, reinstall-all commands when suffixed packages are used.
 - [bugfix] Do not reset package url during upgrade when main package is `pipx`
 
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -147,7 +147,7 @@ def get_package_summary(
         return f"   package {red(bold(venv_dir.name))} has invalid interpreter {str(python_path)}"
     if not venv.package_metadata:
         return (
-            f"   {red(bold(venv_dir.name))} has missing internal pipx metadata.\n"
+            f"   package {red(bold(venv_dir.name))} has missing internal pipx metadata.\n"
             f"       It was likely installed using a pipx version before 0.15.0.0.\n"
             f"       Please uninstall and install this package, or reinstall-all to fix."
         )

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -325,7 +325,7 @@ def run_post_install_actions(
         if venv.safe_to_remove():
             venv.remove_venv()
         raise PipxError(
-            f"No apps associated with package {display_name} or its dependencies."
+            f"No apps associated with package {display_name} or its dependencies. "
             "If you are attempting to install a library, pipx should not be used. "
             "Consider using pip or a similar tool instead."
         )

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -141,8 +141,6 @@ def get_package_summary(
     if package is None:
         package = venv.main_package_name
 
-    package_metadata = venv.package_metadata[package]
-
     if not python_path.is_file():
         return f"   package {red(bold(venv_dir.name))} has invalid interpreter {str(python_path)}"
     if not venv.package_metadata:
@@ -151,6 +149,8 @@ def get_package_summary(
             f"       It was likely installed using a pipx version before 0.15.0.0.\n"
             f"       Please uninstall and install this package, or reinstall-all to fix."
         )
+
+    package_metadata = venv.package_metadata[package]
 
     if package_metadata.package_version is None:
         not_installed = red("is not installed")

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -21,19 +21,12 @@ from pipx.venv import Venv
 
 
 def expose_apps_globally(
-    local_bin_dir: Path,
-    app_paths: List[Path],
-    package: str,
-    *,
-    force: bool,
-    suffix: str = "",
+    local_bin_dir: Path, app_paths: List[Path], *, force: bool, suffix: str = "",
 ) -> None:
     if not _can_symlink(local_bin_dir):
-        _copy_package_apps(local_bin_dir, app_paths, package, suffix=suffix)
+        _copy_package_apps(local_bin_dir, app_paths, suffix=suffix)
     else:
-        _symlink_package_apps(
-            local_bin_dir, app_paths, package, force=force, suffix=suffix
-        )
+        _symlink_package_apps(local_bin_dir, app_paths, force=force, suffix=suffix)
 
 
 _can_symlink_cache: Dict[Path, bool] = {}
@@ -61,7 +54,7 @@ def _can_symlink(local_bin_dir: Path) -> bool:
 
 
 def _copy_package_apps(
-    local_bin_dir: Path, app_paths: List[Path], package: str, suffix: str = "",
+    local_bin_dir: Path, app_paths: List[Path], suffix: str = "",
 ) -> None:
     for src_unresolved in app_paths:
         src = src_unresolved.resolve()
@@ -77,12 +70,7 @@ def _copy_package_apps(
 
 
 def _symlink_package_apps(
-    local_bin_dir: Path,
-    app_paths: List[Path],
-    package: str,
-    *,
-    force: bool,
-    suffix: str = "",
+    local_bin_dir: Path, app_paths: List[Path], *, force: bool, suffix: str = "",
 ) -> None:
     for app_path in app_paths:
         app_name = app_path.name
@@ -333,7 +321,6 @@ def run_post_install_actions(
     expose_apps_globally(
         local_bin_dir,
         package_metadata.app_paths,
-        package,
         force=force,
         suffix=package_metadata.suffix,
     )
@@ -341,11 +328,7 @@ def run_post_install_actions(
     if include_dependencies:
         for _, app_paths in package_metadata.app_paths_of_dependencies.items():
             expose_apps_globally(
-                local_bin_dir,
-                app_paths,
-                package,
-                force=force,
-                suffix=package_metadata.suffix,
+                local_bin_dir, app_paths, force=force, suffix=package_metadata.suffix,
             )
 
     print(get_package_summary(venv_dir, package=package, new_install=True,))

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -138,8 +138,10 @@ def get_package_summary(
     venv = Venv(path)
     python_path = venv.python_path.resolve()
 
-    package_metadata = venv.get_package_metadata(package)
-    package = package_metadata.package or venv.root.name
+    if package is None:
+        package = venv.main_package_name
+
+    package_metadata = venv.package_metadata[package]
 
     if not python_path.is_file():
         return f"   package {red(bold(package))} has invalid interpreter {str(python_path)}"
@@ -281,8 +283,8 @@ def run_post_install_actions(
     *,
     force: bool,
 ):
-    package_metadata = venv.get_package_metadata(package)
-    package = package_metadata.package or package
+    package_metadata = venv.package_metadata[package]
+
     display_name = f"{package}{package_metadata.suffix}"
 
     if not package_metadata.app_paths and not include_dependencies:

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -144,9 +144,7 @@ def get_package_summary(
     package_metadata = venv.package_metadata[package]
 
     if not python_path.is_file():
-        return (
-            f"   {red(bold(venv_dir.name))} has invalid interpreter {str(python_path)}"
-        )
+        return f"   package {red(bold(venv_dir.name))} has invalid interpreter {str(python_path)}"
     if not venv.package_metadata:
         return (
             f"   {red(bold(venv_dir.name))} has missing internal pipx metadata.\n"

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -128,6 +128,7 @@ def _symlink_package_apps(
             )
 
 
+# TODO: 20200914 Error messages here need to refer to suffix also
 def get_package_summary(
     path: Path,
     *,

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -130,13 +130,13 @@ def _symlink_package_apps(
 
 # TODO: 20200914 Error messages here need to refer to suffix also
 def get_package_summary(
-    path: Path,
+    venv_dir: Path,
     *,
     package: str = None,
     new_install: bool = False,
     include_injected: bool = False,
 ) -> str:
-    venv = Venv(path)
+    venv = Venv(venv_dir)
     python_path = venv.python_path.resolve()
 
     if package is None:
@@ -145,17 +145,19 @@ def get_package_summary(
     package_metadata = venv.package_metadata[package]
 
     if not python_path.is_file():
-        return f"   package {red(bold(package))} has invalid interpreter {str(python_path)}"
+        return (
+            f"   {red(bold(venv_dir.name))} has invalid interpreter {str(python_path)}"
+        )
     if not venv.package_metadata:
         return (
-            f"   package {red(bold(package))} has missing internal pipx metadata.\n"
+            f"   {red(bold(venv_dir.name))} has missing internal pipx metadata.\n"
             f"       It was likely installed using a pipx version before 0.15.0.0.\n"
             f"       Please uninstall and install this package, or reinstall-all to fix."
         )
 
     if package_metadata.package_version is None:
         not_installed = red("is not installed")
-        return f"   package {bold(package)} {not_installed} in the venv {str(path)}"
+        return f"   package {bold(package)} {not_installed} in the venv {venv_dir.name}"
 
     apps = package_metadata.apps + package_metadata.apps_of_dependencies
     exposed_app_paths = _get_exposed_app_paths_for_package(

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -128,7 +128,6 @@ def _symlink_package_apps(
             )
 
 
-# TODO: 20200914 Error messages here need to refer to suffix also
 def get_package_summary(
     venv_dir: Path,
     *,

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -41,7 +41,6 @@ def inject(
             "    It was likely installed using a pipx version before 0.15.0.0.\n"
             f"    Please uninstall and install {venv_dir.name!r}, or reinstall-all to fix."
         )
-        return
 
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -34,6 +34,15 @@ def inject(
 
     venv = Venv(venv_dir, verbose=verbose)
 
+    if not venv.package_metadata:
+        raise PipxError(
+            f"Can't inject {package_spec!r} into Virtual Environment {venv_dir.name!r}.\n"
+            f"    {venv_dir.name!r} has missing internal pipx metadata.\n"
+            "    It was likely installed using a pipx version before 0.15.0.0.\n"
+            f"    Please uninstall and install {venv_dir.name!r}, or reinstall-all to fix."
+        )
+        return
+
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
     if package_name is None:

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -17,7 +17,7 @@ def install(
     *,
     force: bool,
     include_dependencies: bool,
-    suffix: Optional[str] = None,
+    suffix: str = "",
 ):
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
@@ -28,7 +28,7 @@ def install(
     if venv_dir is None:
         venv_container = VenvContainer(constants.PIPX_LOCAL_VENVS)
         venv_dir = venv_container.get_venv_dir(package_name)
-        if suffix is not None:
+        if suffix != "":
             venv_dir = venv_dir.parent / f"{venv_dir.stem}{suffix}"
 
     try:
@@ -57,7 +57,7 @@ def install(
             include_dependencies=include_dependencies,
             include_apps=True,
             is_main_package=True,
-            suffix=suffix or "",
+            suffix=suffix,
         )
         run_post_install_actions(
             venv,

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -20,7 +20,7 @@ def install(
     suffix: Optional[str] = None,
 ):
     """ TODO: Description:
-                Create venv_name of package_name+suffix
+                Create venv_dir.name of package_name+suffix
                 Install package_name using spec package_or_url
     """
     # package_spec is anything pip-installable, including package_name, vcs spec,
@@ -35,8 +35,6 @@ def install(
         if suffix is not None:
             venv_dir = venv_dir.parent / f"{venv_dir.stem}{suffix}"
 
-    venv_name = venv_dir.name
-
     try:
         exists = venv_dir.exists() and next(venv_dir.iterdir())
     except StopIteration:
@@ -47,7 +45,7 @@ def install(
             print(f"Installing to existing directory {str(venv_dir)!r}")
         else:
             print(
-                f"{venv_name!r} already seems to be installed. "
+                f"{venv_dir.name!r} already seems to be installed. "
                 f"Not modifying existing installation in {str(venv_dir)!r}. "
                 "Pass '--force' to force installation."
             )

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -8,7 +8,6 @@ from pipx.venv import Venv, VenvContainer
 
 def install(
     venv_dir: Optional[Path],
-    package_name: Optional[str],
     package_spec: str,
     local_bin_dir: Path,
     python: str,
@@ -22,19 +21,21 @@ def install(
 ):
     """ TODO: Description:
                 Create venv_name of package_name+suffix
-                Install package_name using package_or_url
+                Install package_name using spec package_or_url
     """
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
-    # Determine package_name to properly name venv directory.
-    if venv_dir is None or package_name is None:
-        package_name = package_name_from_spec(
-            package_spec, python, pip_args=pip_args, verbose=verbose
-        )
+
+    package_name = package_name_from_spec(
+        package_spec, python, pip_args=pip_args, verbose=verbose
+    )
+    if venv_dir is None:
         venv_container = VenvContainer(constants.PIPX_LOCAL_VENVS)
         venv_dir = venv_container.get_venv_dir(package_name)
         if suffix is not None:
             venv_dir = venv_dir.parent / f"{venv_dir.stem}{suffix}"
+
+    venv_name = venv_dir.name
 
     try:
         exists = venv_dir.exists() and next(venv_dir.iterdir())
@@ -46,7 +47,7 @@ def install(
             print(f"Installing to existing directory {str(venv_dir)!r}")
         else:
             print(
-                f"{package_name!r} already seems to be installed. "
+                f"{venv_name!r} already seems to be installed. "
                 f"Not modifying existing installation in {str(venv_dir)!r}. "
                 "Pass '--force' to force installation."
             )

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -19,10 +19,6 @@ def install(
     include_dependencies: bool,
     suffix: Optional[str] = None,
 ):
-    """ TODO: Description:
-                Create venv_dir.name of package_name+suffix
-                Install package_name using spec package_or_url
-    """
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
 

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -8,6 +8,7 @@ from pipx.venv import Venv, VenvContainer
 
 def install(
     venv_dir: Optional[Path],
+    package_name: Optional[str],
     package_spec: str,
     local_bin_dir: Path,
     python: str,
@@ -22,9 +23,10 @@ def install(
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
 
-    package_name = package_name_from_spec(
-        package_spec, python, pip_args=pip_args, verbose=verbose
-    )
+    if package_name is None:
+        package_name = package_name_from_spec(
+            package_spec, python, pip_args=pip_args, verbose=verbose
+        )
     if venv_dir is None:
         venv_container = VenvContainer(constants.PIPX_LOCAL_VENVS)
         venv_dir = venv_container.get_venv_dir(package_name)

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -20,6 +20,10 @@ def install(
     include_dependencies: bool,
     suffix: Optional[str] = None,
 ):
+    """ TODO: Description:
+                Create venv_name of package_name+suffix
+                Install package_name using package_or_url
+    """
     # package_spec is anything pip-installable, including package_name, vcs spec,
     #   zip file, or tar.gz file.
     # Determine package_name to properly name venv directory.

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -24,6 +24,7 @@ def reinstall(
     # install main package first
     install(
         venv_dir,
+        venv.main_package_name,
         package_or_url,
         local_bin_dir,
         python,

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -17,7 +17,6 @@ def reinstall(
     if venv.pipx_metadata.main_package.package_or_url is not None:
         package_or_url = venv.pipx_metadata.main_package.package_or_url
     else:
-        # TODO: this should be venv.pipx_metadata.main_package.package
         package_or_url = venv_dir.name
 
     uninstall(venv_dir, local_bin_dir, verbose)

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -10,16 +10,16 @@ from pipx.venv import Venv, VenvContainer
 
 
 def reinstall(
-    *, venv_dir: Path, venv_name: str, local_bin_dir: Path, python: str, verbose: bool,
+    *, venv_dir: Path, local_bin_dir: Path, python: str, verbose: bool,
 ):
     venv = Venv(venv_dir, verbose=verbose)
 
     if venv.pipx_metadata.main_package.package_or_url is not None:
         package_or_url = venv.pipx_metadata.main_package.package_or_url
     else:
-        package_or_url = venv_name
+        package_or_url = venv_dir.name
 
-    uninstall(venv_dir, venv_name, local_bin_dir, verbose)
+    uninstall(venv_dir, venv_dir.name, local_bin_dir, verbose)
 
     # install main package first
     install(
@@ -43,7 +43,7 @@ def reinstall(
             # This should never happen, but package_or_url is type
             #   Optional[str] so mypy thinks it could be None
             raise PipxError(
-                f"Internal Error injecting package {injected_package} into {venv_name}"
+                f"Internal Error injecting package {injected_package} into {venv_dir.name}"
             )
         inject(
             venv_dir,
@@ -67,20 +67,18 @@ def reinstall_all(
 ):
     failed: List[str] = []
     for venv_dir in venv_container.iter_venv_dirs():
-        venv_name = venv_dir.name
-        if venv_name in skip:
+        if venv_dir.name in skip:
             continue
         try:
             reinstall(
                 venv_dir=venv_dir,
-                venv_name=venv_name,
                 local_bin_dir=local_bin_dir,
                 python=python,
                 verbose=verbose,
             )
         except PipxError as e:
             print(e, file=sys.stderr)
-            failed.append(venv_name)
+            failed.append(venv_dir.name)
     if len(failed) > 0:
         raise PipxError(
             f"The following package(s) failed to reinstall: {', '.join(failed)}"

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -1,6 +1,6 @@
+import sys
 from pathlib import Path
 from typing import List
-import sys
 
 from pipx.commands.inject import inject
 from pipx.commands.install import install
@@ -10,21 +10,21 @@ from pipx.venv import Venv, VenvContainer
 
 
 def reinstall(
-    *, venv_dir: Path, package: str, local_bin_dir: Path, python: str, verbose: bool,
+    *, venv_dir: Path, venv_name: str, local_bin_dir: Path, python: str, verbose: bool,
 ):
     venv = Venv(venv_dir, verbose=verbose)
 
     if venv.pipx_metadata.main_package.package_or_url is not None:
         package_or_url = venv.pipx_metadata.main_package.package_or_url
     else:
-        package_or_url = package
+        package_or_url = venv_name
 
-    uninstall(venv_dir, package, local_bin_dir, verbose)
+    uninstall(venv_dir, venv_name, local_bin_dir, verbose)
 
     # install main package first
     install(
         venv_dir,
-        package,
+        venv_name,
         package_or_url,
         local_bin_dir,
         python,
@@ -44,7 +44,7 @@ def reinstall(
             # This should never happen, but package_or_url is type
             #   Optional[str] so mypy thinks it could be None
             raise PipxError(
-                f"Internal Error injecting package {injected_package} into {package}"
+                f"Internal Error injecting package {injected_package} into {venv_name}"
             )
         inject(
             venv_dir,
@@ -68,20 +68,20 @@ def reinstall_all(
 ):
     failed: List[str] = []
     for venv_dir in venv_container.iter_venv_dirs():
-        package = venv_dir.name
-        if package in skip:
+        venv_name = venv_dir.name
+        if venv_name in skip:
             continue
         try:
             reinstall(
                 venv_dir=venv_dir,
-                package=package,
+                venv_name=venv_name,
                 local_bin_dir=local_bin_dir,
                 python=python,
                 verbose=verbose,
             )
         except PipxError as e:
             print(e, file=sys.stderr)
-            failed.append(package)
+            failed.append(venv_name)
     if len(failed) > 0:
         raise PipxError(
             f"The following package(s) failed to reinstall: {', '.join(failed)}"

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -19,7 +19,7 @@ def reinstall(
     else:
         package_or_url = venv_dir.name
 
-    uninstall(venv_dir, venv_dir.name, local_bin_dir, verbose)
+    uninstall(venv_dir, local_bin_dir, verbose)
 
     # install main package first
     install(

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -17,7 +17,7 @@ def reinstall(
     if venv.pipx_metadata.main_package.package_or_url is not None:
         package_or_url = venv.pipx_metadata.main_package.package_or_url
     else:
-        package_or_url = venv_dir.name
+        package_or_url = venv.main_package_name
 
     uninstall(venv_dir, local_bin_dir, verbose)
 

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -24,7 +24,6 @@ def reinstall(
     # install main package first
     install(
         venv_dir,
-        venv_name,
         package_or_url,
         local_bin_dir,
         python,

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -32,6 +32,7 @@ def reinstall(
         verbose,
         force=True,
         include_dependencies=venv.pipx_metadata.main_package.include_dependencies,
+        suffix=venv.pipx_metadata.main_package.suffix,
     )
 
     # now install injected packages

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -17,6 +17,7 @@ def reinstall(
     if venv.pipx_metadata.main_package.package_or_url is not None:
         package_or_url = venv.pipx_metadata.main_package.package_or_url
     else:
+        # TODO: this should be venv.pipx_metadata.main_package.package
         package_or_url = venv_dir.name
 
     uninstall(venv_dir, local_bin_dir, verbose)

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -13,11 +13,10 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool):
     """Uninstall entire venv_dir, including main package and all injected
     packages.
     """
-    venv_name = venv_dir.name
     if not venv_dir.exists():
-        print(f"Nothing to uninstall for {venv_name} {sleep}")
+        print(f"Nothing to uninstall for {venv_dir.name} {sleep}")
         # TODO: is the following correct?  Shouldn't there be multiple apps?
-        app = which(venv_name)
+        app = which(venv_dir.name)
         if app:
             print(
                 f"{hazard}  Note: '{app}' still exists on your system and is on your PATH"
@@ -36,9 +35,9 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool):
         # fallback if not metadata from pipx_metadata.json
         if venv.python_path.is_file():
             # has a valid python interpreter and can get metadata about the package
-            # TODO: this should be a real package name, not the venv_name
+            # In pre-metadata-pipx venv_dir.name is name of main package
             metadata = venv.get_venv_metadata_for_package(
-                venv_name
+                venv_dir.name
             )  # TODO: this should fail for suffix
             app_paths = metadata.app_paths
             for dep_paths in metadata.app_paths_of_dependencies.values():
@@ -72,7 +71,7 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool):
                     symlink.unlink()
 
     rmdir(venv_dir)
-    print(f"uninstalled {venv_name}! {stars}")
+    print(f"uninstalled {venv_dir.name}! {stars}")
 
 
 def uninstall_all(venv_container: VenvContainer, local_bin_dir: Path, verbose: bool):

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -15,9 +15,8 @@ def uninstall(venv_dir: Path, venv_name: str, local_bin_dir: Path, verbose: bool
     """
     if not venv_dir.exists():
         print(f"Nothing to uninstall for {venv_name} {sleep}")
-        app = which(
-            venv_name
-        )  # TODO: is this correct?  Shouldn't there be multiple apps?
+        # TODO: is the following correct?  Shouldn't there be multiple apps?
+        app = which(venv_name)
         if app:
             print(
                 f"{hazard}  Note: '{app}' still exists on your system and is on your PATH"

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -15,7 +15,6 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool):
     """
     if not venv_dir.exists():
         print(f"Nothing to uninstall for {venv_dir.name} {sleep}")
-        # TODO: is the following correct?  Shouldn't there be multiple apps?
         app = which(venv_dir.name)
         if app:
             print(

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -2,21 +2,22 @@ import logging
 from pathlib import Path
 from shutil import which
 from typing import List
-from pipx.util import WINDOWS, rmdir
-
 
 from pipx import constants
-from pipx.emojies import hazard, stars, sleep
+from pipx.emojies import hazard, sleep, stars
+from pipx.util import WINDOWS, rmdir
 from pipx.venv import Venv, VenvContainer
 
 
-def uninstall(venv_dir: Path, package: str, local_bin_dir: Path, verbose: bool):
+def uninstall(venv_dir: Path, venv_name: str, local_bin_dir: Path, verbose: bool):
     """Uninstall entire venv_dir, including main package and all injected
     packages.
     """
     if not venv_dir.exists():
-        print(f"Nothing to uninstall for {package} {sleep}")
-        app = which(package)
+        print(f"Nothing to uninstall for {venv_name} {sleep}")
+        app = which(
+            venv_name
+        )  # TODO: is this correct?  Shouldn't there be multiple apps?
         if app:
             print(
                 f"{hazard}  Note: '{app}' still exists on your system and is on your PATH"
@@ -35,7 +36,10 @@ def uninstall(venv_dir: Path, package: str, local_bin_dir: Path, verbose: bool):
         # fallback if not metadata from pipx_metadata.json
         if venv.python_path.is_file():
             # has a valid python interpreter and can get metadata about the package
-            metadata = venv.get_venv_metadata_for_package(package)
+            # TODO: is this redundant with venv.package_metadata[venv_name] ?
+            metadata = venv.get_venv_metadata_for_package(
+                venv_name
+            )  # TODO: this should fail for suffix
             app_paths = metadata.app_paths
             for dep_paths in metadata.app_paths_of_dependencies.values():
                 app_paths += dep_paths
@@ -43,7 +47,7 @@ def uninstall(venv_dir: Path, package: str, local_bin_dir: Path, verbose: bool):
             # Doesn't have a valid python interpreter. We'll take our best guess on what to uninstall
             # here based on symlink location. pipx doesn't use symlinks on windows, so this is for
             # non-windows only.
-            # The heuristic here is any symlink in ~/.local/bin pointing to .local/pipx/venvs/PACKAGE/bin
+            # The heuristic here is any symlink in ~/.local/bin pointing to .local/pipx/venvs/VENV_NAME/bin
             # should be uninstalled.
             if WINDOWS:
                 app_paths = []
@@ -68,10 +72,10 @@ def uninstall(venv_dir: Path, package: str, local_bin_dir: Path, verbose: bool):
                     symlink.unlink()
 
     rmdir(venv_dir)
-    print(f"uninstalled {package}! {stars}")
+    print(f"uninstalled {venv_name}! {stars}")
 
 
 def uninstall_all(venv_container: VenvContainer, local_bin_dir: Path, verbose: bool):
     for venv_dir in venv_container.iter_venv_dirs():
-        package = venv_dir.name
-        uninstall(venv_dir, package, local_bin_dir, verbose)
+        venv_name = venv_dir.name
+        uninstall(venv_dir, venv_name, local_bin_dir, verbose)

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -9,10 +9,11 @@ from pipx.util import WINDOWS, rmdir
 from pipx.venv import Venv, VenvContainer
 
 
-def uninstall(venv_dir: Path, venv_name: str, local_bin_dir: Path, verbose: bool):
+def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool):
     """Uninstall entire venv_dir, including main package and all injected
     packages.
     """
+    venv_name = venv_dir.name
     if not venv_dir.exists():
         print(f"Nothing to uninstall for {venv_name} {sleep}")
         # TODO: is the following correct?  Shouldn't there be multiple apps?
@@ -35,7 +36,7 @@ def uninstall(venv_dir: Path, venv_name: str, local_bin_dir: Path, verbose: bool
         # fallback if not metadata from pipx_metadata.json
         if venv.python_path.is_file():
             # has a valid python interpreter and can get metadata about the package
-            # TODO: is this redundant with venv.package_metadata[venv_name] ?
+            # TODO: this should be a real package name, not the venv_name
             metadata = venv.get_venv_metadata_for_package(
                 venv_name
             )  # TODO: this should fail for suffix
@@ -76,5 +77,4 @@ def uninstall(venv_dir: Path, venv_name: str, local_bin_dir: Path, verbose: bool
 
 def uninstall_all(venv_container: VenvContainer, local_bin_dir: Path, verbose: bool):
     for venv_dir in venv_container.iter_venv_dirs():
-        venv_name = venv_dir.name
-        uninstall(venv_dir, venv_name, local_bin_dir, verbose)
+        uninstall(venv_dir, local_bin_dir, verbose)

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -36,9 +36,7 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool):
         if venv.python_path.is_file():
             # has a valid python interpreter and can get metadata about the package
             # In pre-metadata-pipx venv_dir.name is name of main package
-            metadata = venv.get_venv_metadata_for_package(
-                venv_dir.name
-            )  # TODO: this should fail for suffix
+            metadata = venv.get_venv_metadata_for_package(venv_dir.name)
             app_paths = metadata.app_paths
             for dep_paths in metadata.app_paths_of_dependencies.values():
                 app_paths += dep_paths

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -105,6 +105,7 @@ def upgrade(
 def upgrade_all(
     venv_container: VenvContainer, verbose: bool, *, skip: List[str], force: bool
 ):
+    venv_error = False
     venvs_upgraded = 0
     num_packages = 0
     for venv_dir in venv_container.iter_venv_dirs():
@@ -125,9 +126,15 @@ def upgrade_all(
             )
 
         except Exception:
+            venv_error = True
             logging.error(f"Error encountered when upgrading {venv_dir.name}")
 
     if venvs_upgraded == 0:
         print(
             f"Versions did not change after running 'pip upgrade' for each package {sleep}"
+        )
+    if venv_error:
+        raise PipxError(
+            "Some packages encountered errors during upgrade.  "
+            "See specific error messages above."
         )

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -91,7 +91,6 @@ def upgrade(
         if upgrading_all:
             pass
         else:
-            # TODO: say package (display_name) is already at
             print(
                 f"{display_name} is already at latest version {old_version} (location: {str(venv_dir)})"
             )
@@ -106,18 +105,18 @@ def upgrade(
 def upgrade_all(
     venv_container: VenvContainer, verbose: bool, *, skip: List[str], force: bool
 ):
-    packages_upgraded = 0
+    venvs_upgraded = 0
     num_packages = 0
     for venv_dir in venv_container.iter_venv_dirs():
         num_packages += 1
         venv = Venv(venv_dir, verbose=verbose)
-        # TODO: package really should be suffixed venv name
-        package = venv.main_package_name
-        # TODO: 20200914 do we skip on package name or package+suffix?
-        if package in skip or "--editable" in venv.pipx_metadata.main_package.pip_args:
+        if (
+            venv_dir.name in skip
+            or "--editable" in venv.pipx_metadata.main_package.pip_args
+        ):
             continue
         try:
-            packages_upgraded += upgrade(
+            venvs_upgraded += upgrade(
                 venv_dir,
                 venv.pipx_metadata.main_package.pip_args,
                 verbose,
@@ -126,10 +125,9 @@ def upgrade_all(
             )
 
         except Exception:
-            # TODO: package really should be suffixed venv name
-            logging.error(f"Error encountered when upgrading {package}")
+            logging.error(f"Error encountered when upgrading {venv_dir.name}")
 
-    if packages_upgraded == 0:
+    if venvs_upgraded == 0:
         print(
             f"Versions did not change after running 'pip upgrade' for each package {sleep}"
         )

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -1,8 +1,6 @@
 import logging
-
 from pathlib import Path
 from typing import List
-
 
 from pipx import constants
 from pipx.colors import bold, red
@@ -39,8 +37,7 @@ def upgrade(
         )
         return 0
 
-    package_metadata = venv.get_package_metadata(package)
-    package = package_metadata.package or package
+    package_metadata = venv.package_metadata[package]
 
     if package_metadata.package_or_url is None:
         raise PipxError(f"Internal Error: package {package} has corrupt pipx metadata.")
@@ -67,8 +64,8 @@ def upgrade(
     )
     # TODO 20191026: upgrade injected packages also (Issue #79)
 
-    package_metadata = venv.get_package_metadata(package)
-    package = package_metadata.package or package
+    package_metadata = venv.package_metadata[package]
+
     display_name = f"{package_metadata.package}{package_metadata.suffix}"
     new_version = package_metadata.package_version
 
@@ -112,8 +109,9 @@ def upgrade_all(
     num_packages = 0
     for venv_dir in venv_container.iter_venv_dirs():
         num_packages += 1
-        package = venv_dir.name
         venv = Venv(venv_dir, verbose=verbose)
+        package = venv.main_package_name
+        # TODO: 20200914 do we skip on package name or package+suffix?
         if package in skip or "--editable" in venv.pipx_metadata.main_package.pip_args:
             continue
         try:

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -12,7 +12,6 @@ from pipx.venv import Venv, VenvContainer
 
 def upgrade(
     venv_dir: Path,
-    package: str,
     pip_args: List[str],
     verbose: bool,
     *,
@@ -28,6 +27,7 @@ def upgrade(
         )
 
     venv = Venv(venv_dir, verbose=verbose)
+    package = venv.main_package_name
 
     if not venv.package_metadata:
         print(
@@ -91,6 +91,7 @@ def upgrade(
         if upgrading_all:
             pass
         else:
+            # TODO: say package (display_name) is already at
             print(
                 f"{display_name} is already at latest version {old_version} (location: {str(venv_dir)})"
             )
@@ -110,6 +111,7 @@ def upgrade_all(
     for venv_dir in venv_container.iter_venv_dirs():
         num_packages += 1
         venv = Venv(venv_dir, verbose=verbose)
+        # TODO: package really should be suffixed venv name
         package = venv.main_package_name
         # TODO: 20200914 do we skip on package name or package+suffix?
         if package in skip or "--editable" in venv.pipx_metadata.main_package.pip_args:
@@ -117,7 +119,6 @@ def upgrade_all(
         try:
             packages_upgraded += upgrade(
                 venv_dir,
-                package,
                 venv.pipx_metadata.main_package.pip_args,
                 verbose,
                 upgrading_all=True,
@@ -125,6 +126,7 @@ def upgrade_all(
             )
 
         except Exception:
+            # TODO: package really should be suffixed venv name
             logging.error(f"Error encountered when upgrading {package}")
 
     if packages_upgraded == 0:

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -132,6 +132,6 @@ def upgrade_all(
         )
     if venv_error:
         raise PipxError(
-            "Some packages encountered errors during upgrade.  "
+            "Some packages encountered errors during upgrade. "
             "See specific error messages above."
         )

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -69,7 +69,6 @@ def upgrade(
     expose_apps_globally(
         constants.LOCAL_BIN_DIR,
         package_metadata.app_paths,
-        package,
         force=force,
         suffix=package_metadata.suffix,
     )
@@ -79,7 +78,6 @@ def upgrade(
             expose_apps_globally(
                 constants.LOCAL_BIN_DIR,
                 app_paths,
-                package,
                 force=force,
                 suffix=package_metadata.suffix,
             )

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -66,6 +66,7 @@ packages. 'sudo' is not required to do this.
 pipx install PACKAGE_NAME
 pipx install --python PYTHON PACKAGE_NAME
 pipx install VCS_URL
+pipx install ./LOCAL_PATH
 pipx install ZIP_FILE
 pipx install TAR_GZ_FILE
 
@@ -116,9 +117,6 @@ def run_pipx_command(args: argparse.Namespace):  # noqa: C901
 
     venv_container = VenvContainer(constants.PIPX_LOCAL_VENVS)
 
-    # TODO:
-    #   package means a pypi package name for install
-    #   package means a venv_name (incl. any suffix) for other commands
     if "package" in args:
         package = args.package
         if urllib.parse.urlparse(package).scheme:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -116,6 +116,9 @@ def run_pipx_command(args: argparse.Namespace):  # noqa: C901
 
     venv_container = VenvContainer(constants.PIPX_LOCAL_VENVS)
 
+    # TODO:
+    #   package means a pypi package name for install
+    #   package means a venv_name for other commands (possibly incl. suffix)
     if "package" in args:
         package = args.package
         if urllib.parse.urlparse(package).scheme:
@@ -183,7 +186,7 @@ def run_pipx_command(args: argparse.Namespace):  # noqa: C901
     elif args.command == "list":
         return commands.list_packages(venv_container, args.include_injected)
     elif args.command == "uninstall":
-        return commands.uninstall(venv_dir, package, constants.LOCAL_BIN_DIR, verbose)
+        return commands.uninstall(venv_dir, constants.LOCAL_BIN_DIR, verbose)
     elif args.command == "uninstall-all":
         return commands.uninstall_all(venv_container, constants.LOCAL_BIN_DIR, verbose)
     elif args.command == "upgrade-all":

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -151,6 +151,7 @@ def run_pipx_command(args: argparse.Namespace):  # noqa: C901
     elif args.command == "install":
         return commands.install(
             None,
+            None,
             args.package_spec,
             constants.LOCAL_BIN_DIR,
             args.python,

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -263,7 +263,11 @@ def _add_install(subparsers):
         help="Modify existing virtual environment and files in PIPX_BIN_DIR",
     )
     p.add_argument(
-        "--suffix", help="Optional suffix for virtual environment and executable names"
+        "--suffix",
+        help=(
+            "Optional suffix for virtual environment and executable names."
+            "NOTE: The suffix feature is experimental and subject to change."
+        ),
     )
     p.add_argument(
         "--python",

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -150,7 +150,6 @@ def run_pipx_command(args: argparse.Namespace):  # noqa: C901
     elif args.command == "install":
         return commands.install(
             None,
-            None,
             args.package_spec,
             constants.LOCAL_BIN_DIR,
             args.python,

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -179,7 +179,7 @@ def run_pipx_command(args: argparse.Namespace):  # noqa: C901
             )
     elif args.command == "upgrade":
         return commands.upgrade(
-            venv_dir, package, pip_args, verbose, upgrading_all=False, force=args.force
+            venv_dir, pip_args, verbose, upgrading_all=False, force=args.force
         )
     elif args.command == "list":
         return commands.list_packages(venv_container, args.include_injected)
@@ -282,6 +282,7 @@ def _add_inject(subparsers, autocomplete_list_of_installed_packages):
         help="Install packages into an existing Virtual Environment",
         description="Installs packages to an existing pipx-managed virtual environment.",
     )
+    # TODO: 20200914 specify package_with_suffix
     p.add_argument(
         "package",
         help="Name of the existing pipx-managed Virtual Environment to inject into",
@@ -313,6 +314,7 @@ def _add_upgrade(subparsers, autocomplete_list_of_installed_packages):
         help="Upgrade a package",
         description="Upgrade a package in a pipx-managed Virtual Environment by running 'pip install --upgrade PACKAGE'",
     )
+    # TODO: 20200914 specify package_with_suffix
     p.add_argument("package").completer = autocomplete_list_of_installed_packages
     p.add_argument(
         "--force",
@@ -348,6 +350,7 @@ def _add_uninstall(subparsers, autocomplete_list_of_installed_packages):
         help="Uninstall a package",
         description="Uninstalls a pipx-managed Virtual Environment by deleting it and any files that point to its apps.",
     )
+    # TODO: 20200914 specify package_with_suffix
     p.add_argument("package").completer = autocomplete_list_of_installed_packages
     p.add_argument("--verbose", action="store_true")
 
@@ -467,6 +470,7 @@ def _add_runpip(subparsers, autocomplete_list_of_installed_packages):
         help="Run pip in an existing pipx-managed Virtual Environment",
         description="Run pip in an existing pipx-managed Virtual Environment",
     )
+    # TODO: 20200914 specify package_with_suffix
     p.add_argument(
         "package",
         help="Name of the existing pipx-managed Virtual Environment to run pip in",

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -264,6 +264,7 @@ def _add_install(subparsers):
     )
     p.add_argument(
         "--suffix",
+        default="",
         help=(
             "Optional suffix for virtual environment and executable names. "
             "NOTE: The suffix feature is experimental and subject to change."

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -118,7 +118,7 @@ def run_pipx_command(args: argparse.Namespace):  # noqa: C901
 
     # TODO:
     #   package means a pypi package name for install
-    #   package means a venv_name for other commands (possibly incl. suffix)
+    #   package means a venv_name (incl. any suffix) for other commands
     if "package" in args:
         package = args.package
         if urllib.parse.urlparse(package).scheme:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -286,7 +286,6 @@ def _add_inject(subparsers, autocomplete_list_of_installed_packages):
         help="Install packages into an existing Virtual Environment",
         description="Installs packages to an existing pipx-managed virtual environment.",
     )
-    # TODO: 20200914 specify package_with_suffix
     p.add_argument(
         "package",
         help="Name of the existing pipx-managed Virtual Environment to inject into",
@@ -318,7 +317,6 @@ def _add_upgrade(subparsers, autocomplete_list_of_installed_packages):
         help="Upgrade a package",
         description="Upgrade a package in a pipx-managed Virtual Environment by running 'pip install --upgrade PACKAGE'",
     )
-    # TODO: 20200914 specify package_with_suffix
     p.add_argument("package").completer = autocomplete_list_of_installed_packages
     p.add_argument(
         "--force",
@@ -353,7 +351,6 @@ def _add_uninstall(subparsers, autocomplete_list_of_installed_packages):
         help="Uninstall a package",
         description="Uninstalls a pipx-managed Virtual Environment by deleting it and any files that point to its apps.",
     )
-    # TODO: 20200914 specify package_with_suffix
     p.add_argument("package").completer = autocomplete_list_of_installed_packages
     p.add_argument("--verbose", action="store_true")
 
@@ -473,7 +470,6 @@ def _add_runpip(subparsers, autocomplete_list_of_installed_packages):
         help="Run pip in an existing pipx-managed Virtual Environment",
         description="Run pip in an existing pipx-managed Virtual Environment",
     )
-    # TODO: 20200914 specify package_with_suffix
     p.add_argument(
         "package",
         help="Name of the existing pipx-managed Virtual Environment to run pip in",

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -265,7 +265,7 @@ def _add_install(subparsers):
     p.add_argument(
         "--suffix",
         help=(
-            "Optional suffix for virtual environment and executable names."
+            "Optional suffix for virtual environment and executable names. "
             "NOTE: The suffix feature is experimental and subject to change."
         ),
     )

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -333,8 +333,7 @@ def _add_upgrade(subparsers, autocomplete_list_of_installed_packages):
 def _add_upgrade_all(subparsers):
     p = subparsers.add_parser(
         "upgrade-all",
-        help="Upgrade all packages. "
-        "Runs `pip install -U <pkgname>` for each package.",
+        help="Upgrade all packages. Runs `pip install -U <pkgname>` for each package.",
         description="Upgrades all packages within their virtual environments by running 'pip install --upgrade PACKAGE'",
     )
 

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -158,8 +158,6 @@ class PipxMetadata:
             pass
 
     def read(self, verbose: bool = False) -> None:
-        # TODO: if no file is present or old version, try to deduce what a modern
-        #       metadata would look like and recreate
         try:
             with open(self.venv_dir / PIPX_INFO_FILENAME, "r") as pipx_metadata_fh:
                 self.from_dict(

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -1,11 +1,10 @@
 import json
 import logging
-from pathlib import Path
 import textwrap
-from typing import List, Dict, NamedTuple, Any, Optional
+from pathlib import Path
+from typing import Any, Dict, List, NamedTuple, Optional
 
 from pipx.util import PipxError
-
 
 PIPX_INFO_FILENAME = "pipx_metadata.json"
 
@@ -147,6 +146,8 @@ class PipxMetadata:
             pass
 
     def read(self, verbose: bool = False) -> None:
+        # TODO: if no file is present or old version, try to deduce what a modern
+        #       metadata would look like and recreate
         try:
             with open(self.venv_dir / PIPX_INFO_FILENAME, "r") as pipx_metadata_fh:
                 self.from_dict(

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -112,7 +112,9 @@ class PipxMetadata:
             return metadata_dict
         else:
             raise PipxError(
-                f"{self.venv_dir.name}: Unknown metadata version {metadata_dict['pipx_metadata_version']}"
+                f"{self.venv_dir.name}: Unknown metadata version "
+                f"{metadata_dict['pipx_metadata_version']}. "
+                "Perhaps it was installed with a later version of pipx."
             )
 
     def from_dict(self, input_dict: Dict[str, Any]) -> None:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -31,9 +31,9 @@ assert venv_metadata_inspector_raw is not None, (
 VENV_METADATA_INSPECTOR = venv_metadata_inspector_raw.decode("utf-8")
 
 
-# TODO: 20200914 here we will never deal with suffix, or venv_name
-#   only with the directory name of the venv in __init__,
-#   and actual package names and package_or_url in methods
+# TODO: 20200914 here we will never deal with suffix (except to write metadata),
+#   or venv_name (only with the directory name of the venv in __init__),
+#   Typically using real package names and package_or_url in methods
 
 
 class VenvContainer:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -124,6 +124,8 @@ class Venv:
     @property
     def main_package_name(self) -> str:
         if self.pipx_metadata.main_package.package is None:
+            # This is OK, because if no metadata, we are pipx < v0.15.0.0 and
+            #   venv_name==main_package_name
             return self.root.name
         else:
             return self.pipx_metadata.main_package.package

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -308,7 +308,7 @@ class Venv:
             apps_of_dependencies=venv_package_metadata.apps_of_dependencies,
             app_paths_of_dependencies=venv_package_metadata.app_paths_of_dependencies,
             package_version=venv_package_metadata.package_version,
-            suffix=suffix or "",  # TODO 20200917: is this 'or' necessary?
+            suffix=suffix,
         )
         if is_main_package:
             self.pipx_metadata.main_package = package_info
@@ -371,7 +371,7 @@ class Venv:
             include_dependencies=include_dependencies,
             include_apps=include_apps,
             is_main_package=is_main_package,
-            suffix=suffix or "",
+            suffix=suffix,
         )
 
     def _run_pip(self, cmd: List[str]) -> int:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -129,10 +129,9 @@ class Venv:
     @property
     def main_package_name(self) -> str:
         if self.pipx_metadata.main_package.package is None:
-            raise PipxError(
-                "Internal error: main_package_name requested but None found."
-            )
-        return self.pipx_metadata.main_package.package
+            return self.root.name
+        else:
+            return self.pipx_metadata.main_package.package
 
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
         with animate("creating virtual environment", self.do_animation):

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -31,6 +31,11 @@ assert venv_metadata_inspector_raw is not None, (
 VENV_METADATA_INSPECTOR = venv_metadata_inspector_raw.decode("utf-8")
 
 
+# TODO: 20200914 here we will never deal with suffix, or venv_name
+#   only with the directory name of the venv in __init__,
+#   and actual package names and package_or_url in methods
+
+
 class VenvContainer:
     """A collection of venvs managed by pipx.
     """

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -31,11 +31,6 @@ assert venv_metadata_inspector_raw is not None, (
 VENV_METADATA_INSPECTOR = venv_metadata_inspector_raw.decode("utf-8")
 
 
-# TODO: 20200914 here we will never deal with suffix (except to write metadata),
-#   or venv_name (only with the directory name of the venv in __init__),
-#   Typically using real package names and package_or_url in methods
-
-
 class VenvContainer:
     """A collection of venvs managed by pipx.
     """

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -2,7 +2,7 @@ import json
 import logging
 import pkgutil
 from pathlib import Path
-from typing import Dict, Generator, List, NamedTuple, Optional, Set
+from typing import Dict, Generator, List, NamedTuple, Set
 
 from pipx.animate import animate
 from pipx.constants import PIPX_SHARED_PTH
@@ -121,17 +121,13 @@ class Venv:
             ] = self.pipx_metadata.main_package
         return return_dict
 
-    def get_package_metadata(self, package: Optional[str] = None) -> PackageInfo:
-        if package is None or package == self.root.name:
-            return self.pipx_metadata.main_package
-
-        try:
-            return self.package_metadata[package]
-        except KeyError:
+    @property
+    def main_package_name(self) -> str:
+        if self.pipx_metadata.main_package.package is None:
             raise PipxError(
-                f"Package is not installed. Expected to find package {package}, "
-                "but it does not exist."
+                "Internal error: main_package_name requested but None found."
             )
+        return self.pipx_metadata.main_package.package
 
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
         with animate("creating virtual environment", self.do_animation):

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -308,7 +308,7 @@ class Venv:
             apps_of_dependencies=venv_package_metadata.apps_of_dependencies,
             app_paths_of_dependencies=venv_package_metadata.app_paths_of_dependencies,
             package_version=venv_package_metadata.package_version,
-            suffix=suffix or "",
+            suffix=suffix or "",  # TODO 20200917: is this 'or' necessary?
         )
         if is_main_package:
             self.pipx_metadata.main_package = package_info

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -76,6 +76,10 @@ def _mock_legacy_package_info(
 
 
 def mock_legacy_venv(venv_name: str, metadata_version: Optional[str] = None) -> None:
+    """Convert a venv installed with the most recent pipx to look like
+    one with a previous metadata version.
+    metadata_version=None refers to no metadata file (pipx pre-0.15.0.0)
+    """
     venv_dir = Path(constants.PIPX_LOCAL_VENVS) / venv_name
 
     if metadata_version is None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,10 +1,34 @@
-from shutil import which
+import json
+import os
 import subprocess
 import sys
-from typing import List
+from pathlib import Path
+from shutil import which
+from typing import Any, Dict, List, Optional
 from unittest import mock
 
-from pipx import main
+from pipx import constants, main, pipx_metadata_file
+
+MOCK_PIPXMETADATA_0_1: Dict[str, Any] = {
+    "main_package": None,
+    "python_version": None,
+    "venv_args": [],
+    "injected_packages": {},
+    "pipx_metadata_version": "0.1",
+}
+
+MOCK_PACKAGE_INFO_0_1: Dict[str, Any] = {
+    "package": None,
+    "package_or_url": None,
+    "pip_args": [],
+    "include_dependencies": False,
+    "include_apps": True,
+    "apps": [],
+    "app_paths": [],
+    "apps_of_dependencies": [],
+    "app_paths_of_dependencies": {},
+    "package_version": "",
+}
 
 
 def assert_not_in_virtualenv():
@@ -16,7 +40,7 @@ def run_pipx_cli(pipx_args: List[str]):
         return main.cli()
 
 
-def which_python(python_exe):
+def which_python(python_exe: str) -> Optional[str]:
     try:
         pyenv_which = subprocess.run(
             ["pyenv", "which", python_exe],
@@ -32,3 +56,61 @@ def which_python(python_exe):
     else:
         # pyenv on system, but pyenv has no path to python_exe
         return None
+
+
+def mock_legacy_package_info(
+    modern_package_info: Dict[str, Any], metadata_version: str
+) -> Dict[str, Any]:
+    if metadata_version == "0.1":
+        mock_package_info_template = MOCK_PACKAGE_INFO_0_1
+    else:
+        assert False
+
+    mock_package_info = {}
+    for key in mock_package_info_template:
+        mock_package_info[key] = modern_package_info[key]
+
+    return mock_package_info
+
+
+def mock_legacy_venv(venv_name: str, metadata_version: Optional[str] = None) -> None:
+    venv_dir = Path(constants.PIPX_LOCAL_VENVS) / venv_name
+
+    if metadata_version is None:
+        os.remove(venv_dir / "pipx_metadata.json")
+        return
+
+    modern_metadata = pipx_metadata_file.PipxMetadata(venv_dir).to_dict()
+
+    if metadata_version == "0.1":
+        mock_pipx_metadata_template = MOCK_PIPXMETADATA_0_1
+    else:
+        assert False
+
+    # Convert to mock old metadata
+    mock_pipx_metadata = {}
+    for key in mock_pipx_metadata_template:
+        if key == "main_package":
+            mock_pipx_metadata[key] = mock_legacy_package_info(
+                modern_metadata[key], metadata_version=metadata_version
+            )
+        if key == "injected_packages":
+            for injected in modern_metadata[key]:
+                mock_pipx_metadata[key][injected] = mock_legacy_package_info(
+                    modern_metadata[key][injected], metadata_version=metadata_version
+                )
+        else:
+            mock_pipx_metadata[key] = modern_metadata[key]
+    mock_pipx_metadata["pipx_metadata_version"] = mock_pipx_metadata_template[
+        "pipx_metadata_version"
+    ]
+
+    # replicate pipx_metadata_file.PipxMetadata.write()
+    with open(venv_dir / "pipx_metadata.json", "w") as pipx_metadata_fh:
+        json.dump(
+            mock_pipx_metadata,
+            pipx_metadata_fh,
+            indent=4,
+            sort_keys=True,
+            cls=pipx_metadata_file.JsonEncoderHandlesPath,
+        )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -58,7 +58,7 @@ def which_python(python_exe: str) -> Optional[str]:
         return None
 
 
-def mock_legacy_package_info(
+def _mock_legacy_package_info(
     modern_package_info: Dict[str, Any], metadata_version: str
 ) -> Dict[str, Any]:
     if metadata_version == "0.1":
@@ -95,12 +95,12 @@ def mock_legacy_venv(venv_name: str, metadata_version: Optional[str] = None) -> 
     mock_pipx_metadata = {}
     for key in mock_pipx_metadata_template:
         if key == "main_package":
-            mock_pipx_metadata[key] = mock_legacy_package_info(
+            mock_pipx_metadata[key] = _mock_legacy_package_info(
                 modern_metadata[key], metadata_version=metadata_version
             )
         if key == "injected_packages":
             for injected in modern_metadata[key]:
-                mock_pipx_metadata[key][injected] = mock_legacy_package_info(
+                mock_pipx_metadata[key][injected] = _mock_legacy_package_info(
                     modern_metadata[key][injected], metadata_version=metadata_version
                 )
         else:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -31,11 +31,11 @@ MOCK_PACKAGE_INFO_0_1: Dict[str, Any] = {
 }
 
 
-def assert_not_in_virtualenv():
+def assert_not_in_virtualenv() -> None:
     assert not hasattr(sys, "real_prefix"), "Tests cannot run under virtualenv"
 
 
-def run_pipx_cli(pipx_args: List[str]):
+def run_pipx_cli(pipx_args: List[str]) -> int:
     with mock.patch.object(sys, "argv", ["pipx"] + pipx_args):
         return main.cli()
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -99,6 +99,7 @@ def mock_legacy_venv(venv_name: str, metadata_version: Optional[str] = None) -> 
                 modern_metadata[key], metadata_version=metadata_version
             )
         if key == "injected_packages":
+            mock_pipx_metadata[key] = {}
             for injected in modern_metadata[key]:
                 mock_pipx_metadata[key][injected] = _mock_legacy_package_info(
                     modern_metadata[key][injected], metadata_version=metadata_version

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -64,7 +64,9 @@ def mock_legacy_package_info(
     if metadata_version == "0.1":
         mock_package_info_template = MOCK_PACKAGE_INFO_0_1
     else:
-        assert False
+        raise Exception(
+            f"Internal Test Error: Unknown metadata_version={metadata_version}"
+        )
 
     mock_package_info = {}
     for key in mock_package_info_template:
@@ -85,7 +87,9 @@ def mock_legacy_venv(venv_name: str, metadata_version: Optional[str] = None) -> 
     if metadata_version == "0.1":
         mock_pipx_metadata_template = MOCK_PIPXMETADATA_0_1
     else:
-        assert False
+        raise Exception(
+            f"Internal Test Error: Unknown metadata_version={metadata_version}"
+        )
 
     # Convert to mock old metadata
     mock_pipx_metadata = {}

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -3,13 +3,13 @@ import pytest  # type: ignore
 from helpers import mock_legacy_venv, run_pipx_cli
 
 
-def test_simple(pipx_temp_env, capsys):
+def test_inject_simple(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["inject", "pycowsay", "black"])
 
 
 @pytest.mark.parametrize("metadata_version", [None, "0.1"])
-def test_simple_legacy_venv(pipx_temp_env, capsys, metadata_version):
+def test_inject_simple_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)
     assert not run_pipx_cli(["inject", "pycowsay", "black"])
@@ -21,7 +21,7 @@ def test_spec(pipx_temp_env, capsys):
 
 
 @pytest.mark.parametrize("with_suffix,", [(False,), (True,)])
-def test_include_apps(pipx_temp_env, capsys, with_suffix):
+def test_inject_include_apps(pipx_temp_env, capsys, with_suffix):
     install_args = []
     suffix = ""
 

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -15,7 +15,7 @@ def test_inject_simple_legacy_venv(pipx_temp_env, capsys, metadata_version):
     if metadata_version is not None:
         assert not run_pipx_cli(["inject", "pycowsay", "black"])
     else:
-        # No metadata is should end in PipxError with message
+        # no metadata in venv should result in PipxError with message
         assert run_pipx_cli(["inject", "pycowsay", "black"])
         assert "Please uninstall and install" in capsys.readouterr().err
 

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -1,10 +1,17 @@
 import pytest  # type: ignore
 
-from helpers import run_pipx_cli
+from helpers import mock_legacy_venv, run_pipx_cli
 
 
 def test_simple(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["inject", "pycowsay", "black"])
+
+
+@pytest.mark.parametrize("metadata_version", [None, "0.1"])
+def test_simple_legacy_venv(pipx_temp_env, capsys, metadata_version):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    mock_legacy_venv("pycowsay", metadata_version=metadata_version)
     assert not run_pipx_cli(["inject", "pycowsay", "black"])
 
 

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -12,7 +12,12 @@ def test_inject_simple(pipx_temp_env, capsys):
 def test_inject_simple_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)
-    assert not run_pipx_cli(["inject", "pycowsay", "black"])
+    if metadata_version is not None:
+        assert not run_pipx_cli(["inject", "pycowsay", "black"])
+    else:
+        # No metadata is should end in PipxError with message
+        assert run_pipx_cli(["inject", "pycowsay", "black"])
+        assert "Please uninstall and install" in capsys.readouterr().err
 
 
 def test_spec(pipx_temp_env, capsys):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -16,12 +16,12 @@ def test_missing_interpreter(pipx_temp_env, monkeypatch, capsys):
 
     assert not run_pipx_cli(["list"])
     captured = capsys.readouterr()
-    assert "pycowsay has invalid interpreter" not in captured.out
+    assert "package pycowsay has invalid interpreter" not in captured.out
 
     python_path.unlink()
     assert not run_pipx_cli(["list"])
     captured = capsys.readouterr()
-    assert "pycowsay has invalid interpreter" in captured.out
+    assert "package pycowsay has invalid interpreter" in captured.out
 
 
 def test_list_suffix(pipx_temp_env, monkeypatch, capsys):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -50,7 +50,7 @@ def test_list_suffix_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_ve
     suffix = "_x"
     assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])
     assert not run_pipx_cli(["list"])
-    mock_legacy_venv("pycowsay" + suffix, metadata_version=metadata_version)
+    mock_legacy_venv(f"pycowsay{suffix}", metadata_version=metadata_version)
 
     captured = capsys.readouterr()
     assert f"package pycowsay 0.0.0.1 (pycowsay{suffix})," in captured.out

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -16,12 +16,12 @@ def test_missing_interpreter(pipx_temp_env, monkeypatch, capsys):
 
     assert not run_pipx_cli(["list"])
     captured = capsys.readouterr()
-    assert "package pycowsay has invalid interpreter" not in captured.out
+    assert "pycowsay has invalid interpreter" not in captured.out
 
     python_path.unlink()
     assert not run_pipx_cli(["list"])
     captured = capsys.readouterr()
-    assert "package pycowsay has invalid interpreter" in captured.out
+    assert "pycowsay has invalid interpreter" in captured.out
 
 
 def test_list_suffix(pipx_temp_env, monkeypatch, capsys):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,4 +1,6 @@
-from helpers import run_pipx_cli
+import pytest  # type: ignore
+
+from helpers import mock_legacy_venv, run_pipx_cli
 from pipx import constants, util
 
 
@@ -28,6 +30,27 @@ def test_list_suffix(pipx_temp_env, monkeypatch, capsys):
     suffix = "_x"
     assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])
     assert not run_pipx_cli(["list"])
+
+    captured = capsys.readouterr()
+    assert f"package pycowsay 0.0.0.1 (pycowsay{suffix})," in captured.out
+
+
+@pytest.mark.parametrize("metadata_version", [None, "0.1"])
+def test_list_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_version):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["list"])
+    mock_legacy_venv("pycowsay", metadata_version=metadata_version)
+
+    captured = capsys.readouterr()
+    assert "package pycowsay 0.0.0.1," in captured.out
+
+
+@pytest.mark.parametrize("metadata_version", ["0.1"])
+def test_list_suffix_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_version):
+    suffix = "_x"
+    assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])
+    assert not run_pipx_cli(["list"])
+    mock_legacy_venv("pycowsay" + suffix, metadata_version=metadata_version)
 
     captured = capsys.readouterr()
     assert f"package pycowsay 0.0.0.1 (pycowsay{suffix})," in captured.out

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -29,8 +29,8 @@ def test_missing_interpreter(pipx_temp_env, monkeypatch, capsys):
 def test_list_suffix(pipx_temp_env, monkeypatch, capsys):
     suffix = "_x"
     assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])
-    assert not run_pipx_cli(["list"])
 
+    assert not run_pipx_cli(["list"])
     captured = capsys.readouterr()
     assert f"package pycowsay 0.0.0.1 (pycowsay{suffix})," in captured.out
 
@@ -38,9 +38,9 @@ def test_list_suffix(pipx_temp_env, monkeypatch, capsys):
 @pytest.mark.parametrize("metadata_version", [None, "0.1"])
 def test_list_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])
-    assert not run_pipx_cli(["list"])
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)
 
+    assert not run_pipx_cli(["list"])
     captured = capsys.readouterr()
     assert "package pycowsay 0.0.0.1," in captured.out
 
@@ -49,8 +49,8 @@ def test_list_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_version):
 def test_list_suffix_legacy_venv(pipx_temp_env, monkeypatch, capsys, metadata_version):
     suffix = "_x"
     assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])
-    assert not run_pipx_cli(["list"])
     mock_legacy_venv(f"pycowsay{suffix}", metadata_version=metadata_version)
 
+    assert not run_pipx_cli(["list"])
     captured = capsys.readouterr()
     assert f"package pycowsay 0.0.0.1 (pycowsay{suffix})," in captured.out

--- a/tests/test_reinstall_all.py
+++ b/tests/test_reinstall_all.py
@@ -14,12 +14,14 @@ def test_reinstall_all(pipx_temp_env, capsys):
 def test_reinstall_all_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)
+
     assert not run_pipx_cli(["reinstall-all", "--python", sys.executable])
 
 
 def test_reinstall_all_suffix(pipx_temp_env, capsys):
     suffix = "_x"
     assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])
+
     assert not run_pipx_cli(["reinstall-all", "--python", sys.executable])
 
 
@@ -28,4 +30,5 @@ def test_reinstall_all_suffix_legacy_venv(pipx_temp_env, capsys, metadata_versio
     suffix = "_x"
     assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])
     mock_legacy_venv(f"pycowsay{suffix}", metadata_version=metadata_version)
+
     assert not run_pipx_cli(["reinstall-all", "--python", sys.executable])

--- a/tests/test_reinstall_all.py
+++ b/tests/test_reinstall_all.py
@@ -1,8 +1,17 @@
 import sys
 
-from helpers import run_pipx_cli
+import pytest  # type: ignore
+
+from helpers import mock_legacy_venv, run_pipx_cli
 
 
 def test_reinstall_all(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["reinstall-all", "--python", sys.executable])
+
+
+@pytest.mark.parametrize("metadata_version", [None, "0.1"])
+def test_reinstall_all_legacy_venv(pipx_temp_env, capsys, metadata_version):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    mock_legacy_venv("pycowsay", metadata_version=metadata_version)
     assert not run_pipx_cli(["reinstall-all", "--python", sys.executable])

--- a/tests/test_reinstall_all.py
+++ b/tests/test_reinstall_all.py
@@ -15,3 +15,17 @@ def test_reinstall_all_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)
     assert not run_pipx_cli(["reinstall-all", "--python", sys.executable])
+
+
+def test_reinstall_all_suffix(pipx_temp_env, capsys):
+    suffix = "_x"
+    assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])
+    assert not run_pipx_cli(["reinstall-all", "--python", sys.executable])
+
+
+@pytest.mark.parametrize("metadata_version", [None, "0.1"])
+def test_reinstall_all_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
+    suffix = "_x"
+    assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])
+    mock_legacy_venv(f"pycowsay{suffix}", metadata_version=metadata_version)
+    assert not run_pipx_cli(["reinstall-all", "--python", sys.executable])

--- a/tests/test_reinstall_all.py
+++ b/tests/test_reinstall_all.py
@@ -23,7 +23,7 @@ def test_reinstall_all_suffix(pipx_temp_env, capsys):
     assert not run_pipx_cli(["reinstall-all", "--python", sys.executable])
 
 
-@pytest.mark.parametrize("metadata_version", [None, "0.1"])
+@pytest.mark.parametrize("metadata_version", ["0.1"])
 def test_reinstall_all_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
     suffix = "_x"
     assert not run_pipx_cli(["install", "pycowsay", f"--suffix={suffix}"])

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,9 +1,18 @@
-from helpers import run_pipx_cli
+import pytest  # type: ignore
+
+from helpers import mock_legacy_venv, run_pipx_cli
 from pipx import constants, util
 
 
 def test_uninstall(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["uninstall", "pycowsay"])
+
+
+@pytest.mark.parametrize("metadata_version", [None, "0.1"])
+def test_uninstall_legacy_venv(pipx_temp_env, capsys, metadata_version):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    mock_legacy_venv("pycowsay", metadata_version=metadata_version)
     assert not run_pipx_cli(["uninstall", "pycowsay"])
 
 
@@ -13,6 +22,20 @@ def test_uninstall_suffix(pipx_temp_env, capsys):
     executable = f"{name}{suffix}{'.exe' if constants.WINDOWS else ''}"
 
     assert not run_pipx_cli(["install", "pbr", f"--suffix={suffix}"])
+    assert (constants.LOCAL_BIN_DIR / executable).exists()
+
+    assert not run_pipx_cli(["uninstall", f"{name}{suffix}"])
+    assert not (constants.LOCAL_BIN_DIR / executable).exists()
+
+
+@pytest.mark.parametrize("metadata_version", ["0.1"])
+def test_uninstall_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
+    name = "pbr"
+    suffix = "_a"
+    executable = f"{name}{suffix}{'.exe' if constants.WINDOWS else ''}"
+
+    assert not run_pipx_cli(["install", "pbr", f"--suffix={suffix}"])
+    mock_legacy_venv(name + suffix, metadata_version=metadata_version)
     assert (constants.LOCAL_BIN_DIR / executable).exists()
 
     assert not run_pipx_cli(["uninstall", f"{name}{suffix}"])

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -35,7 +35,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
     executable = f"{name}{suffix}{'.exe' if constants.WINDOWS else ''}"
 
     assert not run_pipx_cli(["install", "pbr", f"--suffix={suffix}"])
-    mock_legacy_venv(name + suffix, metadata_version=metadata_version)
+    mock_legacy_venv(f"{name}{suffix}", metadata_version=metadata_version)
     assert (constants.LOCAL_BIN_DIR / executable).exists()
 
     assert not run_pipx_cli(["uninstall", f"{name}{suffix}"])

--- a/tests/test_uninstall_all.py
+++ b/tests/test_uninstall_all.py
@@ -1,6 +1,15 @@
-from helpers import run_pipx_cli
+import pytest  # type: ignore
+
+from helpers import mock_legacy_venv, run_pipx_cli
 
 
 def test_uninstall_all(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["uninstall-all"])
+
+
+@pytest.mark.parametrize("metadata_version", [None, "0.1"])
+def test_uninstall_all_legacy_venv(pipx_temp_env, capsys, metadata_version):
+    assert not run_pipx_cli(["install", "pycowsay"])
+    mock_legacy_venv("pycowsay", metadata_version=metadata_version)
     assert not run_pipx_cli(["uninstall-all"])

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,4 +1,6 @@
-from helpers import run_pipx_cli
+import pytest  # type: ignore
+
+from helpers import mock_legacy_venv, run_pipx_cli
 
 
 def test_upgrade(pipx_temp_env, capsys):
@@ -7,10 +9,29 @@ def test_upgrade(pipx_temp_env, capsys):
     assert not run_pipx_cli(["upgrade", "pycowsay"])
 
 
+@pytest.mark.parametrize("metadata_version", [None, "0.1"])
+def test_upgrade_legacy_venv(pipx_temp_env, capsys, metadata_version):
+    assert run_pipx_cli(["upgrade", "pycowsay"])
+    assert not run_pipx_cli(["install", "pycowsay"])
+    mock_legacy_venv("pycowsay", metadata_version=metadata_version)
+    assert not run_pipx_cli(["upgrade", "pycowsay"])
+
+
 def test_upgrade_suffix(pipx_temp_env, capsys):
     name = "pycowsay"
     suffix = "_a"
 
     assert not run_pipx_cli(["install", name, f"--suffix={suffix}"])
+    assert run_pipx_cli(["upgrade", f"{name}"])
+    assert not run_pipx_cli(["upgrade", f"{name}{suffix}"])
+
+
+@pytest.mark.parametrize("metadata_version", ["0.1"])
+def test_upgrade_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
+    name = "pycowsay"
+    suffix = "_a"
+
+    assert not run_pipx_cli(["install", name, f"--suffix={suffix}"])
+    mock_legacy_venv(f"{name}{suffix}", metadata_version=metadata_version)
     assert run_pipx_cli(["upgrade", f"{name}"])
     assert not run_pipx_cli(["upgrade", f"{name}{suffix}"])

--- a/tests/test_upgrade_all.py
+++ b/tests/test_upgrade_all.py
@@ -1,7 +1,17 @@
-from helpers import run_pipx_cli
+import pytest  # type: ignore
+
+from helpers import mock_legacy_venv, run_pipx_cli
 
 
 def test_upgrade_all(pipx_temp_env, capsys):
     assert run_pipx_cli(["upgrade", "pycowsay"])
     assert not run_pipx_cli(["install", "pycowsay"])
+    assert not run_pipx_cli(["upgrade-all"])
+
+
+@pytest.mark.parametrize("metadata_version", [None, "0.1"])
+def test_upgrade_all_legacy_venv(pipx_temp_env, capsys, metadata_version):
+    assert run_pipx_cli(["upgrade", "pycowsay"])
+    assert not run_pipx_cli(["install", "pycowsay"])
+    mock_legacy_venv("pycowsay", metadata_version=metadata_version)
     assert not run_pipx_cli(["upgrade-all"])


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`
_(I'm always thankful for this checkbox as I often forget)_

## Summary of changes
This was my attempt to clean up the code completely for suffix operation, as well as fixing the fact that `reinstall-all` was broken.

Major Changes
* Fix reinstall-all to work with suffixed venvs
* Add many tests
  * Test `reinstall-all` with installed suffixed package
  * New helper function `mock_legacy_venv()` to convert existing venv to look like old venv with missing or previous-version metadata
  * Add tests that mock legacy venvs (no metadata or old metadata version) to all commands that access venvs
* Refactor code
  * eliminate some `package` arguments that were often `None` or not necessary anyway
  * try to eliminate ambiguity by renaming variables (e.g. many `package` renamed to `venv_dir.name`), now that it is possible for `main_package` != `package` != `venv_name`
  * Make new `venv.main_package_name` property which is a great convenience for code that accesses venvs
* Changed `inject` to exit with `PipxError` and display instructions to reinstall venv when trying to inject package on pre-0.15.0.0 venv with missing metadata (fixing an existing error condition found by new tests!)
* Changed `upgrade-all` to raise `PipxError` and hence non-zero exit code if any individual venv upgrade had an error.
* Added function `_convert_legacy_metadata` in `pipx_metadata_file.py` to centralize any adjustments needed for reading legacy metadata.
* New `venv.main_package_name` made `venv.get_package_metadata()` unnecessary and it was removed.
* Added help text to `--suffix` indicating that it is an experimental feature.
  
Minor / Incidental Changes
* Added `flake8-bugbear` to `.pre-commit-config.yaml` to make its use of `flake8` match our Lint tests
* Added example of `pipx install ./LOCAL_PATH` to `pipx install` help text

### TODO for later
`pipx` help text is now a little confusing, as it refers to `PACKAGE` when it could mean any of `VENV_WITH_SUFFIX`, `VENV`, `INSTALLED PACKAGE`, etc.  

I at least tried to make the internal code more self consistent, referring to `venv_dir.name`, `main_package`, `package` to clearly differentiate what used to be used interchangeably in the code as `package`.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running

To test the most obvious problem, that `reinstall-all` fails currently on suffixed packages:
```
> pipx install --suffix 2 pycowsay 
  installed package pycowsay 0.0.0.1, Python 3.8.5
  These apps are now globally available
    - pycowsay2
done! ✨ 🌟 ✨
> pipx reinstall-all
Traceback (most recent call last):
  File "/usr/local/Cellar/pipx/0.15.5.1/libexec/bin/pipx", line 33, in <module>
    sys.exit(load_entry_point('pipx==0.15.5.1', 'console_scripts', 'pipx')())
  File "/usr/local/Cellar/pipx/0.15.5.1/libexec/lib/python3.8/site-packages/pipx/main.py", line 591, in cli
    return run_pipx_command(parsed_pipx_args)
  File "/usr/local/Cellar/pipx/0.15.5.1/libexec/lib/python3.8/site-packages/pipx/main.py", line 194, in run_pipx_command
    return commands.reinstall_all(
  File "/usr/local/Cellar/pipx/0.15.5.1/libexec/lib/python3.8/site-packages/pipx/commands/reinstall.py", line 75, in reinstall_all
    reinstall(
  File "/usr/local/Cellar/pipx/0.15.5.1/libexec/lib/python3.8/site-packages/pipx/commands/reinstall.py", line 15, in reinstall
    venv = Venv(venv_dir, verbose=verbose)
  File "/usr/local/Cellar/pipx/0.15.5.1/libexec/lib/python3.8/site-packages/pipx/venv.py", line 82, in __init__
    self.pipx_metadata = PipxMetadata(venv_dir=path)
  File "/usr/local/Cellar/pipx/0.15.5.1/libexec/lib/python3.8/site-packages/pipx/pipx_metadata_file.py", line 68, in __init__
    self.read()
  File "/usr/local/Cellar/pipx/0.15.5.1/libexec/lib/python3.8/site-packages/pipx/pipx_metadata_file.py", line 144, in read
    self.from_dict(
  File "/usr/local/Cellar/pipx/0.15.5.1/libexec/lib/python3.8/site-packages/pipx/pipx_metadata_file.py", line 103, in from_dict
    self.main_package = PackageInfo(**input_dict["main_package"])
TypeError: __new__() got an unexpected keyword argument 'suffix'
> 

```

