### PR TITLE
Fix recent logfiles PR: Remove stray print and put guard on while statement.

### DIFF
--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -626,14 +626,13 @@ def setup_file_handler() -> logging.Handler:
         for existing_log in existing_logs[:-max_logs]:
             try:
                 existing_log.unlink()
-                print(f"Removed file {existing_log}", file=sys.stderr)
             except FileNotFoundError:
                 pass
 
     datetime_str = time.strftime("%Y-%m-%d_%H.%M.%S")
     log_file = constants.PIPX_LOG_DIR / f"cmd_{datetime_str}.log"
     counter = 1
-    while log_file.exists():
+    while log_file.exists() and counter < 10:
         log_file = constants.PIPX_LOG_DIR / f"cmd_{datetime_str}_{counter}.log"
         counter += 1
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Oops!  Merged the recent PR #566 too soon.  This PR removes a stray debug print statement, and makes sure the `while` statement doesn't go on forever as @cs01 suggested in #566.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
