### PR TITLE
Fix monkeypatch of PIPX_SHARED_LIBS to actually work.

### DIFF
--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -4,8 +4,9 @@ import time
 from pathlib import Path
 from typing import List
 
+from pipx import constants
 from pipx.animate import animate
-from pipx.constants import PIPX_SHARED_LIBS, WINDOWS
+from pipx.constants import WINDOWS
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.util import get_site_packages, get_venv_paths, run_verify
 
@@ -14,7 +15,7 @@ SHARED_LIBS_MAX_AGE_SEC = datetime.timedelta(days=30).total_seconds()
 
 class _SharedLibs:
     def __init__(self):
-        self.root = PIPX_SHARED_LIBS
+        self.root = constants.PIPX_SHARED_LIBS
         self.bin_path, self.python_path = get_venv_paths(self.root)
         self.pip_path = self.bin_path / ("pip" if not WINDOWS else "pip.exe")
         # i.e. bin_path is ~/.local/pipx/shared/bin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ def pipx_temp_env(tmp_path, monkeypatch):
     bin_dir = Path(tmp_path) / "otherdir" / "pipxbindir"
 
     monkeypatch.setattr(constants, "PIPX_SHARED_LIBS", shared_dir)
-    # re-initialize shared_libs to get new monkeypatched PIPX_SHARED_LIBS
     monkeypatch.setattr(shared_libs, "shared_libs", shared_libs._SharedLibs())
     monkeypatch.setattr(venv, "shared_libs", shared_libs.shared_libs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest  # type: ignore
 
-from pipx import constants
+from pipx import constants, shared_libs, venv
 
 
 @pytest.fixture
@@ -17,6 +17,10 @@ def pipx_temp_env(tmp_path, monkeypatch):
     bin_dir = Path(tmp_path) / "otherdir" / "pipxbindir"
 
     monkeypatch.setattr(constants, "PIPX_SHARED_LIBS", shared_dir)
+    # re-initialize shared_libs to get new monkeypatched PIPX_SHARED_LIBS
+    monkeypatch.setattr(shared_libs, "shared_libs", shared_libs._SharedLibs())
+    monkeypatch.setattr(venv, "shared_libs", shared_libs.shared_libs)
+
     monkeypatch.setattr(constants, "PIPX_HOME", home_dir)
     monkeypatch.setattr(constants, "LOCAL_BIN_DIR", bin_dir)
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
In our tests, the monkeypatch of `constants.PIPX_SHARED_LIBS` was not really changing where pipx stored shared libs.  This is due to the fact that `shared_libs.py` only creates the instance `shared_libs` on import, and `venv.py` also only fetches `shared_libs.shared_libs` on import.

This change to the `pipx_temp_env` pytest fixture re-instances the `shared_libs` instance inside of both `shared_libs.py` and `venv.py` to use the new monkey-patched location for `constants.PIPX_SHARED_LIBS`.  It successfully changes where pipx stores its shared libraries during test.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
I tested by adding
```
        print(f"Venv: {shared_libs.root = }")
```
inside of `venv.py`, `Venv.__init__()` (temporarily, in uncommitted code!)