### PR TITLE
Fix capsys

### DIFF
--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -44,8 +44,8 @@ def test_reinstall_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
 
 
 def test_reinstall_specifier(pipx_temp_env, capsys):
-    with capsys.disabled():
-        assert not run_pipx_cli(["install", "pylint==2.3.1"])
+    assert not run_pipx_cli(["install", "pylint==2.3.1"])
+    captured = capsys.readouterr()
 
     assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pylint"])
     captured = capsys.readouterr()

--- a/tests/test_reinstall.py
+++ b/tests/test_reinstall.py
@@ -45,6 +45,8 @@ def test_reinstall_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
 
 def test_reinstall_specifier(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pylint==2.3.1"])
+
+    # clear capsys before reinstall
     captured = capsys.readouterr()
 
     assert not run_pipx_cli(["reinstall", "--python", sys.executable, "pylint"])


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Follow-up to #530 

Use a read of `capsys.readouterr()` to reset capsys before checking reinstall output, instead of using `capsys.disabled()` as before.

`capsys.disabled()` stops capturing stdout and stderr, sending both to the logs, making too much noise.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
