### PR TITLE
Propose better way to register fish completions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 dev
 
 - [docs] Update license
+- [docs] Display a more idomatic command for registering completions on fish.
 - [bugfix] Fixed regression in list, inject, upgrade, reinstall-all commands when suffixed packages are used.
 - [bugfix] Do not reset package url during upgrade when main package is `pipx`
 - Updated help text to show description for `ensurepath` and `completions` help

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -70,7 +70,8 @@ tcsh:
     eval `register-python-argcomplete --shell tcsh pipx`
 
 fish:
-    register-python-argcomplete --shell fish pipx | source
+    # Not required to be in the config file, only run once
+    register-python-argcomplete --shell fish pipx >~/.config/fish/completions/pipx.fish
 
 """
 )


### PR DESCRIPTION
- The standard way to add fish completions
- Doesn't require require reloading the shell

<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```fish
❯ pipx completions

Add the appropriate command to your shell's config file
so that it is run on startup. You will likely have to restart
or re-login for the autocompletion to start working.
...

fish:
    # Not required to be in the config file, only run once
    register-python-argcomplete --shell fish pipx >~/.config/fish/completions/pipx.fish

❯ register-python-argcomplete --shell fish pipx >~/.config/fish/completions/pipx.fish
```
