### PR TITLE
Upgrade: add option to upgrade injected packages

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ dev
 - [feature] Autocomplete for venv names is no longer restricted to an exact match to the literal venv name, but will autocomplete any logically-similar python package name (i.e. case does not matter, and `.`, `-`, `_` characters are all equivalent.)
 - pipx now reinstalls its internal shared libraries when the user executes `reinstall-all`.
 - Made sure shell exit codes from every pipx command are correct.  In the past some (like from `pipx upgrade`) were wrong.  The exit code from `pipx runpip` is now the exit code from the `pip` command run.  The exit code from `pipx list` will be 1 if one or more venvs have problems that need to be addressed.
+- Add `--upgrade-injected` option to `pipx upgrade` and `pipx upgrade-all` to direct pipx to also upgrade injected packages.
 
 0.15.6.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ dev
 - [feature] Autocomplete for venv names is no longer restricted to an exact match to the literal venv name, but will autocomplete any logically-similar python package name (i.e. case does not matter, and `.`, `-`, `_` characters are all equivalent.)
 - pipx now reinstalls its internal shared libraries when the user executes `reinstall-all`.
 - Made sure shell exit codes from every pipx command are correct.  In the past some (like from `pipx upgrade`) were wrong.  The exit code from `pipx runpip` is now the exit code from the `pip` command run.  The exit code from `pipx list` will be 1 if one or more venvs have problems that need to be addressed.
-- Add `--upgrade-injected` option to `pipx upgrade` and `pipx upgrade-all` to direct pipx to also upgrade injected packages.
+- `pipx upgrade` and `pipx upgrade-all` now have a `--upgrade-injected` option which directs pipx to also upgrade injected packages.
 
 0.15.6.0
 

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -20,7 +20,7 @@ def _upgrade_package(
     force: bool,
     upgrading_all: bool,
 ) -> int:
-    """Returns 1 if updated version changed, 0 otherwise"""
+    """Returns 1 if package version changed, 0 if same version"""
     package_metadata = venv.package_metadata[package]
 
     if package_metadata.package_or_url is None:
@@ -89,7 +89,7 @@ def _upgrade_venv(
     upgrading_all: bool,
     force: bool,
 ) -> int:
-    """Returns 1 if package version changed, 0 if same version"""
+    """Returns number of packages with changed versions."""
     if not venv_dir.is_dir():
         raise PipxError(
             f"Package is not installed. Expected to find {str(venv_dir)}, "

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -12,31 +12,9 @@ from pipx.util import PipxError
 from pipx.venv import Venv, VenvContainer
 
 
-def _upgrade_venv(
-    venv_dir: Path,
-    pip_args: List[str],
-    verbose: bool,
-    *,
-    upgrading_all: bool,
-    force: bool,
-) -> int:
-    """Returns 1 if package version changed, 0 if same version"""
-    if not venv_dir.is_dir():
-        raise PipxError(
-            f"Package is not installed. Expected to find {str(venv_dir)}, "
-            "but it does not exist."
-        )
-
-    venv = Venv(venv_dir, verbose=verbose)
-    package = venv.main_package_name
-
-    if not venv.package_metadata:
-        raise PipxError(
-            f"Not upgrading {red(bold(package))}.  It has missing internal pipx metadata.\n"
-            f"    It was likely installed using a pipx version before 0.15.0.0.\n"
-            f"    Please uninstall and install this package to fix."
-        )
-
+def _upgrade_package(
+    venv: Venv, package: str, pip_args: List[str], force: bool, upgrading_all: bool
+) -> bool:
     package_metadata = venv.package_metadata[package]
 
     if package_metadata.package_or_url is None:
@@ -59,7 +37,6 @@ def _upgrade_venv(
         is_main_package=True,
         suffix=package_metadata.suffix,
     )
-    # TODO 20191026: upgrade injected packages also (Issue #79)
 
     package_metadata = venv.package_metadata[package]
 
@@ -87,29 +64,81 @@ def _upgrade_venv(
             pass
         else:
             print(
-                f"{display_name} is already at latest version {old_version} (location: {str(venv_dir)})"
+                f"{display_name} is already at latest version {old_version} "
+                f"(location: {str(venv.root)})"
             )
-        return 0
+        return False
     else:
         print(
-            f"upgraded package {display_name} from {old_version} to {new_version} (location: {str(venv_dir)})"
+            f"upgraded package {display_name} from {old_version} to {new_version} "
+            f"(location: {str(venv.root)})"
         )
-        return 1
+        return True
+
+
+def _upgrade_venv(
+    venv_dir: Path,
+    pip_args: List[str],
+    verbose: bool,
+    *,
+    include_injected: bool,
+    upgrading_all: bool,
+    force: bool,
+) -> int:
+    """Returns 1 if package version changed, 0 if same version"""
+    if not venv_dir.is_dir():
+        raise PipxError(
+            f"Package is not installed. Expected to find {str(venv_dir)}, "
+            "but it does not exist."
+        )
+
+    venv = Venv(venv_dir, verbose=verbose)
+
+    if not venv.package_metadata:
+        raise PipxError(
+            f"Not upgrading {red(bold(venv_dir.name))}.  It has missing internal pipx metadata.\n"
+            f"    It was likely installed using a pipx version before 0.15.0.0.\n"
+            f"    Please uninstall and install this package to fix."
+        )
+
+    # TODO 20191026: upgrade injected packages also (Issue #79)
+    package = venv.main_package_name
+
+    version_change = _upgrade_package(venv, package, pip_args, force, upgrading_all)
+
+    return 1 if version_change else 0
 
 
 def upgrade(
-    venv_dir: Path, pip_args: List[str], verbose: bool, *, force: bool
+    venv_dir: Path,
+    pip_args: List[str],
+    verbose: bool,
+    *,
+    include_injected: bool,
+    force: bool,
 ) -> ExitCode:
     """Returns pipx exit code."""
 
-    _ = _upgrade_venv(venv_dir, pip_args, verbose, upgrading_all=False, force=force)
+    _ = _upgrade_venv(
+        venv_dir,
+        pip_args,
+        verbose,
+        include_injected=include_injected,
+        upgrading_all=False,
+        force=force,
+    )
 
     # Any error in upgrade will raise PipxError from vevn._run_pip()
     return EXIT_CODE_OK
 
 
 def upgrade_all(
-    venv_container: VenvContainer, verbose: bool, *, skip: Sequence[str], force: bool
+    venv_container: VenvContainer,
+    verbose: bool,
+    *,
+    include_injected: bool,
+    skip: Sequence[str],
+    force: bool,
 ) -> ExitCode:
     """Returns pipx exit code."""
     venv_error = False
@@ -126,6 +155,7 @@ def upgrade_all(
                 venv_dir,
                 venv.pipx_metadata.main_package.pip_args,
                 verbose,
+                include_injected=include_injected,
                 upgrading_all=True,
                 force=force,
             )

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -19,7 +19,8 @@ def _upgrade_package(
     is_main_package: bool,
     force: bool,
     upgrading_all: bool,
-) -> bool:
+) -> int:
+    """Returns 1 if updated version changed, 0 otherwise"""
     package_metadata = venv.package_metadata[package]
 
     if package_metadata.package_or_url is None:
@@ -70,13 +71,13 @@ def _upgrade_package(
                 f"{display_name} is already at latest version {old_version} "
                 f"(location: {str(venv.root)})"
             )
-        return False
+        return 0
     else:
         print(
             f"upgraded package {display_name} from {old_version} to {new_version} "
             f"(location: {str(venv.root)})"
         )
-        return True
+        return 1
 
 
 def _upgrade_venv(
@@ -110,7 +111,7 @@ def _upgrade_venv(
     versions_updated = 0
 
     package = venv.main_package_name
-    version_change = _upgrade_package(
+    versions_updated += _upgrade_package(
         venv,
         package,
         pip_args,
@@ -118,13 +119,12 @@ def _upgrade_venv(
         force=force,
         upgrading_all=upgrading_all,
     )
-    versions_updated += 1 if version_change else 0
 
     if include_injected:
         for package in venv.package_metadata:
             if package == venv.main_package_name:
                 continue
-            version_change = _upgrade_package(
+            versions_updated += _upgrade_package(
                 venv,
                 package,
                 pip_args,
@@ -132,7 +132,6 @@ def _upgrade_venv(
                 force=force,
                 upgrading_all=upgrading_all,
             )
-            versions_updated += 1 if version_change else 0
 
     return versions_updated
 

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -155,7 +155,7 @@ def upgrade(
         force=force,
     )
 
-    # Any error in upgrade will raise PipxError from vevn._run_pip()
+    # Any error in upgrade will raise PipxError from venv._run_pip()
     return EXIT_CODE_OK
 
 

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -98,15 +98,15 @@ def _upgrade_venv(
 
     venv = Venv(venv_dir, verbose=verbose)
 
-    # Upgrade shared libraries (pip, setuptools and wheel)
-    venv.upgrade_packaging_libraries(pip_args)
-
     if not venv.package_metadata:
         raise PipxError(
             f"Not upgrading {red(bold(venv_dir.name))}.  It has missing internal pipx metadata.\n"
             f"    It was likely installed using a pipx version before 0.15.0.0.\n"
             f"    Please uninstall and install this package to fix."
         )
+
+    # Upgrade shared libraries (pip, setuptools and wheel)
+    venv.upgrade_packaging_libraries(pip_args)
 
     versions_updated = 0
 
@@ -155,7 +155,7 @@ def upgrade(
         force=force,
     )
 
-    # Any error in upgrade will raise PipxError from venv._run_pip()
+    # Any error in upgrade will raise PipxError (e.g. from venv._run_pip())
     return EXIT_CODE_OK
 
 

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -120,7 +120,6 @@ def _upgrade_venv(
     )
     versions_updated += 1 if version_change else 0
 
-    # TODO 20191026: upgrade injected packages also (Issue #79)
     if include_injected:
         for package in venv.package_metadata:
             if package == venv.main_package_name:

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -28,15 +28,13 @@ def _upgrade_package(
 
     package_or_url = parse_specifier_for_upgrade(package_metadata.package_or_url)
     old_version = package_metadata.package_version
-    include_apps = package_metadata.include_apps
-    include_dependencies = package_metadata.include_dependencies
 
     venv.upgrade_package(
         package,
         package_or_url,
         pip_args,
-        include_dependencies=include_dependencies,
-        include_apps=include_apps,
+        include_dependencies=package_metadata.include_dependencies,
+        include_apps=package_metadata.include_apps,
         is_main_package=is_main_package,
         suffix=package_metadata.suffix,
     )
@@ -46,7 +44,7 @@ def _upgrade_package(
     display_name = f"{package_metadata.package}{package_metadata.suffix}"
     new_version = package_metadata.package_version
 
-    if include_apps:
+    if package_metadata.include_apps:
         expose_apps_globally(
             constants.LOCAL_BIN_DIR,
             package_metadata.app_paths,
@@ -54,7 +52,7 @@ def _upgrade_package(
             suffix=package_metadata.suffix,
         )
 
-    if include_dependencies:
+    if package_metadata.include_dependencies:
         for _, app_paths in package_metadata.app_paths_of_dependencies.items():
             expose_apps_globally(
                 constants.LOCAL_BIN_DIR,

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -372,6 +372,11 @@ def _add_upgrade(subparsers, venv_completer) -> None:
     )
     p.add_argument("package").completer = venv_completer
     p.add_argument(
+        "--include-injected",
+        action="store_true",
+        help="Also upgrade packages injected into the main app's environment",
+    )
+    p.add_argument(
         "--force",
         "-f",
         action="store_true",
@@ -387,7 +392,11 @@ def _add_upgrade_all(subparsers) -> None:
         help="Upgrade all packages. Runs `pip install -U <pkgname>` for each package.",
         description="Upgrades all packages within their virtual environments by running 'pip install --upgrade PACKAGE'",
     )
-
+    p.add_argument(
+        "--include-injected",
+        action="store_true",
+        help="Also upgrade packages injected into the main app's environment",
+    )
     p.add_argument("--skip", nargs="+", default=[], help="skip these packages")
     p.add_argument(
         "--force",

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -221,10 +221,20 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
             force=args.force,
         )
     elif args.command == "upgrade":
-        return commands.upgrade(venv_dir, pip_args, verbose, force=args.force)
+        return commands.upgrade(
+            venv_dir,
+            pip_args,
+            verbose,
+            include_injected=args.include_injected,
+            force=args.force,
+        )
     elif args.command == "upgrade-all":
         return commands.upgrade_all(
-            venv_container, verbose, skip=skip_list, force=args.force
+            venv_container,
+            verbose,
+            include_injected=args.include_injected,
+            skip=skip_list,
+            force=args.force,
         )
     elif args.command == "list":
         return commands.list_packages(venv_container, args.include_injected)

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -65,3 +65,13 @@ def test_upgrade_include_injected(pipx_temp_env, capsys):
     captured = capsys.readouterr()
     assert "upgraded package pylint" in captured.out
     assert "upgraded package black" in captured.out
+
+
+def test_upgrade_no_include_injected(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["install", "pylint==2.5.3"])
+    assert not run_pipx_cli(["inject", "pylint", "black==18.9.b0"])
+    captured = capsys.readouterr()
+    assert not run_pipx_cli(["upgrade", "pylint"])
+    captured = capsys.readouterr()
+    assert "upgraded package pylint" in captured.out
+    assert "upgraded package black" not in captured.out

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -61,7 +61,7 @@ def test_upgrade_include_injected(pipx_temp_env, capsys):
     assert not run_pipx_cli(["install", "pylint==2.5.3"])
     assert not run_pipx_cli(["inject", "pylint", "black==18.9.b0"])
     captured = capsys.readouterr()
-    assert not run_pipx_cli(["pipx", "upgrade", "--include-injected", "pylint"])
+    assert not run_pipx_cli(["upgrade", "--include-injected", "pylint"])
     captured = capsys.readouterr()
     assert "upgraded package pylint" in captured.out
     assert "upgraded package black" in captured.out

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -55,3 +55,13 @@ def test_upgrade_specifier(pipx_temp_env, capsys):
     assert not run_pipx_cli(["upgrade", f"{name}"])
     captured = capsys.readouterr()
     assert f"upgraded package {name} from {initial_version} to" in captured.out
+
+
+def test_upgrade_include_injected(pipx_temp_env, capsys):
+    assert not run_pipx_cli(["install", "pylint==2.5.3"])
+    assert not run_pipx_cli(["inject", "pylint", "black==18.9.b0"])
+    captured = capsys.readouterr()
+    assert not run_pipx_cli(["pipx", "upgrade", "--include-injected", "pylint"])
+    captured = capsys.readouterr()
+    assert "upgraded package pylint" in captured.out
+    assert "upgraded package black" in captured.out


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Adds `--include-injected` option to `upgrade` and `upgrade-all`, and if used upgrades all injected packages in the venv(s).  Without the `--include-injected` option `upgrade` and `upgrade-all` work as in the past.

Closes #79 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```shell
> pipx install pylint==2.5.3                           
  installed package pylint 2.5.3, Python 3.9.0
  These apps are now globally available
    - epylint
    - pylint
    - pyreverse
    - symilar
done! ✨ 🌟 ✨
> pipx inject pylint black==18.9.b0
  injected package black into venv pylint
done! ✨ 🌟 ✨
> pipx upgrade --include-injected pylint
upgraded package pylint from 2.5.3 to 2.6.0 (location: /Users/mclapp/.local/pipx/venvs/pylint)
upgraded package black from 18.9b0 to 20.8b1 (location: /Users/mclapp/.local/pipx/venvs/pylint)
> pipx uninstall pylint
uninstalled pylint! ✨ 🌟 ✨
> pipx install pylint==2.5.3            
  installed package pylint 2.5.3, Python 3.9.0
  These apps are now globally available
    - epylint
    - pylint
    - pyreverse
    - symilar
done! ✨ 🌟 ✨
> pipx inject pylint black==18.9.b0     
  injected package black into venv pylint
done! ✨ 🌟 ✨
> pipx upgrade pylint    
upgraded package pylint from 2.5.3 to 2.6.0 (location: /Users/mclapp/.local/pipx/venvs/pylint)
>
```
