### PR TITLE
Wrap environment variable documentation to match rest of help output

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ dev
 - Changed `pipx run` on non-Windows systems to actually replace pipx process with the app process instead of running it as a subprocess.  (Now using python's `os.exec*`)
 - [bugfix] Fixed bug with reinstall-all command when package have been installed using a specifier. Now the initial specifier is used.
 - [bugfix] Override display of DEFAULT_PYTHON value when generating web documentation for `pipx install` #523
+- [bugfix] Wrap help documentation for environment variables.
 
 0.15.6.0
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import sys
 import textwrap
 import urllib.parse
@@ -28,32 +29,47 @@ def print_version() -> None:
     print(__version__)
 
 
+def indented_wrap(text, subsequent_indent="", split="\n", **kwargs):
+    text = textwrap.dedent(text).strip()
+    width = shutil.get_terminal_size().columns - 2
+    return "\n".join(
+        [
+            textwrap.fill(line, width=width, subsequent_indent=subsequent_indent)
+            for line in text.splitlines()
+        ]
+    )
+
+
 SPEC_HELP = textwrap.dedent(
     """The package name or specific installation source passed to pip.
     Runs `pip install -U SPEC`.
     For example `--spec mypackage==2.0.0` or `--spec  git+https://github.com/user/repo.git@branch`
     """
 )
+
 PIPX_DESCRIPTION = textwrap.dedent(
     f"""
-Install and execute apps from Python packages.
+        Install and execute apps from Python packages.
 
-Binaries can either be installed globally into isolated Virtual Environments
-or run directly in an temporary Virtual Environment.
+        Binaries can either be installed globally into isolated Virtual Environments
+        or run directly in an temporary Virtual Environment.
 
-Virtual Environment location is {str(constants.PIPX_LOCAL_VENVS)}.
-Symlinks to apps are placed in {str(constants.LOCAL_BIN_DIR)}.
+        Virtual Environment location is {str(constants.PIPX_LOCAL_VENVS)}.
+        Symlinks to apps are placed in {str(constants.LOCAL_BIN_DIR)}.
 
-Optional Environment Variables:
-PIPX_HOME: Overrides default pipx location. Virtual Environments
-will be installed to $PIPX_HOME/venvs.
-PIPX_BIN_DIR: Overrides location of app installations. Apps are symlinked
-or copied here.
-USE_EMOJI: Override emoji behavior. Default value varies based on platform.
-PIPX_DEFAULT_PYTHON: Overrides default python used for commands.
-"""
+        """
 )
-
+PIPX_DESCRIPTION += "\n"
+PIPX_DESCRIPTION += indented_wrap(
+    """
+        optional environment variables:
+          PIPX_HOME:           Overrides default pipx location. Virtual Environments will be installed to $PIPX_HOME/venvs.
+          PIPX_BIN_DIR:        Overrides location of app installations. Apps are symlinked or copied here.
+          USE_EMOJI:           Override emoji behavior. Default value varies based on platform.
+          PIPX_DEFAULT_PYTHON: Overrides default python used for commands.
+    """,
+    " " * 23,  # magic number 23 matches the indent of the env descriptions.
+)
 
 DOC_DEFAULT_PYTHON = os.getenv("PIPX__DOC_DEFAULT_PYTHON", DEFAULT_PYTHON)
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -63,12 +63,12 @@ PIPX_DESCRIPTION += "\n"
 PIPX_DESCRIPTION += indented_wrap(
     """
         optional environment variables:
-          PIPX_HOME:           Overrides default pipx location. Virtual Environments will be installed to $PIPX_HOME/venvs.
-          PIPX_BIN_DIR:        Overrides location of app installations. Apps are symlinked or copied here.
-          USE_EMOJI:           Override emoji behavior. Default value varies based on platform.
-          PIPX_DEFAULT_PYTHON: Overrides default python used for commands.
+          PIPX_HOME             Overrides default pipx location. Virtual Environments will be installed to $PIPX_HOME/venvs.
+          PIPX_BIN_DIR          Overrides location of app installations. Apps are symlinked or copied here.
+          USE_EMOJI             Overrides emoji behavior. Default value varies based on platform.
+          PIPX_DEFAULT_PYTHON   Overrides default python used for commands.
     """,
-    " " * 23,  # magic number 23 matches the indent of the env descriptions.
+    " " * 24,  # match the indent of argparse options
 )
 
 DOC_DEFAULT_PYTHON = os.getenv("PIPX__DOC_DEFAULT_PYTHON", DEFAULT_PYTHON)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -31,7 +31,8 @@ def print_version() -> None:
 
 def indented_wrap(text, subsequent_indent="", split="\n", **kwargs):
     text = textwrap.dedent(text).strip()
-    width = shutil.get_terminal_size().columns - 2
+    minimum_width = 40
+    width = max(shutil.get_terminal_size((80, 40)).columns, minimum_width) - 2
     return "\n".join(
         [
             textwrap.fill(line, width=width, subsequent_indent=subsequent_indent)


### PR DESCRIPTION
* changed case to match the output of argparse doc section headers.
* This is the same shutil command that argparse uses under the hood
  for determining the width for wrapping.
* indent long strings that are already processed by dedent.
* shutil is already installed as a requirement for argparse.
* The env lines end up long (longer than 88) to work correctly for
  wrapping and indenting.

Addresses wrapping issue mentioned in #523:

| Also, another minor improvement would be to get this help text to
| properly wrap when being viewed from the command (It currently
| doesn't wrap on the console properly.)

<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
# Run help with various screen widths.  Compare with output of command sent into pipe which does not detect width:

# wide terminal, mine is 137:
% echo $COLUMNS
137
% pipx --version
[...snip...]
optional environment variables:
  PIPX_HOME:           Overrides default pipx location. Virtual Environments will be installed to $PIPX_HOME/venvs.
  PIPX_BIN_DIR:        Overrides location of app installations. Apps are symlinked or copied here.
  USE_EMOJI:           Override emoji behavior. Default value varies based on platform.
  PIPX_DEFAULT_PYTHON: Overrides default python used for commands.
[...snip...]

# capped to a default 78 chars:
% pipx --version | cat

[...snip...]
optional environment variables:
  PIPX_HOME:           Overrides default pipx location. Virtual Environments
                       will be installed to $PIPX_HOME/venvs.
  PIPX_BIN_DIR:        Overrides location of app installations. Apps are
                       symlinked or copied here.
  USE_EMOJI:           Override emoji behavior. Default value varies based on
                       platform.
  PIPX_DEFAULT_PYTHON: Overrides default python used for commands.
[...snip...]

# tiny screen
% echo $COLUMNS
55
% pipx --help
[...snip...]
optional environment variables:
  PIPX_HOME:           Overrides default pipx
                       location. Virtual Environments
                       will be installed to
                       $PIPX_HOME/venvs.
  PIPX_BIN_DIR:        Overrides location of app
                       installations. Apps are
                       symlinked or copied here.
  USE_EMOJI:           Override emoji behavior.
                       Default value varies based on
                       platform.
  PIPX_DEFAULT_PYTHON: Overrides default python used
                       for commands.

optional arguments:
  -h, --help            show this help message and
                        exit
  --version             Print version and exit
[...snip...]
```

