### PR TITLE
Don't publish docs in session publish.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -132,7 +132,6 @@ def publish(session):
     build(session)
     print("REMINDER: Has the changelog been updated?")
     session.run("python", "-m", "twine", "upload", "dist/*")
-    publish_docs(session)
 
 
 @nox.session(python="3.8")


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Removes `publish_docs` from nox session `publish`, because it is largely redundant now that we auto-publish docs from the Github Action, both on-github-release and manually.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
