### PR TITLE
Docs: Add a section in  Contributing detailing how to use pre-commit with pipx

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,6 +7,29 @@ To run the pipx executable from your source tree during development, run pipx fr
 python src/pipx --version
 ```
 
+## Pre-commit
+The use of [pre-commit](https://pre-commit.com/) is recommended.  It can show
+all and fix some lint errors before commit, saving you the trouble of finding
+out later that it failed CI Lint errors, and saving you from having to run `nox
+-s lint` separately.
+
+In the pipx git repository is a `.pre-commit-config.yaml` configuration file
+tailored just for pipx and its lint requirements.  To use pre-commit in your
+clone of the pipx repository, you need to do the following **one-time setup
+procedure**:
+
+1. Install pre-commit as described by https://pre-commit.com/#installation
+2. In the top level directory of your clone of the pipx repository, execute `pre-commit install`
+
+Afterwards whenever you commit in this repository, it will first run pipx's
+personalized lint checks.  If it makes a fix to a file (e.g. using `black` or
+`isort`), you will need to `git add` that file again before committing it
+again.  If it can't fix your commit itself, it will tell you what's wrong, and
+you can fix it manually before re-adding the edited files and committing again.
+
+If for some reason you want to commit and skip running pre-commit, you can use
+the switch `git commit --no-verify`.
+
 ## Running Tests
 
 ### Setup

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,7 @@ tailored just for pipx and its lint requirements.  To use pre-commit in your
 clone of the pipx repository, you need to do the following **one-time setup
 procedure**:
 
-1. Install pre-commit using `pipx install pre-commit`.
+1. Install pre-commit using `pipx install pre-commit`
 2. In the top level directory of your clone of the pipx repository, execute `pre-commit install`
 
 Afterwards whenever you commit in this repository, it will first run pipx's

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,7 @@ tailored just for pipx and its lint requirements.  To use pre-commit in your
 clone of the pipx repository, you need to do the following **one-time setup
 procedure**:
 
-1. Install pre-commit as described by https://pre-commit.com/#installation
+1. Install pre-commit using `pipx install pre-commit`.
 2. In the top level directory of your clone of the pipx repository, execute `pre-commit install`
 
 Afterwards whenever you commit in this repository, it will first run pipx's


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Added a section to the docs in "Contributing" that recommends and describes how to use `pre-commit` with pipx.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
