### PR TITLE
Enable `pipx list` to detect non-canonical (bad) venv names

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@ dev
 - pipx now reinstalls its internal shared libraries when the user executes `reinstall-all`.
 - Made sure shell exit codes from every pipx command are correct.  In the past some (like from `pipx upgrade`) were wrong.  The exit code from `pipx runpip` is now the exit code from the `pip` command run.  The exit code from `pipx list` will be 1 if one or more venvs have problems that need to be addressed.
 - pipx now writes a log file for each pipx command executed to `$PIPX_HOME/logs`, typically `~/.local/pipx/logs`.  pipx keeps the most recent 10 logs and deletes others.
-- `pipx list` now detects, identifies, and suggests a remedy for old-internal data (internal venv names) for old pipx-installed packages that need to be updated.
+- `pipx list` now detects, identifies, and suggests a remedy for old-internal data (internal venv names) that need to be updated.
 
 0.15.6.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@ dev
 - pipx now reinstalls its internal shared libraries when the user executes `reinstall-all`.
 - Made sure shell exit codes from every pipx command are correct.  In the past some (like from `pipx upgrade`) were wrong.  The exit code from `pipx runpip` is now the exit code from the `pip` command run.  The exit code from `pipx list` will be 1 if one or more venvs have problems that need to be addressed.
 - pipx now writes a log file for each pipx command executed to `$PIPX_HOME/logs`, typically `~/.local/pipx/logs`.  pipx keeps the most recent 10 logs and deletes others.
-- `pipx list` now detects, identifies, and suggests a remedy for old-internal data (internal venv names) that need to be updated.
+- `pipx list` now detects, identifies, and suggests a remedy for venvs with old-internal data (internal venv names) that need to be updated.
 
 0.15.6.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ dev
 - pipx now reinstalls its internal shared libraries when the user executes `reinstall-all`.
 - Made sure shell exit codes from every pipx command are correct.  In the past some (like from `pipx upgrade`) were wrong.  The exit code from `pipx runpip` is now the exit code from the `pip` command run.  The exit code from `pipx list` will be 1 if one or more venvs have problems that need to be addressed.
 - pipx now writes a log file for each pipx command executed to `$PIPX_HOME/logs`, typically `~/.local/pipx/logs`.  pipx keeps the most recent 10 logs and deletes others.
+- `pipx list` now detects, identifies, and suggests a remedy for old-internal data (internal venv names) for old pipx-installed packages that need to be updated.
 
 0.15.6.0
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -10,6 +10,7 @@ from tempfile import TemporaryDirectory
 from typing import Dict, List, Optional, Set, Tuple
 
 import userpath  # type: ignore
+from packaging.utils import canonicalize_name
 
 from pipx import constants
 from pipx.colors import bold, red
@@ -23,10 +24,12 @@ from pipx.venv import Venv
 class VenvProblems:
     def __init__(
         self,
+        bad_venv_name: bool = False,
         invalid_interpreter: bool = False,
         missing_metadata: bool = False,
         not_installed: bool = False,
     ) -> None:
+        self.bad_venv_name = bad_venv_name
         self.invalid_interpreter = invalid_interpreter
         self.missing_metadata = missing_metadata
         self.not_installed = not_installed
@@ -161,6 +164,11 @@ def get_package_summary(
         return (
             f"   package {red(bold(venv_dir.name))} has missing internal pipx metadata.",
             VenvProblems(missing_metadata=True),
+        )
+    if venv_dir.name != canonicalize_name(venv_dir.name):
+        return (
+            f"   package {red(bold(venv_dir.name))} needs its internal data updated.",
+            VenvProblems(bad_venv_name=True),
         )
 
     package_metadata = venv.package_metadata[package]

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -48,6 +48,12 @@ def list_packages(venv_container: VenvContainer, include_injected: bool) -> Exit
             print(package_summary)
             all_venv_problems.or_(venv_problems)
 
+    if all_venv_problems.bad_venv_name:
+        print(
+            "\nOne or more packages contain out-of-date internal data installed from a\n"
+            "previous pipx version and need to be updated.\n"
+            "    To fix, execute: pipx reinstall-all"
+        )
     if all_venv_problems.invalid_interpreter:
         print(
             "\nOne or more packages have a missing python interpreter.\n"


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Added another issue that `pipx list` can diagnose.  pipx now uses canonicalized venv names internally, and this will tell a user if they have any old-style internal venv names that need to be reinstalled to avoid problems.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```shell
> pipx install pycowsay
  installed package pycowsay 0.0.0.1, Python 3.9.0
  These apps are now globally available
    - pycowsay
done! ✨ 🌟 ✨
> pipx list
venvs are in /Users/mclapp/.local/pipx/venvs
apps are exposed on your $PATH at /Users/mclapp/.local/bin
   package pycowsay 0.0.0.1, Python 3.9.0
    - pycowsay
> mv ~/.local/pipx/venvs/pycowsay ~/.local/pipx/venvs/PyCowsay
> pipx list
venvs are in /Users/mclapp/.local/pipx/venvs
apps are exposed on your $PATH at /Users/mclapp/.local/bin
   package PyCowsay needs its internal data updated.

One or more packages contain out-of-date internal data installed from a
previous pipx version and need to be updated.
    To fix, execute: pipx reinstall-all
```
