### PR TITLE
Make shared libraries create, upgrade not accept pip args

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,12 +3,12 @@ dev
 - Added reinstall command for reinstalling a single venv.
 - Changed `pipx run` on non-Windows systems to actually replace pipx process with the app process instead of running it as a subprocess.  (Now using python's `os.exec*`)
 - [bugfix] Fixed bug with reinstall-all command when package have been installed using a specifier. Now the initial specifier is used.
-- [bugfix] Override display of DEFAULT_PYTHON value when generating web documentation for `pipx install` #523
+- [bugfix] Override display of `PIPX_DEFAULT_PYTHON` value when generating web documentation for `pipx install` #523
 - [bugfix] Wrap help documentation for environment variables.
 - [bugfix] Fixed uninstall crash that could happen on Windows for certain packages
 - [feature] Venv package name arguments now do not have to match exactly as pipx has them stored, but can be specified in any python-package-name-equivalent way. (i.e. case does not matter, and `.`, `-`, `_` characters are interchangeable.)
 - [change] Venvs with a suffix: A suffix can contain any characters, but for purposes of uniqueness, python package name rules apply--upper- and lower-case letters are equivalent, and any number of `.`, `-`, or `_` characters in a row are equivalent.  (e.g. if you have a suffixed venv `pylint_1.0A` you could not add another suffixed venv called `pylint--1-0a`, as it would not be a unique name.)
-- [implementation detail] Pipx shared libraries are no longer installed using pip arguments taken from the last regular pipx install.
+- [implementation detail] Pipx shared libraries (providing pip, setuptools, wheel to pipx) are no longer installed using pip arguments taken from the last regular pipx install.  If you need to apply pip arguments to pipx's use of pip for its internal shared libraries, use PIP_\* environment variables.
 
 0.15.6.0
 
@@ -17,7 +17,7 @@ dev
 - [bugfix] Fixed regression in list, inject, upgrade, reinstall-all commands when suffixed packages are used.
 - [bugfix] Do not reset package url during upgrade when main package is `pipx`
 - Updated help text to show description for `ensurepath` and `completions` help
-- Added support for user-defined default python interpreter via new PIPX_DEFAULT_PYTHON.  Helpful for use with pyenv among other uses.
+- Added support for user-defined default python interpreter via new `PIPX_DEFAULT_PYTHON`.  Helpful for use with pyenv among other uses.
 - [bugfix] Fixed bug where extras were ignored with a PEP 508 package specification with a URL.
 
 0.15.5.1

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ dev
 - [bugfix] Fixed uninstall crash that could happen on Windows for certain packages
 - [feature] Venv package name arguments now do not have to match exactly as pipx has them stored, but can be specified in any python-package-name-equivalent way. (i.e. case does not matter, and `.`, `-`, `_` characters are interchangeable.)
 - [change] Venvs with a suffix: A suffix can contain any characters, but for purposes of uniqueness, python package name rules apply--upper- and lower-case letters are equivalent, and any number of `.`, `-`, or `_` characters in a row are equivalent.  (e.g. if you have a suffixed venv `pylint_1.0A` you could not add another suffixed venv called `pylint--1-0a`, as it would not be a unique name.)
+- [implementation detail] Pipx shared libraries are no longer installed using pip arguments taken from the last regular pipx install.
 
 0.15.6.0
 

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -36,7 +36,7 @@ class _SharedLibs:
                 run_verify([DEFAULT_PYTHON, "-m", "venv", "--clear", self.root])
             # ignore installed packages to ensure no unexpected patches from the OS vendor
             # are used
-            self.upgrade(pip_args=["--ignore-installed"], verbose=verbose)
+            self.upgrade(pip_args=["--force-reinstall"], verbose=verbose)
 
     @property
     def is_valid(self):

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import time
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from pipx import constants
 from pipx.animate import animate
@@ -30,13 +30,13 @@ class _SharedLibs:
 
         return self._site_packages
 
-    def create(self, pip_args: List[str], verbose: bool = False):
+    def create(self, verbose: bool = False):
         if not self.is_valid:
             with animate("creating shared libraries", not verbose):
                 run_verify([DEFAULT_PYTHON, "-m", "venv", "--clear", self.root])
             # ignore installed packages to ensure no unexpected patches from the OS vendor
             # are used
-            self.upgrade(["--ignore-installed"] + pip_args, verbose)
+            self.upgrade(pip_args=["--ignore-installed"], verbose=verbose)
 
     @property
     def is_valid(self):
@@ -58,11 +58,15 @@ class _SharedLibs:
         )
         return time_since_last_update_sec > SHARED_LIBS_MAX_AGE_SEC
 
-    def upgrade(self, pip_args: List[str], verbose: bool = False):
+    def upgrade(self, *, pip_args: Optional[List[str]] = None, verbose: bool = False):
         # Don't try to upgrade multiple times per run
         if self.has_been_updated_this_run:
             logging.info(f"Already upgraded libraries in {self.root}")
             return
+
+        if pip_args is None:
+            pip_args = []
+
         logging.info(f"Upgrading shared libraries in {self.root}")
 
         ignored_args = ["--editable"]

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -53,8 +53,8 @@ class _SharedLibs:
         now = time.time()
         time_since_last_update_sec = now - self.pip_path.stat().st_mtime
         logging.info(
-            f"Time since last upgrade of shared libs, in seconds: {time_since_last_update_sec}. "
-            f"Upgrade will be run by pipx if greater than {SHARED_LIBS_MAX_AGE_SEC}."
+            f"Time since last upgrade of shared libs, in seconds: {time_since_last_update_sec:.0f}. "
+            f"Upgrade will be run by pipx if greater than {SHARED_LIBS_MAX_AGE_SEC:.0f}."
         )
         return time_since_last_update_sec > SHARED_LIBS_MAX_AGE_SEC
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -92,9 +92,9 @@ class Venv:
         if self._existing and self.uses_shared_libs:
             if shared_libs.is_valid:
                 if shared_libs.needs_upgrade:
-                    shared_libs.upgrade([], verbose)
+                    shared_libs.upgrade(verbose=verbose)
             else:
-                shared_libs.create([], verbose)
+                shared_libs.create(verbose)
 
             if not shared_libs.is_valid:
                 raise PipxError(
@@ -146,7 +146,7 @@ class Venv:
         with animate("creating virtual environment", self.do_animation):
             cmd = [self.python, "-m", "venv", "--without-pip"]
             run_verify(cmd + venv_args + [str(self.root)])
-        shared_libs.create(pip_args, self.verbose)
+        shared_libs.create(self.verbose)
         pipx_pth = get_site_packages(self.python_path) / PIPX_SHARED_PTH
         # write path pointing to the shared libs site-packages directory
         # example pipx_pth location:
@@ -176,7 +176,7 @@ class Venv:
 
     def upgrade_packaging_libraries(self, pip_args: List[str]) -> None:
         if self.uses_shared_libs:
-            shared_libs.upgrade(pip_args, self.verbose)
+            shared_libs.upgrade(verbose=self.verbose)
         else:
             # TODO: setuptools and wheel? Original code didn't bother
             # but shared libs code does.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -26,7 +26,9 @@ def install_package(capsys, pipx_temp_env, caplog, package, package_name=""):
         package_name = package
 
     # TODO: remove "--feature=2020-resolver" when pip 20.3 is released
-    run_pipx_cli(["install", package, "--verbose", "--feature=2020-resolver"])
+    run_pipx_cli(
+        ["install", package, "--verbose", "--pip-args='--use-feature=2020-resolver'"]
+    )
     captured = capsys.readouterr()
     assert f"installed package {package_name}" in captured.out
     if not sys.platform.startswith("win"):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -25,7 +25,8 @@ def install_package(capsys, pipx_temp_env, caplog, package, package_name=""):
     if not package_name:
         package_name = package
 
-    run_pipx_cli(["install", package, "--verbose"])
+    # TODO: remove "--feature=2020-resolver" when pip 20.3 is released
+    run_pipx_cli(["install", package, "--verbose", "--feature=2020-resolver"])
     captured = capsys.readouterr()
     assert f"installed package {package_name}" in captured.out
     if not sys.platform.startswith("win"):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -131,7 +131,8 @@ def test_run_ensure_null_pythonpath():
         ("shell-functools", "shell-functools", ["filter", "--help"], True),
         ("black", "black", ["black", "--help"], False),
         ("pylint", "pylint", ["pylint", "--help"], False),
-        ("kaggle", "kaggle", ["kaggle", "--help"], False),
+        # TODO: uncomment when 2020-resolver is default in pip
+        # ("kaggle", "kaggle", ["kaggle", "--help"], False),
         ("ipython", "ipython", ["ipython", "--version"], False),
         ("cloudtoken", "cloudtoken", ["cloudtoken", "--help"], True),
         ("awscli", "awscli", ["aws", "--help"], True),

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -131,8 +131,7 @@ def test_run_ensure_null_pythonpath():
         ("shell-functools", "shell-functools", ["filter", "--help"], True),
         ("black", "black", ["black", "--help"], False),
         ("pylint", "pylint", ["pylint", "--help"], False),
-        # TODO: uncomment when 2020-resolver is default in pip
-        # ("kaggle", "kaggle", ["kaggle", "--help"], False),
+        ("kaggle", "kaggle", ["kaggle", "--help"], False),
         ("ipython", "ipython", ["ipython", "--version"], False),
         ("cloudtoken", "cloudtoken", ["cloudtoken", "--help"], True),
         ("awscli", "awscli", ["aws", "--help"], True),
@@ -149,8 +148,17 @@ def test_package_determination(
 
     caplog.set_level(logging.INFO)
 
+    # TODO: remove "--feature=2020-resolver" when pip 20.3 is released
     run_pipx_cli_exit(
-        ["run", "--verbose", "--spec", package_or_url, "--"] + app_appargs
+        [
+            "run",
+            "--verbose",
+            "--pip-args='--use-feature=2020-resolver'",
+            "--spec",
+            package_or_url,
+            "--",
+        ]
+        + app_appargs
     )
 
     assert "Cannot determine package name" not in caplog.text

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -15,7 +15,7 @@ from pipx import shared_libs
 )
 def test_auto_update_shared_libs(capsys, pipx_temp_env, mtime_minus_now, needs_upgrade):
     now = time.time()
-    shared_libs.shared_libs.create([], verbose=True)
+    shared_libs.shared_libs.create(verbose=True)
     shared_libs.shared_libs.has_been_updated_this_run = False
 
     access_time = now  # this can be anything

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -10,7 +10,15 @@ def test_uninstall(pipx_temp_env, capsys):
 
 
 def test_uninstall_multiple_same_app(pipx_temp_env, capsys):
-    assert not run_pipx_cli(["install", "kaggle==1.5.9", "--include-deps"])
+    # TODO: remove --pip-args when 2020-resolver is default in new pip
+    assert not run_pipx_cli(
+        [
+            "install",
+            "kaggle==1.5.9",
+            "--include-deps",
+            "--pip-args='--use-feature=2020-resolver'",
+        ]
+    )
     assert not run_pipx_cli(["uninstall", "kaggle"])
 
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Closes #544 

Changed the shared libs `create` and `upgrade` functions to no longer accept `pip_args`, which used to be applied inconsistently, sometimes taken from a recent `pipx install`, sometimes not at all.  Now they are never applied.  There are a lot of pip arguments that can even break the installation and/or upgrade of shared libraries (see example in #544).

It is assumed that `PIP_` environment variables can be used if pip behavior in pipx needs to be controlled consistently.

Also changed in `create()`:
```
pip install --upgrade --ignore-installed pip setuptools wheel
```
to
```
pip install --upgrade --force-reinstall pip setuptools wheel
```
As it seems safer to force a reinstall than just to ignore the old libraries.  This code is meant to force a fetch of a fresh pip from pypi to ignore any odd system custom pip version.

Incidental change: on the verbose display of shared libraries age in seconds, I removed the display of fractional seconds! 😄 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
