### PR TITLE
Use native nox for tests (not @cs01 fork of nox)

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -86,8 +86,8 @@ jobs:
       run: |
         python -m pip install wheel
         python -m pip install regex
-    - name: Install native-venv version of nox
-      run: pip install git+https://github.com/cs01/nox.git@5ea70723e9e6#egg=nox
+    - name: Install nox
+      run: pip install nox
     - name: Execute Tests
       run: |
         nox --non-interactive --session tests-${{ matrix.python-version }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -81,6 +81,9 @@ jobs:
     # Build regex wheel into pip cache, so future pipx installs don't compile.
     # This avoids future compile errors in nox tests because of missing
     #   header files.
+    # Inside a pytest session, tests/conftest.py removes all existing paths from
+    #   the system PATH, which can cause C compilation to fail.  So here we
+    #   pre-build some packages' wheels outside of pytest.
     - name: Install wheel and build wheel for regex to pip cache
       if: ${{ runner.os == 'macOS' }}
       run: |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,11 +16,8 @@ pipx uses an automation tool called [nox](https://pypi.org/project/nox/) for dev
 
 Install nox for pipx development:
 ```
-python -m pip install --user git+https://github.com/cs01/nox.git@5ea70723e9e6 nox
+python -m pip install --user nox
 ```
-
-!!! note
-    A specific version of nox must be used for pipx development until [nox issue 233](https://github.com/theacodes/nox/issues/233) is resolved.
 
 Tests are defined as `nox` sessions. You can see all nox sessions with
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -51,13 +51,13 @@ nox -s tests-3.7
 ```
 
 !!! tip
-    You can running a specific unit test by passing arguments to pytest, the test runner pipx uses:
+    You can run a specific unit test by passing arguments to pytest, the test runner pipx uses:
 
     ```
     nox -s tests-3.8 -- -k EXPRESSION
     ```
 
-    Expression can be a test name, such as
+    `EXPRESSION` can be a test name, such as
 
     ```
     nox -s tests-3.8 -- -k test_uninstall

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 .PHONY: test docs develop build publish publish_docs lint
 
 develop:
-	pipx run --spec=git+https://github.com/cs01/nox.git@5ea70723e9e6 nox -s develop
+	pipx run nox -s develop
 
 lint:
 	pipx run nox -s lint
@@ -9,7 +9,7 @@ lint:
 test:
 	# TODO use `pipx run nox` when nox supports venv creation (and thus
 	# pipx tests pass)
-	pipx run --spec=git+https://github.com/cs01/nox.git@5ea70723e9e6 nox
+	pipx run nox
 
 publish:
 	pipx run nox -s publish-3.7

--- a/makefile
+++ b/makefile
@@ -7,8 +7,6 @@ lint:
 	pipx run nox -s lint
 
 test:
-	# TODO use `pipx run nox` when nox supports venv creation (and thus
-	# pipx tests pass)
 	pipx run nox
 
 publish:

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,7 +34,7 @@ lint_dependencies = [
 ]
 
 
-@nox.session(python=python)
+@nox.session(python=python, venv_backend="venv")
 def tests(session):
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,7 +25,7 @@ lint_dependencies = [
 ]
 
 
-@nox.session(python=python, venv_backend="venv")
+@nox.session(python=python)
 def tests(session):
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,15 +4,6 @@ from pathlib import Path
 
 import nox  # type: ignore
 
-# NOTE: these tests require nox to create virtual environments
-# with venv. nox currently uses virtualenv. pipx
-# uses a fork of nox at https://github.com/cs01/nox
-# on the branch cs01/use-venv
-# To invoke nox for pipx, use:
-# pipx run --spec=git+https://github.com/cs01/nox.git@2ba8984a nox
-# until this is fixed in nox. See
-# https://github.com/theacodes/nox/issues/199
-
 python = ["3.6", "3.7", "3.8"]
 
 if sys.platform == "win32":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,4 +22,7 @@ def pipx_temp_env(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
     monkeypatch.setattr(constants, "PIPX_VENV_CACHEDIR", home_dir / ".cache")
 
+    # TODO: macOS needs /usr/bin to compile certain packages, but applications
+    #   in /usr/bin cause test_install.py tests to raise warnings which make
+    #   tests fail
     monkeypatch.setenv("PATH", str(bin_dir))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
+import os
 from pathlib import Path
 
 import pytest  # type: ignore
 
 from pipx import constants
+
+# we keep /usr/bin because it enables C-compiling python modules on macOS
+PATH_KEEPLIST = ["/usr/bin"]
 
 
 @pytest.fixture
@@ -22,4 +26,7 @@ def pipx_temp_env(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
     monkeypatch.setattr(constants, "PIPX_VENV_CACHEDIR", home_dir / ".cache")
 
-    monkeypatch.setenv("PATH", str(bin_dir))
+    path_keep = [
+        x for x in os.getenv("PATH", "").split(os.pathsep) if x in PATH_KEEPLIST
+    ]
+    monkeypatch.setenv("PATH", ":".join([str(bin_dir)] + path_keep))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,8 @@
-import os
 from pathlib import Path
 
 import pytest  # type: ignore
 
 from pipx import constants
-
-# we keep /usr/bin because it enables C-compiling python modules on macOS
-PATH_KEEPLIST = ["/usr/bin"]
 
 
 @pytest.fixture
@@ -26,7 +22,4 @@ def pipx_temp_env(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
     monkeypatch.setattr(constants, "PIPX_VENV_CACHEDIR", home_dir / ".cache")
 
-    path_keep = [
-        x for x in os.getenv("PATH", "").split(os.pathsep) if x in PATH_KEEPLIST
-    ]
-    monkeypatch.setenv("PATH", ":".join([str(bin_dir)] + path_keep))
+    monkeypatch.setenv("PATH", str(bin_dir))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,5 +24,5 @@ def pipx_temp_env(tmp_path, monkeypatch):
 
     # TODO: macOS needs /usr/bin in PATH to compile certain packages, but
     #   applications in /usr/bin cause test_install.py tests to raise warnings
-    #   which make tests fail
+    #   which make tests fail (e.g. on Github ansible apps exist in /usr/bin)
     monkeypatch.setenv("PATH", str(bin_dir))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def pipx_temp_env(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
     monkeypatch.setattr(constants, "PIPX_VENV_CACHEDIR", home_dir / ".cache")
 
-    # TODO: macOS needs /usr/bin to compile certain packages, but applications
-    #   in /usr/bin cause test_install.py tests to raise warnings which make
-    #   tests fail
+    # TODO: macOS needs /usr/bin in PATH to compile certain packages, but
+    #   applications in /usr/bin cause test_install.py tests to raise warnings
+    #   which make tests fail
     monkeypatch.setenv("PATH", str(bin_dir))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,6 @@
-from shutil import which
 import subprocess
 import sys
+from shutil import which
 from typing import List
 from unittest import mock
 
@@ -8,7 +8,7 @@ from pipx import main
 
 
 def assert_not_in_virtualenv():
-    assert not hasattr(sys, "real_prefix"), "Tests cannot run under virtualenv"
+    assert True
 
 
 def run_pipx_cli(pipx_args: List[str]):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,10 +7,6 @@ from unittest import mock
 from pipx import main
 
 
-def assert_not_in_virtualenv():
-    assert True
-
-
 def run_pipx_cli(pipx_args: List[str]):
     with mock.patch.object(sys, "argv", ["pipx"] + pipx_args):
         return main.cli()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,11 +5,8 @@ from unittest import mock
 
 import pytest  # type: ignore
 
-from helpers import assert_not_in_virtualenv, run_pipx_cli, which_python
+from helpers import run_pipx_cli, which_python
 from pipx import constants
-
-assert_not_in_virtualenv()
-
 
 PYTHON3_5 = which_python("python3.5")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,10 +3,8 @@ from unittest import mock
 
 import pytest  # type: ignore
 
-from helpers import assert_not_in_virtualenv, run_pipx_cli
+from helpers import run_pipx_cli
 from pipx import main
-
-assert_not_in_virtualenv()
 
 
 def test_help_text(monkeypatch, capsys):

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -3,12 +3,9 @@ from pathlib import Path
 import pytest  # type: ignore
 
 import pipx.constants
-from helpers import assert_not_in_virtualenv, run_pipx_cli
+from helpers import run_pipx_cli
 from pipx.pipx_metadata_file import PackageInfo, PipxMetadata
 from pipx.util import PipxError
-
-assert_not_in_virtualenv()
-
 
 TEST_PACKAGE1 = PackageInfo(
     package="test_package",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Due presumably to updates in virtualenv, and possibly nox, we can now use regular nox for our tests and don't need to use the special fork of nox. 

Closes #508 

This seems to work fine.  However, in the future if we ever notice something that requires `venv` to be used in nox tests, we can add `venv_backend="venv"` as an argument to `@nox.session()` before `def tests()` in `noxfile.py`.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running

```
# command(s) to exercise these changes
```
