### PR TITLE
Add `--format` option to `list` command.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ dev
 - `pipx upgrade` and `pipx upgrade-all` now have a `--upgrade-injected` option which directs pipx to also upgrade injected packages.
 - `pipx list` now detects, identifies, and suggests a remedy for venvs with old-internal data (internal venv names) that need to be updated.
 - Added a "Troubleshooting" page to the pipx web documentation for common problems pipx users may encounter.
+- Added `--format` option to `pipx list` to control the format of the output (`human`, `freeze` or `json`).
 
 0.15.6.0
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -47,6 +47,8 @@ After running the above commands, you will be able to import and use the `reques
 
 
 ## `pipx list` example
+To list the installed packages use the list command.
+
 ```
 > pipx list
 venvs are in /Users/user/.local/pipx/venvs
@@ -56,4 +58,12 @@ binaries are exposed on your $PATH at /Users/user/.local/bin
     - blackd
    package pipx 0.10.0, Python 3.7.0
     - pipx
+```
+
+The list can also be printed in machine readable formats with the `--format freeze` and `--format json` options:
+
+``` 
+> pipx list --format freeze
+black==20.8b1
+poetry==1.1.4
 ```

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -1,13 +1,15 @@
+import json
 from functools import partial
 from pathlib import Path
-from typing import Callable, Collection, Optional
+from typing import Callable, Collection, List, Optional
 
 from pipx import constants
 from pipx.colors import bold
 from pipx.commands.common import VenvProblems, get_package_summary
 from pipx.constants import EXIT_CODE_LIST_PROBLEM, EXIT_CODE_OK, ExitCode
 from pipx.emojies import sleep
-from pipx.venv import VenvContainer
+from pipx.util import PipxError
+from pipx.venv import Venv, VenvContainer
 
 Pool: Optional[Callable]
 try:
@@ -17,18 +19,38 @@ except ImportError:
     Pool = None
 
 
-def list_packages(venv_container: VenvContainer, include_injected: bool) -> ExitCode:
+def list_packages(
+    venv_container: VenvContainer, include_injected: bool, format: str
+) -> ExitCode:
     """Returns pipx exit code."""
     dirs: Collection[Path] = sorted(venv_container.iter_venv_dirs())
     if not dirs:
         print(f"nothing has been installed with pipx {sleep}")
         return EXIT_CODE_OK
 
-    print(f"venvs are in {bold(str(venv_container))}")
-    print(f"apps are exposed on your $PATH at {bold(str(constants.LOCAL_BIN_DIR))}")
-
     venv_container.verify_shared_libs()
 
+    if format == "human":
+        print(f"venvs are in {bold(str(venv_container))}")
+        print(f"apps are exposed on your $PATH at {bold(str(constants.LOCAL_BIN_DIR))}")
+
+        return _print_packages_and_check_venv_problems(dirs, include_injected)
+
+    elif format == "freeze":
+        return _print_packages_as_pip_freeze(dirs)
+
+    elif format == "json":
+        return _print_packages_as_json(dirs, include_injected)
+
+    else:
+        raise PipxError(f"Unsupported format for list: '{format}'")
+
+    return EXIT_CODE_OK
+
+
+def _print_packages_and_check_venv_problems(
+    dirs: Collection[Path], include_injected: bool
+) -> ExitCode:
     all_venv_problems = VenvProblems()
     if Pool:
         p = Pool()
@@ -74,5 +96,39 @@ def list_packages(venv_container: VenvContainer, include_injected: bool) -> Exit
     if all_venv_problems.any_():
         print()
         return EXIT_CODE_LIST_PROBLEM
+
+    return EXIT_CODE_OK
+
+
+def _print_packages_as_pip_freeze(dirs: Collection[Path]) -> ExitCode:
+    packages = ""
+    for venv_dir in dirs:
+        venv = Venv(venv_dir)
+        main_pkg = venv.pipx_metadata.main_package
+        packages += f"{main_pkg.package_or_url}=={main_pkg.package_version}\n"
+    print(packages)
+
+    return EXIT_CODE_OK
+
+
+def _print_packages_as_json(dirs: Collection[Path], include_injected: bool) -> ExitCode:
+    class JSONEncoder(json.JSONEncoder):
+        """OVerloaded JSON Encoder to properly handle Path objects."""
+
+        def default(self, obj):
+            if isinstance(obj, Path):
+                return str(obj)
+
+            return json.JSONEncoder.default(self, obj)
+
+    packages: List[dict] = []
+    for venv_dir in dirs:
+        venv = Venv(venv_dir)
+        package_metadata = venv.pipx_metadata.to_dict()
+        if not include_injected:
+            del package_metadata["injected_packages"]
+
+        packages.append(package_metadata)
+    print(json.dumps(packages, cls=JSONEncoder))
 
     return EXIT_CODE_OK

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -238,7 +238,9 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
             force=args.force,
         )
     elif args.command == "list":
-        return commands.list_packages(venv_container, args.include_injected)
+        return commands.list_packages(
+            venv_container, args.include_injected, args.format
+        )
     elif args.command == "uninstall":
         return commands.uninstall(venv_dir, constants.LOCAL_BIN_DIR, verbose)
     elif args.command == "uninstall-all":
@@ -494,6 +496,12 @@ def _add_list(subparsers) -> None:
         "--include-injected",
         action="store_true",
         help="Show packages injected into the main app's environment",
+    )
+    p.add_argument(
+        "--format",
+        choices=["human", "freeze", "json"],
+        default="human",
+        help="Control the format output in a machine readable manner",
     )
     p.add_argument("--verbose", action="store_true")
 


### PR DESCRIPTION
This flag controls how the output should be formatted. It accepts 3
possible values:

- `human`, the default value, uses the current output;
- `freeze`, prints the installed packages using a format similar to `pip
   freeze` (`name==version`).
- `json`: prints the complete details of the installed package in JSON

* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

- change `src/pipx/main.py` to add the `--format` option
- change `src/pipx/commands/list_packages.py` to implement the new formats
- change `docs/examples.md` to add an example of the new functionality

## Test plan
Ensure that the following commands produce the expected output:

The following command should produce the same output as the current version of pipx
``` console
$ pipx list 
$ pipx list --format human
```

The `--format freeze` option should list only installed packages and versions:
``` console 
$ pipx list --format freeze
```

The `--format json` should list the complete details of the installed packages.
``` console 
$ pipx list --format json
$ pipx list --format json --include-injected
```