### PR TITLE
Windows: uninstall: check if app file exists before unlinking

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ dev
 - [bugfix] Fixed bug with reinstall-all command when package have been installed using a specifier. Now the initial specifier is used.
 - [bugfix] Override display of DEFAULT_PYTHON value when generating web documentation for `pipx install` #523
 - [bugfix] Wrap help documentation for environment variables.
+- [bugfix] Fixed uninstall crash that could happen on Windows for certain packages
 
 0.15.6.0
 

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -55,13 +55,13 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool):
                 ]
                 app_paths = apps_linking_to_venv_bin_dir
 
-    for file in local_bin_dir.iterdir():
+    for filepath in local_bin_dir.iterdir():
         if WINDOWS:
             for b in app_paths:
-                if file.name == b.name:
-                    file.unlink()
+                if filepath.exists() and filepath.name == b.name:
+                    filepath.unlink()
         else:
-            symlink = file
+            symlink = filepath
             for b in app_paths:
                 if symlink.exists() and b.exists() and symlink.samefile(b):
                     logging.info(f"removing symlink {str(symlink)}")

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -9,6 +9,11 @@ def test_uninstall(pipx_temp_env, capsys):
     assert not run_pipx_cli(["uninstall", "pycowsay"])
 
 
+def test_uninstall_multiple_same_app(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["install", "kaggle=1.5.9", "--include-deps"])
+    assert not run_pipx_cli(["uninstall", "kaggle"])
+
+
 @pytest.mark.parametrize("metadata_version", [None, "0.1"])
 def test_uninstall_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not run_pipx_cli(["install", "pycowsay"])

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -10,7 +10,7 @@ def test_uninstall(pipx_temp_env, capsys):
 
 
 def test_uninstall_multiple_same_app(pipx_temp_env, capsys):
-    assert not run_pipx_cli(["install", "kaggle=1.5.9", "--include-deps"])
+    assert not run_pipx_cli(["install", "kaggle==1.5.9", "--include-deps"])
     assert not run_pipx_cli(["uninstall", "kaggle"])
 
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Add a check on Windows if a file still exists before trying to unlink it during install.  This is important if the same app name shows up twice in the list of apps, and the app is deleted first before trying to delete it again.  Previously, this would result in a crash on Windows.

Possibly fixes and definitely pertains to #540 .

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running on Windows:
```
> pipx install kaggle==1.5.9 --include-deps
  Overwriting file C:\Users\mclapp\.local\bin\slugify with C:\Users\mclapp\.local\pipx\venvs\kaggle\Scripts\slugify
done!
creating virtual environment...
installing kaggle from spec 'kaggle==1.5.9'...
  installed package kaggle 1.5.9, Python 3.9.0
  These apps are now globally available
    - chardetect.exe
    - kaggle.exe
    - slugify
    - slugify.exe
    - tqdm.exe
> pipx uninstall kaggle
uninstalled kaggle!
```

Previously, this would crash like so:
```
> pipx install kaggle==1.5.9 --include-deps
  Overwriting file C:\Users\mclapp\.local\bin\slugify with C:\Users\mclapp\.local\pipx\venvs\kaggle\Scripts\slugify
done!
creating virtual environment...
installing kaggle from spec 'kaggle==1.5.9'...
  installed package kaggle 1.5.9, Python 3.9.0
  These apps are now globally available
    - chardetect.exe
    - kaggle.exe
    - slugify
    - slugify.exe
    - tqdm.exe
> pipx uninstall kaggle
Traceback (most recent call last):
  File "c:\program files\python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\program files\python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\mclapp\AppData\Roaming\Python\Python39\Scripts\pipx.exe\__main__.py", line 7, in <module>
  File "C:\Users\mclapp\AppData\Roaming\Python\Python39\site-packages\pipx\main.py", line 609, in cli
    return run_pipx_command(parsed_pipx_args)
  File "C:\Users\mclapp\AppData\Roaming\Python\Python39\site-packages\pipx\main.py", line 192, in run_pipx_command
    return commands.uninstall(venv_dir, constants.LOCAL_BIN_DIR, verbose)
  File "C:\Users\mclapp\AppData\Roaming\Python\Python39\site-packages\pipx\commands\uninstall.py", line 62, in uninstall
    file.unlink()
  File "c:\program files\python39\lib\pathlib.py", line 1343, in unlink
    self._accessor.unlink(self)
FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\Users\\mclapp\\.local\\bin\\slugify'
```
