### PR TITLE
Add help description for `ensurepath` and `completions`.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ dev
 - [docs] Update license
 - [bugfix] Fixed regression in list, inject and upgrade commands when suffixed packages are used.
 - [bugfix] Do not reset package url during upgrade when main package is `pipx`
+- Update help text to show description for `ensurepath` and `completions` help
 
 
 0.15.5.1

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -484,6 +484,10 @@ def _add_ensurepath(subparsers):
     p = subparsers.add_parser(
         "ensurepath",
         help=(
+            "Ensure directories necessary for pipx operation are in your "
+            "PATH environment variable."
+        ),
+        description=(
             "Ensure directory where pipx stores apps is in your "
             "PATH environment variable. Also if pipx was installed via "
             "`pip install --user`, ensure pipx itself is in your PATH. "
@@ -531,7 +535,9 @@ def get_command_parser():
 
     parser.add_argument("--version", action="store_true", help="Print version and exit")
     subparsers.add_parser(
-        "completions", help="Print instructions on enabling shell completions for pipx"
+        "completions",
+        help="Print instructions on enabling shell completions for pipx",
+        description="Print instructions on enabling shell completions for pipx",
     )
     return parser
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
The subparsers for `ensurepath` and `completions` didn't have a `description` argument.  This meant that getting the specific help for the subcommand (e.g. `pipx ensurepath --help`) didn't give you a description of the subcommand, you had to view the overall pipx help (`pipx --help`) to read the description of those subcommands.

For the pipx  subcommand `completions`, I duplicated the `help` argument of its subparser into the `description` argument.

For the pipx subcommand `ensurepath`, I moved the verbose help description into its subparser's `description`, and made a briefer summary to replace its `help` text (which is shown for `pipx --help`).

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx --help
pipx ensurepath --help
pipx completions --help
```

### New
```
> pipx --help
usage: pipx [-h] [--version]
            {install,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall-all,list,run,runpip,ensurepath,completions}
            ...
```
[...]
```
subcommands:
  Get help for commands with pipx COMMAND --help

  {install,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall-all,list,run,runpip,ensurepath,completions}
    install             Install a package
    inject              Install packages into an existing Virtual Environment
    upgrade             Upgrade a package
    upgrade-all         Upgrade all packages. Runs `pip install -U <pkgname>`
                        for each package.
    uninstall           Uninstall a package
    uninstall-all       Uninstall all packages
    reinstall-all       Reinstall all packages
    list                List installed packages
    run                 Download the latest version of a package to a
                        temporary virtual environment, then run an app from
                        it. Also compatible with local `__pypackages__`
                        directory (experimental).
    runpip              Run pip in an existing pipx-managed Virtual
                        Environment
    ensurepath          Ensure directories necessary for pipx operation are in
                        your PATH environment variable.
    completions         Print instructions on enabling shell completions for
                        pipx
> pipx ensurepath --help
usage: pipx ensurepath [-h] [--force]

Ensure directory where pipx stores apps is in your PATH environment variable.
Also if pipx was installed via `pip install --user`, ensure pipx itself is in
your PATH. Note that running this may modify your shell's configuration
file(s) such as '~/.bashrc'.

optional arguments:
  -h, --help   show this help message and exit
  --force, -f  Add text to your shell's config file even if it looks like your
               PATH already contains paths to pipx and pipx-install apps.
> pipx completions --help
usage: pipx completions [-h]

Print instructions on enabling shell completions for pipx

optional arguments:
  -h, --help  show this help message and exit
> 
```

### Old
```
> pipx --help
usage: pipx [-h] [--version]
            {install,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall-all,list,run,runpip,ensurepath,completions}
            ...
```
```
subcommands:
  Get help for commands with pipx COMMAND --help

  {install,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall-all,list,run,runpip,ensurepath,completions}
    install             Install a package
    inject              Install packages into an existing Virtual Environment
    upgrade             Upgrade a package
    upgrade-all         Upgrade all packages. Runs `pip install -U <pkgname>`
                        for each package.
    uninstall           Uninstall a package
    uninstall-all       Uninstall all packages
    reinstall-all       Reinstall all packages
    list                List installed packages
    run                 Download the latest version of a package to a
                        temporary virtual environment, then run an app from
                        it. Also compatible with local `__pypackages__`
                        directory (experimental).
    runpip              Run pip in an existing pipx-managed Virtual
                        Environment
    ensurepath          Ensure directory where pipx stores apps is in your
                        PATH environment variable. Also if pipx was installed
                        via `pip install --user`, ensure pipx itself is in
                        your PATH. Note that running this may modify your
                        shell's configuration file(s) such as '~/.bashrc'.
    completions         Print instructions on enabling shell completions for
                        pipx
> pipx ensurepath --help
usage: pipx ensurepath [-h] [--force]

optional arguments:
  -h, --help   show this help message and exit
  --force, -f  Add text to your shell's config file even if it looks like your
               PATH already contains paths to pipx and pipx-install apps.
> pipx completions --help
usage: pipx completions [-h]

optional arguments:
  -h, --help  show this help message and exit
> 
```