### PR TITLE
Fix pep508

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,8 +3,9 @@ dev
 - [docs] Update license
 - [bugfix] Fixed regression in list, inject, upgrade, reinstall-all commands when suffixed packages are used.
 - [bugfix] Do not reset package url during upgrade when main package is `pipx`
-- Update help text to show description for `ensurepath` and `completions` help
-- Add support for user-defined default python interpreter via new PIPX_DEFAULT_PYTHON.  Helpful for use with pyenv among other uses.
+- Updated help text to show description for `ensurepath` and `completions` help
+- Added support for user-defined default python interpreter via new PIPX_DEFAULT_PYTHON.  Helpful for use with pyenv among other uses.
+- [bugfix] Fixed bug where extras were ignored with a PEP 508 package specification with a URL.
 
 
 0.15.5.1

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -141,7 +141,7 @@ def parse_specifier_for_install(
     """Return package_or_url and pip_args suitable for pip install
 
     Specifically:
-    * Strip any markers (e.g. python_version > 3.4)
+    * Strip any markers (e.g. python_version > "3.4")
     * Ensure --editable is removed for any package_spec not a local path
     * Convert local paths to absolute paths
     """

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -203,8 +203,9 @@ def fix_package_name(package_or_url: str, package: str) -> str:
     if canonicalize_name(package_req.name) != canonicalize_name(package):
         logging.warning(
             textwrap.fill(
-                f"Name supplied in package specifier was {package_req.name} but "
-                f"package found has name {package}.  Using {package}.",
+                f"{hazard}  Name supplied in package specifier was "
+                f"{package_req.name!r} but package found has name "
+                f"{package!r}.  Using {package!r}.",
                 subsequent_indent="    ",
             )
         )

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -184,7 +184,7 @@ class Venv:
         if pip_args is None:
             pip_args = []
 
-        # fix package name in package specifier if necessary
+        # package name in package specifier can mismatch URL due to user error
         package_or_url = fix_package_name(package_or_url, package)
 
         # check syntax and clean up spec and pip_args

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -8,6 +8,7 @@ from pipx.animate import animate
 from pipx.constants import PIPX_SHARED_PTH
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.package_specifier import (
+    fix_package_name,
     parse_specifier_for_install,
     parse_specifier_for_metadata,
 )
@@ -182,6 +183,9 @@ class Venv:
     ) -> None:
         if pip_args is None:
             pip_args = []
+
+        # fix package name in package specifier if necessary
+        package_or_url = fix_package_name(package_or_url, package)
 
         # check syntax and clean up spec and pip_args
         (package_or_url, pip_args) = parse_specifier_for_install(

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -50,6 +50,16 @@ TEST_DATA_PATH = "./testdata/test_package_specifier"
             "black@ https://github.com/ambv/black/archive/18.9b0.zip",
             True,
         ),
+        (
+            "black[extra] @ https://github.com/ambv/black/archive/18.9b0.zip",
+            "black[extra]@ https://github.com/ambv/black/archive/18.9b0.zip",
+            True,
+        ),
+        (
+            'my-project[cli] @ git+ssh://git@bitbucket.org/my-company/myproject.git ; python_version<"3.7"',
+            "my-project[cli]@ git+ssh://git@bitbucket.org/my-company/myproject.git",
+            True,
+        ),
         ("path/doesnt/exist", "non-existent-path", False,),
         (
             "https:/github.com/ambv/black/archive/18.9b0.zip",

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -3,12 +3,50 @@ from pathlib import Path
 import pytest  # type: ignore
 
 from pipx.package_specifier import (
+    fix_package_name,
     parse_specifier_for_install,
     parse_specifier_for_metadata,
+    valid_pypi_name,
 )
 from pipx.util import PipxError
 
 TEST_DATA_PATH = "./testdata/test_package_specifier"
+
+
+@pytest.mark.parametrize(
+    "package_spec_in,package_name_out",
+    [
+        ("Black", "black"),
+        ("https://github.com/ambv/black/archive/18.9b0.zip", None),
+        ("black @ https://github.com/ambv/black/archive/18.9b0.zip", None),
+    ],
+)
+def test_valid_pypi_name(package_spec_in, package_name_out):
+    assert valid_pypi_name(package_spec_in) == package_name_out
+
+
+@pytest.mark.parametrize(
+    "package_spec_in,package_name,package_spec_out",
+    [
+        (
+            "https://github.com/ambv/black/archive/18.9b0.zip",
+            "black",
+            "https://github.com/ambv/black/archive/18.9b0.zip",
+        ),
+        (
+            "nox@https://github.com/ambv/black/archive/18.9b0.zip",
+            "black",
+            "black@ https://github.com/ambv/black/archive/18.9b0.zip",
+        ),
+        (
+            "nox[extra]@https://github.com/ambv/black/archive/18.9b0.zip",
+            "black",
+            "black[extra]@ https://github.com/ambv/black/archive/18.9b0.zip",
+        ),
+    ],
+)
+def test_fix_package_name(package_spec_in, package_name, package_spec_out):
+    assert fix_package_name(package_spec_in, package_name) == package_spec_out
 
 
 # TODO: Make sure git+ works with tests, correct in test_install as well

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -32,7 +32,7 @@ TEST_DATA_PATH = "./testdata/test_package_specifier"
         ),
         (
             "nox@git+https://github.com/cs01/nox.git@5ea70723e9e6",
-            "git+https://github.com/cs01/nox.git@5ea70723e9e6",
+            "nox@ git+https://github.com/cs01/nox.git@5ea70723e9e6",
             True,
         ),
         (
@@ -42,12 +42,12 @@ TEST_DATA_PATH = "./testdata/test_package_specifier"
         ),
         (
             "black@https://github.com/ambv/black/archive/18.9b0.zip",
-            "https://github.com/ambv/black/archive/18.9b0.zip",
+            "black@ https://github.com/ambv/black/archive/18.9b0.zip",
             True,
         ),
         (
             "black @ https://github.com/ambv/black/archive/18.9b0.zip",
-            "https://github.com/ambv/black/archive/18.9b0.zip",
+            "black@ https://github.com/ambv/black/archive/18.9b0.zip",
             True,
         ),
         ("path/doesnt/exist", "non-existent-path", False,),


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Fixes bug in handling of PEP508 package specifications including URLs and extras

Closes #515 

I was too aggressive in the original code for "cleaning" PEP508 package specifications for pipx.  I originally removed the package name if there was a URL present, on the idea that the user-supplied name might not match the URL and we should just use the URL only to avoid confusion.  Unfortunately, this also removed the only way to supply package extras with a URL.

The new code is more surgical.  The basic idea: convert package specification string to Requirement object, null out anything we don't want as pipx, convert Requirement object back to string.  We then use that string for `package_or_url`.

To guard against the user supplying a mismatched package name to the URL in their PEP508 package specification, I modified `valid_pypi_name` to return `None` if a URL is present, signifying to the calling code that it needs to do a trial install of the URL to determine package name, even if it's present in the PEP508 package specifier.   I also, introduced a new function `fix_package_name` which fixes the package_name part of a spec if necessary.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
`pipx install <package>[<extra>] @ URL`

Does anybody have a good suggestion for a test package that uses a URL and has at least one possible extra?  I couldn't easily find one.
