### PR TITLE
pytest-cov fix

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -49,9 +49,7 @@ def tests(session):
     prebuild_wheels(session, prebuild_packages)
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
-    session.run(
-        "pytest", "--cov=pipx", "--cov-config=.coveragerc", "--cov-report=", *tests
-    )
+    session.run("pytest", "--cov=pipx", "--cov-report=", *tests)
     session.notify("cover")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,7 +50,7 @@ def tests(session):
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
     session.run(
-        "pytest", "--cov=pipx", "--cov-config", ".coveragerc", "--cov-report=", *tests
+        "pytest", "--cov=pipx", "--cov-config=.coveragerc", "--cov-report=", *tests
     )
     session.notify("cover")
 

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -28,11 +28,15 @@ def list_packages(venv_container: VenvContainer, include_injected: bool) -> None
     venv_container.verify_shared_libs()
 
     if Pool:
-        with Pool() as p:
+        p = Pool()
+        try:
             for package_summary in p.map(
                 partial(get_package_summary, include_injected=include_injected), dirs,
             ):
                 print(package_summary)
+        finally:
+            p.close()
+            p.join()
     else:
         for package_summary in map(
             partial(get_package_summary, include_injected=include_injected), dirs,


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
These changes fix the way we use `multiprocessing.Pool()` to be compatible with pytest-cov as described here:
https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html#if-you-use-multiprocessing-pool

Currently our pytest-cov coverage doesn't work robustly (especially on Windows and macOS) because we are not using a pytest-cov-compatible way of using `multiprocessing.Pool` in the pipx code.  This leaves a lot of malformed `.coverage.<computername>.<number>.<number>` files lying around, which cannot be combined together by `coverage` and generate warnings like this in our CI logs and during locally-run tests:
```
Coverage.py warning: Data file '/Users/runner/work/pipx/pipx/.coverage.Mac-1603002934033.local.1276.503379' doesn't seem to be a coverage data file: cannot unpack non-iterable NoneType object
```

(For some reason the current code "happens to work" with pytest-cov on linux with no warnings.)

The code modifications here prevent all of these warnings and almost all spurious `.coverage.*` files.  On my macOS system there is still one left-over `.coverage.<computername>.<number>.<number>` file left over that I have not been able to fix.  But at least all the warnings have gone away and this is a much improved situation.

### Incidental changes
I also removed the `--cov-config=.coveragerc` switch because we don't have a `.coveragerc` file.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
