### PR TITLE
venv_dir, skip arguments: canonicalize before matching existing venv dirs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,13 +6,13 @@ dev
 - [bugfix] Override display of DEFAULT_PYTHON value when generating web documentation for `pipx install` #523
 - [bugfix] Wrap help documentation for environment variables.
 - [bugfix] Fixed uninstall crash that could happen on Windows for certain packages
-- [feature] Venv package name arguments now do not have to match exactly as pipx has them stored, but can be specified in any python-package-name-equivalent way. (i.e. case does not matter, and any number of `.`, `-`, or `_` characters in a row are equivalent.)
+- [feature] Venv package name arguments now do not have to match exactly as pipx has them stored, but can be specified in any python-package-name-equivalent way. (i.e. case does not matter, and `.`, `-`, `_` characters are interchangeable.)
 - [change] Venvs with a suffix: A suffix can contain any characters, but for purposes of uniqueness, python package name rules apply--upper- and lower-case letters are equivalent, and any number of `.`, `-`, or `_` characters in a row are equivalent.  (e.g. if you have a suffixed venv `pylint_1.0A` you could not add another suffixed venv called `pylint--1-0a`, as it would not be a unique name.)
 
 0.15.6.0
 
 - [docs] Update license
-- [docs] Display a more idomatic command for registering completions on fish.
+- [docs] Display a more idiomatic command for registering completions on fish.
 - [bugfix] Fixed regression in list, inject, upgrade, reinstall-all commands when suffixed packages are used.
 - [bugfix] Do not reset package url during upgrade when main package is `pipx`
 - Updated help text to show description for `ensurepath` and `completions` help
@@ -57,7 +57,7 @@ dev
 - [bugfix] Replaced implicit dependency on setuptools with an explicit dependency on packaging (#339).
 - [bugfix] Continue reinstalling packages after failure
 - [bugfix] Hide cursor while pipx runs
-- [feature] Add environment variable `USE_EMOJI` to allow enabling/disabling emojies (#376)
+- [feature] Add environment variable `USE_EMOJI` to allow enabling/disabling emojis (#376)
 - [refactor] Moved all commands to separate files within the commands module (#255).
 - [bugfix] Ignore system shared libraries when installing shared libraries pip, wheel, and setuptools. This also fixes an incompatibility with Debian/Ubuntu's version of pip (#386).
 
@@ -93,13 +93,13 @@ Upgrade instructions: When upgrading to 0.15.0.0 or above from a pre-0.15.0.0 ve
 - `reinstall-all` options `--include-deps`, `--system-site-packages`, `--index-url`, `--editable`, and `--pip-args` were removed. Pipx now uses the original options used to install each application instead. (#222)
 - Handle missing interpreters more gracefully (#146)
 - Change `reinstall-all` to use system python by default for apps. Now use `--python` option to specify a different python version.
-- Remove the PYTHONPATH environment variable when executing any command to prevent conflicts between pipx dependencies and package dependencies when pipx is installed via homebrew. Homebrew can use pythonpath manipulation instead of virtual environments. (#233)
+- Remove the PYTHONPATH environment variable when executing any command to prevent conflicts between pipx dependencies and package dependencies when pipx is installed via homebrew. Homebrew can use PYTHONPATH manipulation instead of virtual environments. (#233)
 - Add printed summary after successful call to `pipx inject`
 - Support associating apps with Python 3.5
 - Improvements to animation status text
 - Make `--python` argument in `reinstall-all` command optional
 - Use threads on OS's without support for semaphores
-- Stricter parsing when passing `--` argument as delimeter
+- Stricter parsing when passing `--` argument as delimiter
 
 0.14.0.0
 
@@ -116,7 +116,7 @@ Upgrade instructions: When upgrading to 0.15.0.0 or above from a pre-0.15.0.0 ve
 
 0.13.2.2
 
-- Remove unneccesary and sometimes incorrect check after `pipx inject` (#195)
+- Remove unnecessary and sometimes incorrect check after `pipx inject` (#195)
 - Make status text/animation reliably disappear before continuing
 - Update animation symbols
 
@@ -176,7 +176,7 @@ Upgrade instructions: When upgrading to 0.15.0.0 or above from a pre-0.15.0.0 ve
 - Add `--include-deps` argument to include binaries of dependent packages when installing with pipx. This improves compatibility with packages that depend on other installed packages, such as `jupyter`.
 - Speed up `pipx list` output (by running multiple processes in parallel) and by collecting all metadata in a single subprocess call
 - More aggressive cache directory removal when `--no-cache` is passed to `pipx run`
-- [dev] Move inline text passed to subprocess calls to their own files to enable autoformating, linting, unit testing
+- [dev] Move inline text passed to subprocess calls to their own files to enable autoformatting, linting, unit testing
 
 0.12.2.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ dev
 - [bugfix] Wrap help documentation for environment variables.
 - [bugfix] Fixed uninstall crash that could happen on Windows for certain packages
 - [feature] Venv package name arguments now do not have to match exactly as pipx has them stored, but can be specified in any python-package-name-equivalent way. (e.g. case does not matter, certain punctuation does not matter.)
+- [change] Venvs with a suffix: A suffix can contain any characters, but for purposes of uniqueness, python package name rules apply--upper- and lower-case letters are equivalent, and any number of ., -, or _ characters in a row are equivalent.  (e.g. if you have a suffixed venv `pylint_1.0A you could not add another suffixed venv called pylint--1-0a, as it would not be a unique name.)
 
 0.15.6.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@ dev
 - [bugfix] Override display of DEFAULT_PYTHON value when generating web documentation for `pipx install` #523
 - [bugfix] Wrap help documentation for environment variables.
 - [bugfix] Fixed uninstall crash that could happen on Windows for certain packages
-- [feature] Venv package name arguments now do not have to match exactly as pipx has them stored, but can be specified in any python-package-name-equivalent way. (e.g. case does not matter, certain punctuation does not matter.)
+- [feature] Venv package name arguments now do not have to match exactly as pipx has them stored, but can be specified in any python-package-name-equivalent way. (i.e. case does not matter, and any number of `.`, `-`, or `_` characters in a row are equivalent.)
 - [change] Venvs with a suffix: A suffix can contain any characters, but for purposes of uniqueness, python package name rules apply--upper- and lower-case letters are equivalent, and any number of `.`, `-`, or `_` characters in a row are equivalent.  (e.g. if you have a suffixed venv `pylint_1.0A` you could not add another suffixed venv called `pylint--1-0a`, as it would not be a unique name.)
 
 0.15.6.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ dev
 - [bugfix] Wrap help documentation for environment variables.
 - [bugfix] Fixed uninstall crash that could happen on Windows for certain packages
 - [feature] Venv package name arguments now do not have to match exactly as pipx has them stored, but can be specified in any python-package-name-equivalent way. (e.g. case does not matter, certain punctuation does not matter.)
-- [change] Venvs with a suffix: A suffix can contain any characters, but for purposes of uniqueness, python package name rules apply--upper- and lower-case letters are equivalent, and any number of ., -, or _ characters in a row are equivalent.  (e.g. if you have a suffixed venv `pylint_1.0A you could not add another suffixed venv called pylint--1-0a, as it would not be a unique name.)
+- [change] Venvs with a suffix: A suffix can contain any characters, but for purposes of uniqueness, python package name rules apply--upper- and lower-case letters are equivalent, and any number of `.`, `-`, or `_` characters in a row are equivalent.  (e.g. if you have a suffixed venv `pylint_1.0A` you could not add another suffixed venv called `pylint--1-0a`, as it would not be a unique name.)
 
 0.15.6.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ dev
 - [bugfix] Override display of DEFAULT_PYTHON value when generating web documentation for `pipx install` #523
 - [bugfix] Wrap help documentation for environment variables.
 - [bugfix] Fixed uninstall crash that could happen on Windows for certain packages
+- [feature] Venv package name arguments now do not have to match pipx's canonical package name format, but can be specified in any python-package-name-equivalent way. (e.g. case does not matter, certain punctuation does not matter.)
 
 0.15.6.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@ dev
 - [bugfix] Override display of DEFAULT_PYTHON value when generating web documentation for `pipx install` #523
 - [bugfix] Wrap help documentation for environment variables.
 - [bugfix] Fixed uninstall crash that could happen on Windows for certain packages
-- [feature] Venv package name arguments now do not have to match pipx's canonical package name format, but can be specified in any python-package-name-equivalent way. (e.g. case does not matter, certain punctuation does not matter.)
+- [feature] Venv package name arguments now do not have to match exactly as pipx has them stored, but can be specified in any python-package-name-equivalent way. (e.g. case does not matter, certain punctuation does not matter.)
 
 0.15.6.0
 

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -36,10 +36,10 @@ def inject(
 
     if not venv.package_metadata:
         raise PipxError(
-            f"Can't inject {package_spec!r} into Virtual Environment {venv_dir.name!r}.\n"
-            f"    {venv_dir.name!r} has missing internal pipx metadata.\n"
+            f"Can't inject {package_spec!r} into Virtual Environment {venv.name!r}.\n"
+            f"    {venv.name!r} has missing internal pipx metadata.\n"
             "    It was likely installed using a pipx version before 0.15.0.0.\n"
-            f"    Please uninstall and install {venv_dir.name!r}, or reinstall-all to fix."
+            f"    Please uninstall and install {venv.name!r}, or reinstall-all to fix."
         )
 
     # package_spec is anything pip-installable, including package_name, vcs spec,
@@ -67,5 +67,5 @@ def inject(
             force=force,
         )
 
-    print(f"  injected package {bold(package_name)} into venv {bold(venv_dir.name)}")
+    print(f"  injected package {bold(package_name)} into venv {bold(venv.name)}")
     print(f"done! {stars}", file=sys.stderr)

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -36,18 +36,18 @@ def install(
     except StopIteration:
         exists = False
 
+    venv = Venv(venv_dir, python=python, verbose=verbose)
     if exists:
         if force:
-            print(f"Installing to existing directory {str(venv_dir)!r}")
+            print(f"Installing to existing venv {venv.name!r}")
         else:
             print(
-                f"{venv_dir.name!r} already seems to be installed. "
+                f"{venv.name!r} already seems to be installed. "
                 f"Not modifying existing installation in {str(venv_dir)!r}. "
                 "Pass '--force' to force installation."
             )
             return
 
-    venv = Venv(venv_dir, python=python, verbose=verbose)
     try:
         venv.create_venv(venv_args, pip_args)
         venv.install_package(

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -29,9 +29,7 @@ def install(
         )
     if venv_dir is None:
         venv_container = VenvContainer(constants.PIPX_LOCAL_VENVS)
-        venv_dir = venv_container.get_venv_dir(package_name)
-        if suffix != "":
-            venv_dir = venv_dir.parent / f"{venv_dir.stem}{suffix}"
+        venv_dir = venv_container.get_venv_dir(f"{package_name}{suffix}")
 
     try:
         exists = venv_dir.exists() and next(venv_dir.iterdir())

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import List
+from typing import List, Sequence
 
 from pipx.commands.inject import inject
 from pipx.commands.install import install
@@ -73,7 +73,7 @@ def reinstall_all(
     python: str,
     verbose: bool,
     *,
-    skip: List[str],
+    skip: Sequence[str],
 ) -> int:
     """Returns pipx shell exit code"""
     failed: List[str] = []

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -51,7 +51,7 @@ def reinstall(
             # This should never happen, but package_or_url is type
             #   Optional[str] so mypy thinks it could be None
             raise PipxError(
-                f"Internal Error injecting package {injected_package} into {venv_dir.name}"
+                f"Internal Error injecting package {injected_package} into {venv.name}"
             )
         inject(
             venv_dir,

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -68,7 +68,7 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool):
                     symlink.unlink()
 
     rmdir(venv_dir)
-    print(f"uninstalled {venv_dir.name}! {stars}")
+    print(f"uninstalled {venv.name}! {stars}")
 
 
 def uninstall_all(venv_container: VenvContainer, local_bin_dir: Path, verbose: bool):

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List
+from typing import List, Sequence
 
 from pipx import constants
 from pipx.colors import bold, red
@@ -99,7 +99,7 @@ def upgrade(
 
 
 def upgrade_all(
-    venv_container: VenvContainer, verbose: bool, *, skip: List[str], force: bool
+    venv_container: VenvContainer, verbose: bool, *, skip: Sequence[str], force: bool
 ):
     venv_error = False
     venvs_upgraded = 0

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -15,6 +15,7 @@ import urllib.parse
 from typing import Dict, List
 
 import argcomplete  # type: ignore
+from packaging.utils import canonicalize_name
 
 from . import commands, constants
 from .animate import hide_cursor, show_cursor
@@ -156,6 +157,8 @@ def run_pipx_command(args: argparse.Namespace) -> int:  # noqa: C901
 
         venv_dir = venv_container.get_venv_dir(package)
         logging.info(f"Virtual Environment location is {venv_dir}")
+    if "skip" in args:
+        skip_list = [canonicalize_name(x) for x in args.skip]
 
     if args.command == "run":
         package_or_url = (
@@ -224,7 +227,7 @@ def run_pipx_command(args: argparse.Namespace) -> int:  # noqa: C901
         return commands.uninstall_all(venv_container, constants.LOCAL_BIN_DIR, verbose)
     elif args.command == "upgrade-all":
         return commands.upgrade_all(
-            venv_container, verbose, skip=args.skip, force=args.force
+            venv_container, verbose, skip=skip_list, force=args.force
         )
     elif args.command == "reinstall":
         return commands.reinstall(
@@ -239,7 +242,7 @@ def run_pipx_command(args: argparse.Namespace) -> int:  # noqa: C901
             constants.LOCAL_BIN_DIR,
             args.python,
             verbose,
-            skip=args.skip,
+            skip=skip_list,
         )
     elif args.command == "runpip":
         if not venv_dir:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -105,6 +105,17 @@ class Venv:
                 )
 
     @property
+    def name(self) -> str:
+        if self.pipx_metadata.main_package is not None:
+            venv_name = (
+                f"{self.main_package_name}"
+                f"{self.package_metadata[self.main_package_name].suffix}"
+            )
+        else:
+            venv_name = self.root.name
+        return venv_name
+
+    @property
     def uses_shared_libs(self) -> bool:
         if self._existing:
             pth_files = self.root.glob("**/" + PIPX_SHARED_PTH)

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -108,8 +108,7 @@ class Venv:
     def name(self) -> str:
         if self.pipx_metadata.main_package is not None:
             venv_name = (
-                f"{self.main_package_name}"
-                f"{self.package_metadata[self.main_package_name].suffix}"
+                f"{self.main_package_name}" f"{self.pipx_metadata.main_package.suffix}"
             )
         else:
             venv_name = self.root.name

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -106,9 +106,10 @@ class Venv:
 
     @property
     def name(self) -> str:
-        if self.pipx_metadata.main_package is not None:
+        if self.pipx_metadata.main_package.package is not None:
             venv_name = (
-                f"{self.main_package_name}" f"{self.pipx_metadata.main_package.suffix}"
+                f"{self.pipx_metadata.main_package.package}"
+                f"{self.pipx_metadata.main_package.suffix}"
             )
         else:
             venv_name = self.root.name

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -56,12 +56,7 @@ class VenvContainer:
 
     def get_venv_dir(self, package: str) -> Path:
         """Return the expected venv path for given `package`."""
-        # We cannot just canonicalize the whole name because suffix may not
-        #   be canonicalized
-        if not self._root.joinpath(package).exists():
-            if self._root.joinpath(canonicalize_name(package)).exists():
-                return self._root.joinpath(canonicalize_name(package))
-        return self._root.joinpath(package)
+        return self._root.joinpath(canonicalize_name(package))
 
     def verify_shared_libs(self):
         for p in self.iter_venv_dirs():

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -56,7 +56,12 @@ class VenvContainer:
 
     def get_venv_dir(self, package: str) -> Path:
         """Return the expected venv path for given `package`."""
-        return self._root.joinpath(canonicalize_name(package))
+        # We cannot just canonicalize the whole name because suffix may not
+        #   be canonicalized
+        if not self._root.joinpath(package).exists():
+            if self._root.joinpath(canonicalize_name(package)).exists():
+                return self._root.joinpath(canonicalize_name(package))
+        return self._root.joinpath(package)
 
     def verify_shared_libs(self):
         for p in self.iter_venv_dirs():

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -4,6 +4,8 @@ import pkgutil
 from pathlib import Path
 from typing import Dict, Generator, List, NamedTuple, Set
 
+from packaging.utils import canonicalize_name
+
 from pipx.animate import animate
 from pipx.constants import PIPX_SHARED_PTH
 from pipx.interpreter import DEFAULT_PYTHON
@@ -54,7 +56,7 @@ class VenvContainer:
 
     def get_venv_dir(self, package: str) -> Path:
         """Return the expected venv path for given `package`."""
-        return self._root.joinpath(package)
+        return self._root.joinpath(canonicalize_name(package))
 
     def verify_shared_libs(self):
         for p in self.iter_venv_dirs():

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,6 +7,8 @@ from shutil import which
 from typing import Any, Dict, List, Optional
 from unittest import mock
 
+from packaging.utils import canonicalize_name
+
 from pipx import constants, main, pipx_metadata_file
 
 MOCK_PIPXMETADATA_0_1: Dict[str, Any] = {
@@ -76,7 +78,7 @@ def mock_legacy_venv(venv_name: str, metadata_version: Optional[str] = None) -> 
     one with a previous metadata version.
     metadata_version=None refers to no metadata file (pipx pre-0.15.0.0)
     """
-    venv_dir = Path(constants.PIPX_LOCAL_VENVS) / venv_name
+    venv_dir = Path(constants.PIPX_LOCAL_VENVS) / canonicalize_name(venv_name)
 
     if metadata_version is None:
         os.remove(venv_dir / "pipx_metadata.json")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -86,7 +86,7 @@ def test_force_install(pipx_temp_env, capsys):
 
     run_pipx_cli(["install", "pycowsay", "--force"])
     captured = capsys.readouterr()
-    assert "Installing to existing directory" in captured.out
+    assert "Installing to existing venv" in captured.out
 
 
 def test_install_no_packages_found(pipx_temp_env, capsys):


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Pipx commands accepting `venv_dir` as an argument currently won't match if a python-library-name equivalent is used for an existing venv.  One needs to specify exactly pipx's version (the canonical pypi name).  This means all lower-case, and only dashes (-).

~~This PR changes `VenvContainer.get_venv_dir()` to try the literal `venv_dir` pipx command argument first, and then the canonicalized version of the `venv_dir` argument to see if it matches an existing venv.  If neither match, it returns the literal venv_dir supplied argument as before.~~

~~I would've just canonicalized the entire `venv_dir` argument, but unfortunately this is not compatible with suffixed venvs, as it is currently possible for them to have non-canonical characters.  One possible change that could fix this would be to also canonicalize the suffix recorded as venv directory name.  I'd be interested to know if there is interest in that approach.  The suffix could still remain the same, but the suffixed venv directory would be canonicalized.~~

EDIT: I changed this to canonicalize both `venv_dir` and `--skip` arguments before trying to match existing venv directory names.  Also new venv directory names are now strictly canonicalized, even suffixes.  Internally, suffixes are still stored literally, so app names have the un-canonicalized suffix.  And whenever metadata is available, if there is a suffix we use the literal un-canonicalized suffix to display in messages.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
This is best seen on linux which has a case-sensitive file system.  With this PR on linux:
```
> pipx install kaggle                                                 
  installed package kaggle 1.5.9, Python 3.9.0                                  
  These apps are now globally available                                         
    - kaggle                                                                    
done! ✨ 🌟 ✨                                                                  
> pipx uninstall KaGgLe                                        
uninstalled kaggle! ✨ 🌟 ✨                                                    
```

Existing behavior on linux below:
```
> pipx install kaggle                                                 
  installed package kaggle 1.5.9, Python 3.9.0                                  
  These apps are now globally available                                         
    - kaggle                                                                    
done! ✨ 🌟 ✨                                                                  
> pipx uninstall KaGgLe                                               
Nothing to uninstall for KaGgLe 😴                                              
```
