### PR TITLE
Implement rotating file logging, log more info to file.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ dev
 - [feature] Autocomplete for venv names is no longer restricted to an exact match to the literal venv name, but will autocomplete any logically-similar python package name (i.e. case does not matter, and `.`, `-`, `_` characters are all equivalent.)
 - pipx now reinstalls its internal shared libraries when the user executes `reinstall-all`.
 - Made sure shell exit codes from every pipx command are correct.  In the past some (like from `pipx upgrade`) were wrong.  The exit code from `pipx runpip` is now the exit code from the `pip` command run.  The exit code from `pipx list` will be 1 if one or more venvs have problems that need to be addressed.
+- pipx now writes a log file for each pipx command executed to `$PIPX_HOME/logs`, typically `~/.local/pipx/logs`.  pipx keeps the most recent 10 logs and deletes others.
 
 0.15.6.0
 

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -195,4 +195,5 @@ def _http_get_request(url: str) -> str:
         charset = res.headers.get_content_charset() or "utf-8"  # type: ignore
         return res.read().decode(charset)
     except Exception as e:
+        logging.debug("Uncaught Exception:", exc_info=True)
         raise PipxError(str(e))

--- a/src/pipx/constants.py
+++ b/src/pipx/constants.py
@@ -8,6 +8,7 @@ DEFAULT_PIPX_HOME = Path.home() / ".local/pipx"
 DEFAULT_PIPX_BIN_DIR = Path.home() / ".local/bin"
 PIPX_HOME = Path(os.environ.get("PIPX_HOME", DEFAULT_PIPX_HOME)).resolve()
 PIPX_LOCAL_VENVS = PIPX_HOME / "venvs"
+PIPX_LOG_DIR = PIPX_HOME / "logs"
 DEFAULT_PIPX_SHARED_LIBS = PIPX_HOME / "shared"
 PIPX_SHARED_LIBS = Path(
     os.environ.get("PIPX_SHARED_LIBS", DEFAULT_PIPX_SHARED_LIBS)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -723,7 +723,7 @@ def cli() -> ExitCode:
         return run_pipx_command(parsed_pipx_args)
     except PipxError as e:
         print(str(e), file=sys.stderr)
-        logging.debug(f"PipxError: {e}")
+        logging.debug(f"PipxError: {e}", exc_info=True)
         return ExitCode(1)
     except KeyboardInterrupt:
         return ExitCode(1)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -620,13 +620,13 @@ def setup_file_logging(logger: logging.Logger) -> None:
     # don't use utils.mkdir, to prevent emit of log message
     constants.PIPX_LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_file = constants.PIPX_LOG_DIR / "command.log"
-    log_file_exists = log_file.exists()
+    # log_file_exists = log_file.exists()
     # delay=True so file won't be open and doRollover works on Windows without
     #   PermissionError
     file_handler = RotatingFileHandler(log_file, backupCount=5, delay=True)
     file_handler.setLevel(logging.DEBUG)
-    if log_file_exists:
-        file_handler.doRollover()
+    # if log_file_exists:
+    #     file_handler.doRollover()
     file_handler.setFormatter(
         logging.Formatter(
             "{relativeCreated: >8.1f}ms ({funcName}:{lineno}): {message}", style="{"

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -256,6 +256,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
         try:
             return commands.ensure_pipx_paths(force=args.force)
         except Exception as e:
+            logging.debug("Uncaught Exception:", exc_info=True)
             raise PipxError(e)
     elif args.command == "completions":
         print(constants.completion_instructions)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -719,19 +719,15 @@ def cli() -> ExitCode:
         if not parsed_pipx_args.command:
             parser.print_help()
             return ExitCode(1)
-        # TODO: need show_cursor() ?
         return run_pipx_command(parsed_pipx_args)
     except PipxError as e:
         print(str(e), file=sys.stderr)
         logging.debug(f"PipxError: {e}")
-        # TODO: need show_cursor() ?
         return ExitCode(1)
     except KeyboardInterrupt:
-        # TODO: need show_cursor() ?
         return ExitCode(1)
     except Exception:
-        logging.debug("Uncaught Exception", exc_info=True)
-        # TODO: need show_cursor() ?
+        logging.debug("Uncaught Exception:", exc_info=True)
         raise
     finally:
         show_cursor()

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -621,7 +621,9 @@ def setup_file_logging(logger: logging.Logger) -> None:
     constants.PIPX_LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_file = constants.PIPX_LOG_DIR / "command.log"
     log_file_exists = log_file.exists()
-    file_handler = RotatingFileHandler(log_file, backupCount=5)
+    # delay=True so file won't be open and doRollover works on Windows without
+    #   PermissionError
+    file_handler = RotatingFileHandler(log_file, backupCount=5, delay=True)
     file_handler.setLevel(logging.DEBUG)
     if log_file_exists:
         file_handler.doRollover()

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -624,7 +624,8 @@ def setup(args: argparse.Namespace) -> None:
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
 
-    mkdir(constants.PIPX_LOG_DIR)
+    # don't use utils.mkdir, to prevent emit of log message
+    constants.PIPX_LOG_DIR.mkdir(parents=True, exist_ok=True)
     file_handler = RotatingFileHandler(
         constants.PIPX_LOG_DIR / "command.log", backupCount=5
     )
@@ -632,7 +633,7 @@ def setup(args: argparse.Namespace) -> None:
     file_handler.doRollover()
     file_handler.setFormatter(
         logging.Formatter(
-            "{relativeCreated: >8.1f}ms ({funcName}:{lineno}): {message}", style="{",
+            "{relativeCreated: >8.1f}ms ({funcName}:{lineno}): {message}", style="{"
         )
     )
     root_logger.addHandler(file_handler)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -10,7 +10,9 @@ import shlex
 import shutil
 import sys
 import textwrap
+import time
 import urllib.parse
+from logging.handlers import RotatingFileHandler
 from typing import Dict, List
 
 import argcomplete  # type: ignore
@@ -619,13 +621,36 @@ def setup(args: argparse.Namespace) -> None:
         print_version()
         sys.exit(0)
 
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
+
+    mkdir(constants.PIPX_LOG_DIR)
+    file_handler = RotatingFileHandler(
+        constants.PIPX_LOG_DIR / "command.log", backupCount=5
+    )
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.doRollover()
+    file_handler.setFormatter(
+        logging.Formatter(
+            "{relativeCreated: >8.1f}ms ({funcName}:{lineno}): {message}", style="{",
+        )
+    )
+    root_logger.addHandler(file_handler)
+    # log these infos only to file
+    logging.info(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
+    logging.info(f"{' '.join(sys.argv)}")
+
+    stream_handler = logging.StreamHandler()
     if "verbose" in args and args.verbose:
         pipx_str = bold(green("pipx >")) if sys.stdout.isatty() else "pipx >"
-        format_str = f"{pipx_str} (%(funcName)s:%(lineno)d): %(message)s"
-
-        logging.basicConfig(level=logging.DEBUG, format=format_str)
+        stream_handler.setLevel(logging.DEBUG)
+        stream_handler.setFormatter(
+            logging.Formatter(pipx_str + "({funcName}:{lineno}): {message}", style="{")
+        )
     else:
-        logging.basicConfig(level=logging.WARNING, format="%(message)s")
+        stream_handler.setLevel(logging.WARNING)
+        stream_handler.setFormatter(logging.Formatter("{message}", style="{"))
+    root_logger.addHandler(stream_handler)
 
     logging.info(f"pipx version is {__version__}")
     logging.info(f"Default python interpreter is {repr(DEFAULT_PYTHON)}")

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -112,6 +112,7 @@ class PipxMetadata:
             or self.main_package.package_or_url is None
             or not self.main_package.include_apps
         ):
+            logging.debug(f"PipxMetadata corrupt:\n{self.to_dict()}")
             raise PipxError("Internal Error: PipxMetadata is corrupt, cannot write.")
 
     def write(self) -> None:

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -134,7 +134,6 @@ class PipxMetadata:
                     width=79,
                 )
             )
-            pass
 
     def read(self, verbose: bool = False) -> None:
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ def pipx_temp_env(tmp_path, monkeypatch):
     monkeypatch.setattr(constants, "LOCAL_BIN_DIR", bin_dir)
     monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
     monkeypatch.setattr(constants, "PIPX_VENV_CACHEDIR", home_dir / ".cache")
+    monkeypatch.setattr(constants, "PIPX_LOG_DIR", home_dir / "logs")
 
     # TODO: macOS needs /usr/bin in PATH to compile certain packages, but
     #   applications in /usr/bin cause test_install.py tests to raise warnings


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Closes #274 

This adds a subdirectory `logs/` to `PIPX_HOME`.  Each pipx command run gets a new logfile written to this directory with a datestamp in the filename.  The 10 most recent log files are kept and others are deleted.

`logging.DEBUG` log level and above are logged to these files.  The console output logging is `logging.INFO` and above for `--verbose` mode, and `logging.WARNING` and above for non-verbose mode.

We used to have no `logging.debug()` logging statements, and I added a lot to capture the stack trace for various errors that we catch and may not print out fully to the console

Since these logs do **not** need to be turned on manually (i.e. with `--verbose`), it should allow a very verbose log to be available for one-off or non-replicable errors.

I implemented the file rotation myself, because trying to use `logging.handlers.RotatingFileHandler` and manually initiating a `doRollover()` for each new command caused file permission errors on Windows.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
After running 3 pipx commands:
```shell
> ls ~/.local/pipx/logs
cmd_2020-11-25_19.26.39.log  cmd_2020-11-25_19.26.58.log
cmd_2020-11-25_19.26.53.log
> 
```
