### PR TITLE
Fix: reinstall should use the initial specifier

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@ dev
 
 - Added reinstall command for reinstalling a single venv.
 - Changed `pipx run` on non-Windows systems to actually replace pipx process with the app process instead of running it as a subprocess.  (Now using python's `os.exec*`)
-- [bugfix] fix bug with reinstall-all. Now the initial specifier is used 
+- [bugfix] Fixed bug with reinstall-all command when pachake have been installed using a specifier. Now the initial specifier is used.
 
 0.15.6.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@ dev
 
 - Added reinstall command for reinstalling a single venv.
 - Changed `pipx run` on non-Windows systems to actually replace pipx process with the app process instead of running it as a subprocess.  (Now using python's `os.exec*`)
+- [bugfix] fix bug with reinstall-all. Now the initial specifier is used 
 
 0.15.6.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@ dev
 
 - Added reinstall command for reinstalling a single venv.
 - Changed `pipx run` on non-Windows systems to actually replace pipx process with the app process instead of running it as a subprocess.  (Now using python's `os.exec*`)
-- [bugfix] Fixed bug with reinstall-all command when pachake have been installed using a specifier. Now the initial specifier is used.
+- [bugfix] Fixed bug with reinstall-all command when package have been installed using a specifier. Now the initial specifier is used.
 
 0.15.6.0
 

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -6,6 +6,7 @@ from pipx import constants
 from pipx.colors import bold, red
 from pipx.commands.common import expose_apps_globally
 from pipx.emojies import sleep
+from pipx.package_specifier import parse_specifier_for_upgrade
 from pipx.util import PipxError
 from pipx.venv import Venv, VenvContainer
 
@@ -42,7 +43,7 @@ def upgrade(
     if package_metadata.package_or_url is None:
         raise PipxError(f"Internal Error: package {package} has corrupt pipx metadata.")
 
-    package_or_url = package_metadata.package_or_url
+    package_or_url = parse_specifier_for_upgrade(package_metadata.package_or_url)
     old_version = package_metadata.package_version
     include_apps = package_metadata.include_apps
     include_dependencies = package_metadata.include_dependencies

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -161,12 +161,11 @@ def parse_specifier_for_metadata(package_spec: str) -> str:
 
     Specifically:
     * Strip any version specifiers (e.g. package == 1.5.4)
-    * Strip any markers (e.g. python_version > 3.4)
     * Convert local paths to absolute paths
     """
     parsed_package = _parse_specifier(package_spec)
     package_or_url = _parsed_package_to_package_or_url(
-        parsed_package, remove_version_specifiers=True
+        parsed_package, remove_version_specifiers=False
     )
     return package_or_url
 

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -185,9 +185,6 @@ def parse_specifier_for_upgrade(package_spec: str) -> str:
     return package_or_url
 
 
-#
-
-
 def valid_pypi_name(package_spec: str) -> Optional[str]:
     try:
         package_req = Requirement(package_spec)

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -160,7 +160,7 @@ def parse_specifier_for_metadata(package_spec: str) -> str:
     """Return package_or_url suitable for pipx metadata
 
     Specifically:
-    * Strip any version specifiers (e.g. package == 1.5.4)
+    * Strip any markers (e.g. python_version > 3.4)
     * Convert local paths to absolute paths
     """
     parsed_package = _parse_specifier(package_spec)
@@ -168,6 +168,24 @@ def parse_specifier_for_metadata(package_spec: str) -> str:
         parsed_package, remove_version_specifiers=False
     )
     return package_or_url
+
+
+def parse_specifier_for_upgrade(package_spec: str) -> str:
+    """Return package_or_url suitable for pip upgrade
+
+    Specifically:
+    * Strip any version specifiers (e.g. package == 1.5.4)
+    * Strip any markers (e.g. python_version > 3.4)
+    * Convert local paths to absolute paths
+    """
+    parsed_package = _parse_specifier(package_spec)
+    package_or_url = _parsed_package_to_package_or_url(
+        parsed_package, remove_version_specifiers=True
+    )
+    return package_or_url
+
+
+#
 
 
 def valid_pypi_name(package_spec: str) -> Optional[str]:

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -6,6 +6,7 @@ from pipx.package_specifier import (
     fix_package_name,
     parse_specifier_for_install,
     parse_specifier_for_metadata,
+    parse_specifier_for_upgrade,
     valid_pypi_name,
 )
 from pipx.util import PipxError
@@ -55,11 +56,11 @@ def test_fix_package_name(package_spec_in, package_name, package_spec_out):
     [
         ("pipx", "pipx", True),
         ("PiPx_stylized.name", "pipx-stylized-name", True),
-        ("pipx==0.15.0", "pipx", True),
-        ("pipx>=0.15.0", "pipx", True),
-        ("pipx<=0.15.0", "pipx", True),
+        ("pipx==0.15.0", "pipx==0.15.0", True),
+        ("pipx>=0.15.0", "pipx>=0.15.0", True),
+        ("pipx<=0.15.0", "pipx<=0.15.0", True),
         ('pipx;python_version>="3.6"', "pipx", True),
-        ('pipx==0.15.0;python_version>="3.6"', "pipx", True),
+        ('pipx==0.15.0;python_version>="3.6"', "pipx==0.15.0", True),
         ("pipx[extra1]", "pipx[extra1]", True),
         ("pipx[extra1, extra2]", "pipx[extra1,extra2]", True),
         ("src/pipx", str(Path("src/pipx").resolve()), True),
@@ -117,6 +118,75 @@ def test_parse_specifier_for_metadata(
         print(f"package_spec_in = {package_spec_in}")
         with pytest.raises(PipxError, match=r"^Unable to parse package spec"):
             package_or_url = parse_specifier_for_metadata(package_spec_in)
+
+
+@pytest.mark.parametrize(
+    "package_spec_in,package_or_url_correct,valid_spec",
+    [
+        ("pipx", "pipx", True),
+        ("PiPx_stylized.name", "pipx-stylized-name", True),
+        ("pipx==0.15.0", "pipx", True),
+        ("pipx>=0.15.0", "pipx", True),
+        ("pipx<=0.15.0", "pipx", True),
+        ('pipx;python_version>="3.6"', "pipx", True),
+        ('pipx==0.15.0;python_version>="3.6"', "pipx", True),
+        ("pipx[extra1]", "pipx[extra1]", True),
+        ("pipx[extra1, extra2]", "pipx[extra1,extra2]", True),
+        ("src/pipx", str(Path("src/pipx").resolve()), True),
+        (
+            "git+https://github.com/cs01/nox.git@5ea70723e9e6",
+            "git+https://github.com/cs01/nox.git@5ea70723e9e6",
+            True,
+        ),
+        (
+            "nox@git+https://github.com/cs01/nox.git@5ea70723e9e6",
+            "nox@ git+https://github.com/cs01/nox.git@5ea70723e9e6",
+            True,
+        ),
+        (
+            "https://github.com/ambv/black/archive/18.9b0.zip",
+            "https://github.com/ambv/black/archive/18.9b0.zip",
+            True,
+        ),
+        (
+            "black@https://github.com/ambv/black/archive/18.9b0.zip",
+            "black@ https://github.com/ambv/black/archive/18.9b0.zip",
+            True,
+        ),
+        (
+            "black @ https://github.com/ambv/black/archive/18.9b0.zip",
+            "black@ https://github.com/ambv/black/archive/18.9b0.zip",
+            True,
+        ),
+        (
+            "black[extra] @ https://github.com/ambv/black/archive/18.9b0.zip",
+            "black[extra]@ https://github.com/ambv/black/archive/18.9b0.zip",
+            True,
+        ),
+        (
+            'my-project[cli] @ git+ssh://git@bitbucket.org/my-company/myproject.git ; python_version<"3.7"',
+            "my-project[cli]@ git+ssh://git@bitbucket.org/my-company/myproject.git",
+            True,
+        ),
+        ("path/doesnt/exist", "non-existent-path", False,),
+        (
+            "https:/github.com/ambv/black/archive/18.9b0.zip",
+            "URL-syntax-error-slash",
+            False,
+        ),
+    ],
+)
+def test_parse_specifier_for_upgrade(
+    package_spec_in, package_or_url_correct, valid_spec
+):
+    if valid_spec:
+        package_or_url = parse_specifier_for_upgrade(package_spec_in)
+        assert package_or_url == package_or_url_correct
+    else:
+        # print package_spec_in for info in case no error is raised
+        print(f"package_spec_in = {package_spec_in}")
+        with pytest.raises(PipxError, match=r"^Unable to parse package spec"):
+            package_or_url = parse_specifier_for_upgrade(package_spec_in)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pipx_metadata_file.py
+++ b/tests/test_pipx_metadata_file.py
@@ -47,7 +47,7 @@ PYCOWSAY_PACKAGE_REF = PackageInfo(
 )
 BLACK_PACKAGE_REF = PackageInfo(
     package="black",
-    package_or_url="black",
+    package_or_url="black==19.10b0",
     pip_args=[],
     include_dependencies=False,
     include_apps=True,

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -41,3 +41,11 @@ def test_reinstall_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(
         ["reinstall", "--python", sys.executable, f"pycowsay{suffix}"]
     )
+
+def test_reinstall_specifier(pipx_temp_env, capsys):
+    with capsys.disabled():
+        assert not run_pipx_cli(["install", "pathlib2==2.0.1"])
+    
+    assert not run_pipx_cli(["reinstall", "--python", sys.executable, "2.0.1"])
+    captured = capsys.readouterr()
+    assert f"installed package 2.0.1 2.3.1" in captured.out

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -45,8 +45,8 @@ def test_reinstall_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
 
 def test_reinstall_specifier(pipx_temp_env, capsys):
     with capsys.disabled():
-        assert not run_pipx_cli(["install", "pathlib2==2.0.1"])
+        assert not run_pipx_cli(["install", "pylint==2.3.1"])
 
-    assert not run_pipx_cli(["reinstall", "--python", sys.executable, "2.0.1"])
+    assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pylint"])
     captured = capsys.readouterr()
-    assert "installed package 2.0.1 2.3.1" in captured.out
+    assert "installed package pylint 2.3.1" in captured.out

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -42,10 +42,11 @@ def test_reinstall_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
         ["reinstall", "--python", sys.executable, f"pycowsay{suffix}"]
     )
 
+
 def test_reinstall_specifier(pipx_temp_env, capsys):
     with capsys.disabled():
         assert not run_pipx_cli(["install", "pathlib2==2.0.1"])
-    
+
     assert not run_pipx_cli(["reinstall", "--python", sys.executable, "2.0.1"])
     captured = capsys.readouterr()
-    assert f"installed package 2.0.1 2.3.1" in captured.out
+    assert "installed package 2.0.1 2.3.1" in captured.out

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -38,8 +38,8 @@ def test_upgrade_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
 
 
 def test_upgrade_specifier(pipx_temp_env, capsys):
-    name = "pathlib2"
-    specifier = "==2.0.1"
+    name = "pylint"
+    specifier = "==2.3.1"
 
     assert not run_pipx_cli(["install", f"{name}{specifier}"])
     assert run_pipx_cli(["upgrade", f"{name}"])

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -35,3 +35,13 @@ def test_upgrade_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
     mock_legacy_venv(f"{name}{suffix}", metadata_version=metadata_version)
     assert run_pipx_cli(["upgrade", f"{name}"])
     assert not run_pipx_cli(["upgrade", f"{name}{suffix}"])
+
+
+def test_upgrade_specifier(pipx_temp_env, capsys):
+    name = "pathlib2"
+    specifier = "==2.0.1"
+
+    assert not run_pipx_cli(["install", f"{name}{specifier}"])
+    assert run_pipx_cli(["upgrade", f"{name}"])
+    captured = capsys.readouterr()
+    assert "upgraded package pathlib2 from 2.3.1 to" in captured.out

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -40,8 +40,9 @@ def test_upgrade_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
 def test_upgrade_specifier(pipx_temp_env, capsys):
     name = "pylint"
     specifier = "==2.3.1"
+    initial_version = "2.3.1"
 
     assert not run_pipx_cli(["install", f"{name}{specifier}"])
     assert run_pipx_cli(["upgrade", f"{name}"])
     captured = capsys.readouterr()
-    assert "upgraded package pathlib2 from 2.3.1 to" in captured.out
+    assert f"upgraded package {name} from {initial_version} to" in captured.out


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Fix #527 

To allow reinstall using the specifier used during installation, the specifier has been added to metadata.
The specifier is removed just before upgrading to allow `pip` command to fetch latest version. 

Test suite have been updated.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx install pylint==2.3.1
pipx reinstall pylint
pipx upgrade pylint
```

