### PR TITLE
Fix/default python during nox test

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ dev
 - Added reinstall command for reinstalling a single venv.
 - Changed `pipx run` on non-Windows systems to actually replace pipx process with the app process instead of running it as a subprocess.  (Now using python's `os.exec*`)
 - [bugfix] Fixed bug with reinstall-all command when package have been installed using a specifier. Now the initial specifier is used.
+- [bugfix] Override display of DEFAULT_PYTHON value when generating web documentation for `pipx install` #523
 
 0.15.6.0
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -77,6 +77,7 @@ def lint(session):
 @nox.session(python="3.8")
 def docs(session):
     session.install(*doc_dependencies)
+    session.env["PIPX__DOC_DEFAULT_PYTHON"] = "/usr/bin/python"
     session.run("python", "generate_docs.py")
     session.run("mkdocs", "build")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -77,7 +77,7 @@ def lint(session):
 @nox.session(python="3.8")
 def docs(session):
     session.install(*doc_dependencies)
-    session.env["PIPX__DOC_DEFAULT_PYTHON"] = "/usr/bin/python"
+    session.env["PIPX__DOC_DEFAULT_PYTHON"] = "typically the python used to execute pipx"
     session.run("python", "generate_docs.py")
     session.run("mkdocs", "build")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -77,7 +77,9 @@ def lint(session):
 @nox.session(python="3.8")
 def docs(session):
     session.install(*doc_dependencies)
-    session.env["PIPX__DOC_DEFAULT_PYTHON"] = "typically the python used to execute pipx"
+    session.env[
+        "PIPX__DOC_DEFAULT_PYTHON"
+    ] = "typically the python used to execute pipx"
     session.run("python", "generate_docs.py")
     session.run("mkdocs", "build")
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -53,37 +53,37 @@ PIPX_DEFAULT_PYTHON: Overrides default python used for commands.
 """
 )
 
-INSTALL_DESCRIPTION = f"""
-The install command is the preferred way to globally install apps
-from python packages on your system. It creates an isolated virtual
-environment for the package, then ensures the package's apps are
-accessible on your $PATH.
+INSTALL_DESCRIPTION = textwrap.dedent(f"""
+    The install command is the preferred way to globally install apps
+    from python packages on your system. It creates an isolated virtual
+    environment for the package, then ensures the package's apps are
+    accessible on your $PATH.
 
-The result: apps you can run from anywhere, located in packages
-you can cleanly upgrade or uninstall. Guaranteed to not have
-dependency version conflicts or interfere with your OS's python
-packages. 'sudo' is not required to do this.
+    The result: apps you can run from anywhere, located in packages
+    you can cleanly upgrade or uninstall. Guaranteed to not have
+    dependency version conflicts or interfere with your OS's python
+    packages. 'sudo' is not required to do this.
 
-pipx install PACKAGE_NAME
-pipx install --python PYTHON PACKAGE_NAME
-pipx install VCS_URL
-pipx install ./LOCAL_PATH
-pipx install ZIP_FILE
-pipx install TAR_GZ_FILE
+    pipx install PACKAGE_NAME
+    pipx install --python PYTHON PACKAGE_NAME
+    pipx install VCS_URL
+    pipx install ./LOCAL_PATH
+    pipx install ZIP_FILE
+    pipx install TAR_GZ_FILE
 
-The PACKAGE_SPEC argument is passed directly to `pip install`.
+    The PACKAGE_SPEC argument is passed directly to `pip install`.
 
-The default virtual environment location is {constants.DEFAULT_PIPX_HOME}
-and can be overridden by setting the environment variable `PIPX_HOME`
- (Virtual Environments will be installed to `$PIPX_HOME/venvs`).
+    The default virtual environment location is {constants.DEFAULT_PIPX_HOME}
+    and can be overridden by setting the environment variable `PIPX_HOME`
+    (Virtual Environments will be installed to `$PIPX_HOME/venvs`).
 
-The default app location is {constants.DEFAULT_PIPX_BIN_DIR} and can be
-overridden by setting the environment variable `PIPX_BIN_DIR`.
+    The default app location is {constants.DEFAULT_PIPX_BIN_DIR} and can be
+    overridden by setting the environment variable `PIPX_BIN_DIR`.
 
-The default python executable used to install a package is
-{DEFAULT_PYTHON} and can be overridden by setting the environment
-variable `PIPX_DEFAULT_PYTHON`.
-"""
+    The default python executable used to install a package is
+    {DEFAULT_PYTHON} and can be overridden by setting the environment
+    variable `PIPX_DEFAULT_PYTHON`.
+    """)
 
 
 class LineWrapRawTextHelpFormatter(argparse.RawDescriptionHelpFormatter):

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -5,6 +5,7 @@
 import argparse
 import functools
 import logging
+import os
 import re
 import shlex
 import sys
@@ -53,7 +54,11 @@ PIPX_DEFAULT_PYTHON: Overrides default python used for commands.
 """
 )
 
-INSTALL_DESCRIPTION = textwrap.dedent(f"""
+
+DOC_DEFAULT_PYTHON = os.getenv("PIPX__DOC_DEFAULT_PYTHON", DEFAULT_PYTHON)
+
+INSTALL_DESCRIPTION = textwrap.dedent(
+    f"""
     The install command is the preferred way to globally install apps
     from python packages on your system. It creates an isolated virtual
     environment for the package, then ensures the package's apps are
@@ -81,9 +86,10 @@ INSTALL_DESCRIPTION = textwrap.dedent(f"""
     overridden by setting the environment variable `PIPX_BIN_DIR`.
 
     The default python executable used to install a package is
-    {DEFAULT_PYTHON} and can be overridden by setting the environment
+    {DOC_DEFAULT_PYTHON} and can be overridden by setting the environment
     variable `PIPX_DEFAULT_PYTHON`.
-    """)
+    """
+)
 
 
 class LineWrapRawTextHelpFormatter(argparse.RawDescriptionHelpFormatter):

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -86,8 +86,8 @@ INSTALL_DESCRIPTION = textwrap.dedent(
     overridden by setting the environment variable `PIPX_BIN_DIR`.
 
     The default python executable used to install a package is
-    {DOC_DEFAULT_PYTHON} and can be overridden by setting the environment
-    variable `PIPX_DEFAULT_PYTHON`.
+    {DOC_DEFAULT_PYTHON} and can be overridden
+    by setting the environment variable `PIPX_DEFAULT_PYTHON`.
     """
 )
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes

% nox -s docs
# view changes in docs/docs.md
% grep overridden docs/docs.md | tail -1
/usr/bin/python and can be overridden by setting the environment

# compare with output when `PIPX__DOX_DEFAULT_PYTHON` is not set.
% pipx install --help |grep overridden |tail -1
/homd/spazm/src/github/spazm/pipx/venv/bin/python and can be overridden by setting the environment
```
