### PR TITLE
[Docs] Update to pipx release instructions in `contributing.md`

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -115,7 +115,7 @@ Finally, from a clone of the main pipxproject pipx repo (not a fork), run
 nox -s publish
 ```
 
-and create a new release in GitHub.
+Additionally, create a new release in GitHub.
 
 ### Post-release
 * Update pipx's version in `src/pipx/version.py` by adding a suffix `"dev0"` for unreleased development.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -101,17 +101,22 @@ nox -s publish_docs
 ```
 
 ## Releasing New `pipx` Versions
-To create a new release
+### Pre-release
 
-* Update pipx's version in `src/pipx/version.py` and regenerate documentation.
+* Update pipx's version in `src/pipx/version.py` to the new version
 * Make sure the changelog is updated
     * Add new version to head the latest block of changes (instead of "dev").
     * Make sure all notable changes are listed.
+* Regenerate documentation.
 
-Finally, run
+### Release
+Finally, from a clone of the main pipxproject pipx repo (not a fork), run
 ```bash
 nox -s publish
-nox -s publish_docs
 ```
 
 and create a new release in GitHub.
+
+### Post-release
+* Update pipx's version in `src/pipx/version.py` by adding a suffix `"dev0"` for unreleased development.
+* Update the changelog to start a new section at the top temporarily entitled `dev`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -110,7 +110,7 @@ nox -s publish_docs
 * Regenerate documentation.
 
 ### Release
-Finally, from a clone of the main pipxproject pipx repo (not a fork), run
+To publish to PyPI: From a clone of the main pipxproject pipx repo (not a fork), run
 ```bash
 nox -s publish
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -105,7 +105,7 @@ nox -s publish_docs
 
 * Update pipx's version in `src/pipx/version.py` to the new version
 * Make sure the changelog is updated
-    * Add new version to head the latest block of changes (instead of "dev").
+    * Put the version of the new release as the header for the latest block of changes (instead of "dev").
     * Make sure all notable changes are listed.
 * Regenerate documentation.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -119,4 +119,4 @@ and create a new release in GitHub.
 
 ### Post-release
 * Update pipx's version in `src/pipx/version.py` by adding a suffix `"dev0"` for unreleased development.
-* Update the changelog to start a new section at the top temporarily entitled `dev`
+* Update the changelog to start a new section at the top entitled `dev`


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
I fleshed out in more detail the steps to release pipx.  I removed the docs publish step (as this is now done automatically by our GitHub Action.)  I also added some post-release steps to change the version to have a `dev0` suffix and to ready the changelog for future development.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
