### PR TITLE
Convert pipx to use PEP 517

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -94,11 +94,10 @@ def develop(session):
 
 @nox.session(python="3.8")
 def build(session):
-    session.install("setuptools")
-    session.install("wheel")
+    session.install("build")
     session.install("twine")
     session.run("rm", "-rf", "dist", "build", external=True)
-    session.run("python", "setup.py", "--quiet", "sdist", "bdist_wheel")
+    session.run("python", "-m", "build")
 
 
 def has_changes():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,43 @@
+[metadata]
+name = pipx
+version = attr: pipx.version.__version__
+author = Chad Smith
+author_email = Chad Smith <grassfedcode@gmail.com>
+description = Install and Run Python Applications in Isolated Environments
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/pipxproject/pipx
+project_urls =
+    Documentation = https://pipxproject.github.io/pipx/
+    Source Code = https://github.com/pipxproject/pipx
+    Bug Tracker = https://github.com/pipxproject/pipx/issues
+keywords = pip, install, cli, workflow, Virtual Environment
+license = License :: OSI Approved :: MIT License
+classifiers =
+    Operating System :: OS Independent
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3 :: Only
+
+[options]
+packages = find:
+package_dir =
+    = src
+include_package_data = true
+zip_safe = true
+python_requires = >=3.6
+install_requires =
+    userpath>=1.4.1
+    argcomplete>=1.9.4, <2.0
+    packaging>=20.0
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    pipx = pipx.main:cli

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import setup  # type: ignore
 
 if sys.version_info < (3, 6, 0):
     sys.exit(
@@ -11,56 +11,4 @@ if sys.version_info < (3, 6, 0):
         "for installation instructions."
     )
 
-from pathlib import Path  # noqa E402
-from runpy import run_path  # noqa E402
-from typing import List  # noqa E402
-
-CURDIR = Path(__file__).parent
-
-REQUIRED = [
-    "userpath>=1.4.1",
-    "argcomplete>=1.9.4, <2.0",
-    "packaging>=20.0",
-]  # type: List[str]
-
-
-def get_version():
-    version_file = CURDIR.joinpath("src", "pipx", "version.py").resolve()
-    namespace = run_path(str(version_file))
-    return namespace["__version__"]
-
-
-setup(
-    name="pipx",
-    version=get_version(),
-    author="Chad Smith",
-    author_email="grassfedcode@gmail.com",
-    description="Install and Run Python Applications in Isolated Environments",
-    long_description=CURDIR.joinpath("README.md").read_text(encoding="utf-8"),
-    long_description_content_type="text/markdown",
-    url="https://github.com/pipxproject/pipx",
-    license="License :: OSI Approved :: MIT License",
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
-    include_package_data=True,
-    keywords=["pip", "install", "cli", "workflow", "Virtual Environment"],
-    scripts=[],
-    entry_points={"console_scripts": ["pipx = pipx.main:cli"]},
-    zip_safe=False,
-    install_requires=REQUIRED,
-    test_suite="tests.test_pipx",
-    classifiers=[
-        "Operating System :: OS Independent",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3 :: Only",
-    ],
-    project_urls={
-        "Documentation": "https://pipxproject.github.io/pipx/",
-        "Source Code": "https://github.com/pipxproject/pipx",
-        "Bug Tracker": "https://github.com/pipxproject/pipx/issues",
-    },
-)
+setup()


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

Fix #550. I manually checked the generated metadata and everything seems identical, except some delibrate changes:

* I added RFC-822 format to `author-email`. This is supported, and is more friendly to email clients.
* The `Requires-Python` metadata is added since the cfg format can safely ignore unknown keys in older setuptools.
* I added the `Python :: 3.9` trove classifier because why not 🙂 

noxfile is updated to build with the new PyPA PEP 517 [build](https://github.com/pypa/build/) tool instead of calling `setup.py` directly.