### PR TITLE
New Troubleshooting webpage in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -4,7 +4,12 @@ about: Report a bug or unexpected behavior.
 
 ---
 
-<!-- Thank you for filing a bug! Please feel free to answer as much or as little of this template as you can. -->
+<!--
+Thank you for filing a bug! Please feel free to answer as much or as little of this template as you can.
+
+Please check pipx's Troubleshooting page to see if any of those solutions help solve your issue:
+https://pipxproject.github.io/pipx/troubleshooting/
+-->
 
 **Describe the bug**
 <!-- Please be as detailed as possible! -->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ dev
 - pipx now reinstalls its internal shared libraries when the user executes `reinstall-all`.
 - Made sure shell exit codes from every pipx command are correct.  In the past some (like from `pipx upgrade`) were wrong.  The exit code from `pipx runpip` is now the exit code from the `pip` command run.  The exit code from `pipx list` will be 1 if one or more venvs have problems that need to be addressed.
 - pipx now writes a log file for each pipx command executed to `$PIPX_HOME/logs`, typically `~/.local/pipx/logs`.  pipx keeps the most recent 10 logs and deletes others.
+- Added a "Troubleshooting" page to the pipx web documentation for common problems pipx users may encounter.
 
 0.15.6.0
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
-## Fix for most issues
+## `reinstall-all` fixes most issues
 
-The following command fixes most problems you may encounter as a pipx user:
+The following command should fix most problems you may encounter as a pipx user:
 
 ```
 pipx reinstall-all
@@ -8,7 +8,7 @@ pipx reinstall-all
 
 If your pipx-installed package was installed using a pipx version before
 0.15.0.0 and you want to specify particular options, then you may want to
-uninstall and install manually:
+uninstall and install it manually:
 
 ```
 pipx uninstall <mypackage>
@@ -24,7 +24,7 @@ pipx has been upgraded a lot over the years.  If you are a long-standing pipx
 user (thanks, by the way!) then you may have old pipx-installed packages that
 have internal data that is different than what pipx currently expects.  By
 executing `pipx reinstall-all`, pipx will re-write its internal data and this
-should fix a majority of issues you may encounter.
+should fix many of issues you may encounter.
 
 ## Specifying pipx options
 
@@ -40,9 +40,21 @@ pipx uses `pip` to install and manage packages.  If you see pipx exhibiting
 strange behavior on install or upgrade, check that you don't have special
 environment variables that affect `pip`'s behavior in your environment.
 
-To check on unix or macOS for `pip` environment variables, execute:
+To check for `pip` environment variables, execute the following depending on your system:
+
+### Unix or macOS
 ```
 env | grep '^PIP_'
+```
+
+### Windows PowerShell
+```
+ls env:PIP_*
+```
+
+### Windows `cmd`
+```
+set PIP_
 ```
 
 Reference: [pip Environment Variables](https://pip.pypa.io/en/stable/user_guide/#environment-variables)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,9 +6,9 @@ The following command fixes most problems you may encounter as a pipx user:
 pipx reinstall-all
 ```
 
-If your pipx-installed package is **very** old (it was installed using a pipx
-version before 0.15.0.0) and you want to specify particular options, then you
-may want to uninstall and install manually:
+If your pipx-installed package was installed using a pipx version before
+0.15.0.0 and you want to specify particular options, then you may want to
+uninstall and install manually:
 
 ```
 pipx uninstall <mypackage>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 ## Fixes most issues
 
-The following command fixes most problems you may encounter as a user:
+The following command fixes most problems you may encounter as a pipx user:
 
 ```
 pipx reinstall-all
@@ -23,7 +23,7 @@ This is a good fix for the following problems:
 pipx has been upgraded a lot over the years.  If you are a long-standing pipx
 user (thanks, by the way!) then you may have old pipx-installed packages that
 have internal data that is different than what pipx currently expects.  By
-executing `pipx reinstall-all`, pipx will re-do its internal data and this
+executing `pipx reinstall-all`, pipx will re-write its internal data and this
 should fix a majority of issues you may encounter.
 
 ## Specifying pipx options
@@ -72,8 +72,8 @@ source test_venv/bin/activate
 python3 -m pip install <problem-package>
 ```
 
-If installation into this "virtual environment" using pip fails, then it's most
-probably that the problem is with the package or your host system.
+If installation into this "virtual environment" using pip fails, then it's
+likely that the problem is with the package or your host system.
 
 To clean up after this experiment:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,4 +1,4 @@
-## Fixes most issues
+## Fix for most issues
 
 The following command fixes most problems you may encounter as a pipx user:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 ## `reinstall-all` fixes most issues
 
-The following command should fix most problems you may encounter as a pipx user:
+The following command should fix many problems you may encounter as a pipx user:
 
 ```
 pipx reinstall-all

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,6 +26,15 @@ have internal data that is different than what pipx currently expects.  By
 executing `pipx reinstall-all`, pipx will re-write its internal data and this
 should fix many of issues you may encounter.
 
+## Diagnosing problems using `list`
+
+```
+pipx list
+```
+
+will not only list all of your pipx-installed packages, but can also diagnose
+some problems with them, as well as suggest solutions.
+
 ## Specifying pipx options
 
 The most reliable method to specify command-line options that require an

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,83 @@
+## Fixes most issues
+
+The following command fixes most problems you may encounter as a user:
+
+```
+pipx reinstall-all
+```
+
+If your pipx-installed package is **very** old (it was installed using a pipx
+version before 0.15.0.0) and you want to specify particular options, then you
+may want to uninstall and install manually:
+
+```
+pipx uninstall <mypackage>
+pipx install <mypackage>
+```
+
+This is a good fix for the following problems:
+
+* System python was upgraded and the python used with a pipx-package is no longer available
+* pipx upgrade causes issues with old pipx-installed packages
+
+pipx has been upgraded a lot over the years.  If you are a long-standing pipx
+user (thanks, by the way!) then you may have old pipx-installed packages that
+have internal data that is different than what pipx currently expects.  By
+executing `pipx reinstall-all`, pipx will re-do its internal data and this
+should fix a majority of issues you may encounter.
+
+## Specifying pipx options
+
+The most reliable method to specify command-line options that require an
+argument is to use an `=`-sign.  An example:
+```
+pipx install pycowsay --pip-args="--no-cache-dir"
+```
+
+## Check for `PIP_*` environment variables
+
+pipx uses `pip` to install and manage packages.  If you see pipx exhibiting
+strange behavior on install or upgrade, check that you don't have special
+environment variables that affect `pip`'s behavior in your environment.
+
+To check on unix or macOS for `pip` environment variables, execute:
+```
+env | grep '^PIP_'
+```
+
+Reference: [pip Environment Variables](https://pip.pypa.io/en/stable/user_guide/#environment-variables)
+
+## Debian, Ubuntu issues
+
+If you have issues using pipx on Debian, Ubuntu, or other Debian-based linux
+distributions, make sure you have the following packages installed on your
+system.  (Debian systems do not install these by default with their python
+installations.)
+
+```
+sudo apt install python3-venv python3-pip
+```
+
+Reference: [Python Packaging User Guide: Installing pip/setuptools/wheel with Linux Package Managers](https://packaging.python.org/guides/installing-using-linux-tools)
+
+## Does it work to install your package with `pip`?
+
+This is a tip for advanced users.  An easy way to check if pipx is the problem
+or a package you're trying to install is the problem, is to try installing it
+using `pip`.  For example:
+
+```
+python3 -m venv test_venv
+source test_venv/bin/activate
+python3 -m pip install <problem-package>
+```
+
+If installation into this "virtual environment" using pip fails, then it's most
+probably that the problem is with the package or your host system.
+
+To clean up after this experiment:
+
+```
+deactivate
+rm -rf test_venv
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - Installation: "installation.md"
   - Getting Started: "getting-started.md"
   - Docs: "docs.md"
+  - Troubleshooting: "troubleshooting.md"
   - Examples: "examples.md"
   - Comparison to Other Tools: "comparisons.md"
   - How pipx works: "how-pipx-works.md"


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Added a "Troubleshooting" page with common solutions to common problems.  Also added a link to the Troubleshooting page to the GitHub bug report template urging users to check it first.

I looked through the past year or so of Issues to try and find common user problems that were easily remedied (and not actual pipx bugs.)

Hopefully this will save time on the easiest bug reports and at least give a webpage to link to for answers to common problems.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
