### PR TITLE
Fix tests on macOS

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -70,11 +70,11 @@ jobs:
       id: pip-cache
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
-    - name: Persistent Github pip cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip${{ matrix.python-version }}
+        # - name: Persistent Github pip cache
+        #   uses: actions/cache@v2
+        #   with:
+        #     path: ${{ steps.pip-cache.outputs.dir }}
+        #     key: ${{ runner.os }}-pip${{ matrix.python-version }}
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
     - name: Install nox

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -70,11 +70,11 @@ jobs:
       id: pip-cache
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
-        #- name: Persistent Github pip cache
-        #  uses: actions/cache@v2
-        #  with:
-        #    path: ${{ steps.pip-cache.outputs.dir }}
-        #    key: ${{ runner.os }}-pip${{ matrix.python-version }}
+    - name: Persistent Github pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip${{ matrix.python-version }}
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
     - name: Install nox

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -70,11 +70,11 @@ jobs:
       id: pip-cache
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
-    - name: Persistent Github pip cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip${{ matrix.python-version }}
+        #- name: Persistent Github pip cache
+        #  uses: actions/cache@v2
+        #  with:
+        #    path: ${{ steps.pip-cache.outputs.dir }}
+        #    key: ${{ runner.os }}-pip${{ matrix.python-version }}
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
     - name: Install nox

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -77,18 +77,6 @@ jobs:
         key: ${{ runner.os }}-pip${{ matrix.python-version }}
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
-    # macOS: Install wheel to allow wheel-building for nox and regex
-    # Build regex wheel into pip cache, so future pipx installs don't compile.
-    # This avoids future compile errors in nox tests because of missing
-    #   header files.
-    # Inside a pytest session, tests/conftest.py removes all existing paths from
-    #   the system PATH, which can cause C compilation to fail.  So here we
-    #   pre-build some packages' wheels outside of pytest.
-    - name: Install wheel and build wheel for regex to pip cache
-      if: ${{ runner.os == 'macOS' }}
-      run: |
-        python -m pip install wheel
-        python -m pip install regex
     - name: Install nox
       run: pip install nox
     - name: Execute Tests

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -70,11 +70,11 @@ jobs:
       id: pip-cache
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
-        # - name: Persistent Github pip cache
-        #   uses: actions/cache@v2
-        #   with:
-        #     path: ${{ steps.pip-cache.outputs.dir }}
-        #     key: ${{ runner.os }}-pip${{ matrix.python-version }}
+    - name: Persistent Github pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip${{ matrix.python-version }}
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
     - name: Install nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,7 @@ def tests(session):
         #   They will end up in the pip cache.
         session.install("wheel")
         for prebuild_package in macos_prebuild_packages:
-            session.run("pip", "wheel", prebuild_package)
+            session.run("pip", "wheel", prebuild_package, silent=True)
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,8 +23,8 @@ lint_dependencies = [
     "check-manifest",
     "packaging>=20.0",
 ]
-# Packages that need to be compiled and need an intact system PATH on macOS
-macos_prebuild_packages = ["regex", "argon2-cffi"]
+# Packages that need an intact system PATH to compile on macOS
+macos_prebuild_packages = ["argon2-cffi"]
 
 
 @nox.session(python=python)
@@ -32,9 +32,10 @@ def tests(session):
     if sys.platform == "darwin":
         # For macOS, we need /usr/bin in PATH to compile some packages,
         #   but pytest setup clears PATH.  So we pre-build some wheels first.
+        #   They will end up in the pip cache.
         session.install("wheel")
         for prebuild_package in macos_prebuild_packages:
-            session.install(prebuild_package)
+            session.run("pip", "wheel", prebuild_package)
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,7 @@ lint_dependencies = [
 def tests(session):
     if sys.platform == "darwin":
         # For macOS, we need /usr/bin in PATH to compile some packages,
-        #   but tests clear PATH.  So we pre-build wheels here first.
+        #   but pytest setup clears PATH.  So we pre-build some wheels first.
         session.install("wheel")
         session.install("regex")
         session.install("argon2-cffi")

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,6 +27,12 @@ lint_dependencies = [
 
 @nox.session(python=python)
 def tests(session):
+    if sys.platform == "darwin":
+        # For macOS, we need /usr/bin in PATH to compile some packages,
+        #   but tests clear PATH.  So we pre-build wheels here first.
+        session.install("wheel")
+        session.install("regex")
+        session.install("argon2-cffi")
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,8 @@ lint_dependencies = [
     "check-manifest",
     "packaging>=20.0",
 ]
+# Packages that need to be compiled and need an intact system PATH on macOS
+macos_prebuild_packages = ["regex", "argon2-cffi"]
 
 
 @nox.session(python=python)
@@ -31,8 +33,8 @@ def tests(session):
         # For macOS, we need /usr/bin in PATH to compile some packages,
         #   but pytest setup clears PATH.  So we pre-build some wheels first.
         session.install("wheel")
-        session.install("regex")
-        session.install("argon2-cffi")
+        for prebuild_package in macos_prebuild_packages:
+            session.install(prebuild_package)
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ lint_dependencies = [
     "packaging>=20.0",
 ]
 # Packages that need an intact system PATH to compile on macOS
-macos_prebuild_packages = ["argon2-cffi"]
+macos_prebuild_packages = ["argon2-cffi", "regex"]
 
 
 @nox.session(python=python)


### PR DESCRIPTION
<!-- Thank you for filing a bug! Please feel free to answer as much or as little of this template as you can. -->

**Describe the bug**
<!-- Please be as detailed as possible! -->

Closes #348  Closes #488 

This PR moves the pre-building of wheels into the pip cache, from our GitHub workflow into our nox session.  This enables our tests to be able to be run reliably from both CI and manually from a macOS computer.  Previously, depending on the pip cache, certain install tests would fail when run manually on a macOS computer.

Before running our pytest tests, the code only builds certain wheels but does not install the packages.  This is enough to put the wheels for these packages into the pip cache (`pip wheel` adds its wheels to the pip cache).

**Longer Explanation**

Because we remove the entire system PATH and replace it with only the pipx bin directory inside of `tests/conftest.py`, on macOS building certain wheels that require C compilation can fail.  Compiling on macOS seems to require `/usr/bin` in the system PATH.  

Building wheels for certain packages like `regex` and `argon2-cffi` can thus fail if they are attempted to be built from within our pytest tests.  Since these libraries are dependencies of some of our test installation packages, our install tests can fail if these dependency wheels are not already in the pip cache.

This dependency on the pip cache can lead to seemingly non-deterministic failures (see #348, #488) until a build of the package in question is made outside of pipx's pytest tests, in which case the wheel can be successfully built and added to pip's cache.

This is why it was necessary to add pre-installation of `regex`, for example, to our Github Workflow.  By moving it and other similar packages' builds into our nox session (before running pytest), it also means we can reliably run tests on a macOS computer manually.

**How to reproduce**
<!-- If possible, include output of `pipx --verbose ...` -->

**Expected behavior**
<!-- What should have happened? -->
