### PR TITLE
Fix CI tests

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -87,7 +87,7 @@ jobs:
         python -m pip install wheel
         python -m pip install regex
     - name: Install native-venv version of nox
-      run: pip install git+https://github.com/cs01/nox.git@5ea70723e9e6#egg=nox
+      run: pip install --use-feature=2020-resolver git+https://github.com/cs01/nox.git@5ea70723e9e6#egg=nox
     - name: Execute Tests
       run: |
         nox --non-interactive --session tests-${{ matrix.python-version }}

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -47,12 +47,12 @@ def test_install_easy_packages(capsys, pipx_temp_env, caplog, package):
 
 
 @pytest.mark.parametrize(
-    "package", ["cloudtoken", "awscli", "ansible", "shell-functools"]
+    "package", ["cloudtoken", "awscli", "ansible==2.9.13", "shell-functools"]
 )
 def test_install_tricky_packages(capsys, pipx_temp_env, caplog, package):
     if os.getenv("FAST"):
         pytest.skip("skipping slow tests")
-    if sys.platform.startswith("win") and package == "ansible":
+    if sys.platform.startswith("win") and package == "ansible==2.9.13":
         pytest.skip("Ansible is not installable on Windows")
 
     install_package(capsys, pipx_temp_env, caplog, package)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from unittest import mock
 
@@ -55,7 +56,9 @@ def test_install_tricky_packages(capsys, pipx_temp_env, caplog, package):
     if sys.platform.startswith("win") and package == "ansible==2.9.13":
         pytest.skip("Ansible is not installable on Windows")
 
-    install_package(capsys, pipx_temp_env, caplog, package)
+    install_package(
+        capsys, pipx_temp_env, caplog, package, re.sub(r"==.+$", "", package)
+    )
 
 
 # TODO: Add git+... spec when git is in binpath of tests (Issue #303)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Use pip option `--use-feature=2020-resolver` to resolve the proper version of `importlib-metadata` to prevent installation of nox failing.

Use specific version of `ansible` to make its install test work again and increase test determinism.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running

Fixes #507, #504 

```
# command(s) to exercise these changes
```
