### PR TITLE
Word-wrap and make more consistent PipxError, warning, and other messages

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ dev
 - `pipx upgrade` and `pipx upgrade-all` now have a `--upgrade-injected` option which directs pipx to also upgrade injected packages.
 - `pipx list` now detects, identifies, and suggests a remedy for venvs with old-internal data (internal venv names) that need to be updated.
 - Added a "Troubleshooting" page to the pipx web documentation for common problems pipx users may encounter.
+- pipx error, warning, and other messages now word-wrap so words are not split across lines.  Their appearance is also now more consistent.
 
 0.15.6.0
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -331,10 +331,10 @@ def run_post_install_actions(
             raise PipxError(
                 wrap(
                     f"""
-                    No apps associated with package {display_name}.  Try again
+                    No apps associated with package {display_name}. Try again
                     with '--include-deps' to include apps of dependent
-                    packages, which are listed above.  If you are attempting to
-                    install a library, pipx should not be used.  Consider using
+                    packages, which are listed above. If you are attempting to
+                    install a library, pipx should not be used. Consider using
                     pip or a similar tool instead.
                     """
                 )
@@ -343,7 +343,7 @@ def run_post_install_actions(
             raise PipxError(
                 wrap(
                     f"""
-                    No apps associated with package {display_name}.  If you are
+                    No apps associated with package {display_name}. If you are
                     attempting to install a library, pipx should not be used.
                     Consider using pip or a similar tool instead.
                     """

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -314,11 +314,7 @@ def run_post_install_actions(
 
     display_name = f"{package}{package_metadata.suffix}"
 
-    if (
-        not package_metadata.apps
-        and package_metadata.apps_of_dependencies
-        and not include_dependencies
-    ):
+    if not package_metadata.app_paths and not include_dependencies:
         # No apps associated with this package and we aren't including dependencies.
         # This package has nothing for pipx to use, so this is an error.
         for dep, dependent_apps in package_metadata.app_paths_of_dependencies.items():
@@ -330,27 +326,45 @@ def run_post_install_actions(
 
         if venv.safe_to_remove():
             venv.remove_venv()
-        raise PipxError(
-            wrap(
-                f"""
-                No apps associated with package {display_name}. Try again
-                with '--include-deps' to include apps of dependent packages,
-                which are listed above. If you are attempting to install a
-                library, pipx should not be used. Consider using pip or a
-                similar tool instead.
-                """
+
+        if package_metadata.app_paths_of_dependencies:
+            raise PipxError(
+                wrap(
+                    f"""
+                    No apps associated with package {display_name}.  Try again
+                    with '--include-deps' to include apps of dependent
+                    packages, which are listed above.  If you are attempting to
+                    install a library, pipx should not be used.  Consider using
+                    pip or a similar tool instead.
+                    """
+                )
             )
-        )
-    if not package_metadata.apps and not package_metadata.apps_of_dependencies:
+        else:
+            raise PipxError(
+                wrap(
+                    f"""
+                    No apps associated with package {display_name}.  If you are
+                    attempting to install a library, pipx should not be used.
+                    Consider using pip or a similar tool instead.
+                    """
+                )
+            )
+
+    if package_metadata.apps:
+        pass
+    elif package_metadata.apps_of_dependencies and include_dependencies:
+        pass
+    else:
+        # No apps associated with this package and we aren't including dependencies.
+        # This package has nothing for pipx to use, so this is an error.
         if venv.safe_to_remove():
             venv.remove_venv()
         raise PipxError(
             wrap(
                 f"""
-                No apps associated with package {display_name} or its
-                dependencies. If you are attempting to install a library, pipx
-                should not be used. Consider using pip or a similar tool
-                instead.
+                No apps associated with package {display_name} or its dependencies.
+                If you are attempting to install a library, pipx should not be used.
+                Consider using pip or a similar tool instead.
                 """
             )
         )

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -336,7 +336,8 @@ def run_post_install_actions(
                     packages, which are listed above.  If you are attempting to
                     install a library, pipx should not be used.  Consider using
                     pip or a similar tool instead.
-                    """
+                    """,
+                    subsequent_indent="",
                 )
             )
         else:
@@ -346,7 +347,8 @@ def run_post_install_actions(
                     No apps associated with package {display_name}.  If you are
                     attempting to install a library, pipx should not be used.
                     Consider using pip or a similar tool instead.
-                    """
+                    """,
+                    subsequent_indent="",
                 )
             )
 
@@ -365,7 +367,8 @@ def run_post_install_actions(
                 No apps associated with package {display_name} or its dependencies.
                 If you are attempting to install a library, pipx should not be used.
                 Consider using pip or a similar tool instead.
-                """
+                """,
+                subsequent_indent="",
             )
         )
 
@@ -400,7 +403,8 @@ def warn_if_not_on_path(local_bin_dir: Path) -> None:
                 accessible until your PATH is updated. Run `pipx ensurepath` to
                 automatically add it, or manually modify your PATH in your
                 shell's config file (i.e. ~/.bashrc).
-                """
+                """,
+                subsequent_indent=" " * 4,
             )
         )
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -336,8 +336,7 @@ def run_post_install_actions(
                     packages, which are listed above.  If you are attempting to
                     install a library, pipx should not be used.  Consider using
                     pip or a similar tool instead.
-                    """,
-                    subsequent_indent="",
+                    """
                 )
             )
         else:
@@ -347,8 +346,7 @@ def run_post_install_actions(
                     No apps associated with package {display_name}.  If you are
                     attempting to install a library, pipx should not be used.
                     Consider using pip or a similar tool instead.
-                    """,
-                    subsequent_indent="",
+                    """
                 )
             )
 
@@ -367,8 +365,7 @@ def run_post_install_actions(
                 No apps associated with package {display_name} or its dependencies.
                 If you are attempting to install a library, pipx should not be used.
                 Consider using pip or a similar tool instead.
-                """,
-                subsequent_indent="",
+                """
             )
         )
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -322,7 +322,6 @@ def run_post_install_actions(
 
         if venv.safe_to_remove():
             venv.remove_venv()
-
         raise PipxError(
             f"No apps associated with package {display_name}. "
             "Try again with '--include-deps' to include apps of dependent packages, "
@@ -333,7 +332,6 @@ def run_post_install_actions(
     if not package_metadata.apps and not package_metadata.apps_of_dependencies:
         if venv.safe_to_remove():
             venv.remove_venv()
-
         raise PipxError(
             f"No apps associated with package {display_name} or its dependencies. "
             "If you are attempting to install a library, pipx should not be used. "

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -121,8 +121,14 @@ def _symlink_package_apps(
                 logging.info(f"Same path {str(symlink_path)} and {str(app_path)}")
             else:
                 logging.warning(
-                    f"{hazard}  File exists at {str(symlink_path)} and points "
-                    f"to {symlink_path.resolve()}, not {str(app_path)}. Not modifying."
+                    wrap(
+                        f"""
+                        {hazard}  File exists at {str(symlink_path)} and points
+                        to {symlink_path.resolve()}, not {str(app_path)}. Not
+                        modifying.
+                        """,
+                        subsequent_indent=" " * 4,
+                    )
                 )
             continue
         if is_symlink and not exists:

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -335,7 +335,7 @@ def run_post_install_actions(
             venv.remove_venv()
 
         raise PipxError(
-            f"No apps associated with package {display_name}. "
+            f"No apps associated with package {display_name} or its dependencies. "
             "If you are attempting to install a library, pipx should not be used. "
             "Consider using pip or a similar tool instead."
         )

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -17,7 +17,7 @@ from pipx.colors import bold, red
 from pipx.emojies import hazard, stars
 from pipx.package_specifier import parse_specifier_for_install, valid_pypi_name
 from pipx.pipx_metadata_file import PackageInfo
-from pipx.util import WINDOWS, PipxError, mkdir, rmdir, wrap
+from pipx.util import WINDOWS, PipxError, mkdir, pipx_wrap, rmdir
 from pipx.venv import Venv
 
 
@@ -121,7 +121,7 @@ def _symlink_package_apps(
                 logging.info(f"Same path {str(symlink_path)} and {str(app_path)}")
             else:
                 logging.warning(
-                    wrap(
+                    pipx_wrap(
                         f"""
                         {hazard}  File exists at {str(symlink_path)} and points
                         to {symlink_path.resolve()}, not {str(app_path)}. Not
@@ -143,7 +143,7 @@ def _symlink_package_apps(
 
         if existing_executable_on_path:
             logging.warning(
-                wrap(
+                pipx_wrap(
                     f"""
                     {hazard}  Note: {app_name_suffixed} was already on your
                     PATH at {existing_executable_on_path}
@@ -340,25 +340,21 @@ def run_post_install_actions(
 
         if package_metadata.app_paths_of_dependencies:
             raise PipxError(
-                wrap(
-                    f"""
-                    No apps associated with package {display_name}. Try again
-                    with '--include-deps' to include apps of dependent
-                    packages, which are listed above. If you are attempting to
-                    install a library, pipx should not be used. Consider using
-                    pip or a similar tool instead.
-                    """
-                )
+                f"""
+                No apps associated with package {display_name}. Try again with
+                '--include-deps' to include apps of dependent packages, which
+                are listed above. If you are attempting to install a library,
+                pipx should not be used. Consider using pip or a similar tool
+                instead.
+                """
             )
         else:
             raise PipxError(
-                wrap(
-                    f"""
-                    No apps associated with package {display_name}. If you are
-                    attempting to install a library, pipx should not be used.
-                    Consider using pip or a similar tool instead.
-                    """
-                )
+                f"""
+                No apps associated with package {display_name}. If you are
+                attempting to install a library, pipx should not be used.
+                Consider using pip or a similar tool instead.
+                """
             )
 
     if package_metadata.apps:
@@ -371,13 +367,11 @@ def run_post_install_actions(
         if venv.safe_to_remove():
             venv.remove_venv()
         raise PipxError(
-            wrap(
-                f"""
-                No apps associated with package {display_name} or its dependencies.
-                If you are attempting to install a library, pipx should not be used.
-                Consider using pip or a similar tool instead.
-                """
-            )
+            f"""
+            No apps associated with package {display_name} or its dependencies.
+            If you are attempting to install a library, pipx should not be
+            used.  Consider using pip or a similar tool instead.
+            """
         )
 
     expose_apps_globally(
@@ -404,7 +398,7 @@ def run_post_install_actions(
 def warn_if_not_on_path(local_bin_dir: Path) -> None:
     if not userpath.in_current_path(str(local_bin_dir)):
         logging.warning(
-            wrap(
+            pipx_wrap(
                 f"""
                 {hazard}  Note: {str(local_bin_dir)!r} is not on your PATH
                 environment variable. These apps will not be globally

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -143,8 +143,13 @@ def _symlink_package_apps(
 
         if existing_executable_on_path:
             logging.warning(
-                f"{hazard}  Note: {app_name_suffixed} was already on your PATH at "
-                f"{existing_executable_on_path}"
+                wrap(
+                    f"""
+                    {hazard}  Note: {app_name_suffixed} was already on your
+                    PATH at {existing_executable_on_path}
+                    """,
+                    subsequent_indent=" " * 4,
+                )
             )
 
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -17,7 +17,7 @@ from pipx.colors import bold, red
 from pipx.emojies import hazard, stars
 from pipx.package_specifier import parse_specifier_for_install, valid_pypi_name
 from pipx.pipx_metadata_file import PackageInfo
-from pipx.util import WINDOWS, PipxError, mkdir, rmdir
+from pipx.util import WINDOWS, PipxError, mkdir, rmdir, wrap
 from pipx.venv import Venv
 
 
@@ -331,19 +331,28 @@ def run_post_install_actions(
         if venv.safe_to_remove():
             venv.remove_venv()
         raise PipxError(
-            f"No apps associated with package {display_name}. "
-            "Try again with '--include-deps' to include apps of dependent packages, "
-            "which are listed above. "
-            "If you are attempting to install a library, pipx should not be used. "
-            "Consider using pip or a similar tool instead."
+            wrap(
+                f"""
+                No apps associated with package {display_name}. Try again
+                with '--include-deps' to include apps of dependent packages,
+                which are listed above. If you are attempting to install a
+                library, pipx should not be used. Consider using pip or a
+                similar tool instead.
+                """
+            )
         )
     if not package_metadata.apps and not package_metadata.apps_of_dependencies:
         if venv.safe_to_remove():
             venv.remove_venv()
         raise PipxError(
-            f"No apps associated with package {display_name} or its dependencies. "
-            "If you are attempting to install a library, pipx should not be used. "
-            "Consider using pip or a similar tool instead."
+            wrap(
+                f"""
+                No apps associated with package {display_name} or its
+                dependencies. If you are attempting to install a library, pipx
+                should not be used. Consider using pip or a similar tool
+                instead.
+                """
+            )
         )
 
     expose_apps_globally(
@@ -370,11 +379,15 @@ def run_post_install_actions(
 def warn_if_not_on_path(local_bin_dir: Path) -> None:
     if not userpath.in_current_path(str(local_bin_dir)):
         logging.warning(
-            f"{hazard}  Note: {str(local_bin_dir)!r} is not on your PATH environment "
-            "variable. These apps will not be globally accessible until "
-            "your PATH is updated. Run `pipx ensurepath` to "
-            "automatically add it, or manually modify your PATH in your shell's "
-            "config file (i.e. ~/.bashrc)."
+            wrap(
+                f"""
+                {hazard}  Note: {str(local_bin_dir)!r} is not on your PATH
+                environment variable. These apps will not be globally
+                accessible until your PATH is updated. Run `pipx ensurepath` to
+                automatically add it, or manually modify your PATH in your
+                shell's config file (i.e. ~/.bashrc).
+                """
+            )
         )
 
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -306,7 +306,11 @@ def run_post_install_actions(
 
     display_name = f"{package}{package_metadata.suffix}"
 
-    if not package_metadata.app_paths and not include_dependencies:
+    if (
+        not package_metadata.apps
+        and package_metadata.apps_of_dependencies
+        and not include_dependencies
+    ):
         # No apps associated with this package and we aren't including dependencies.
         # This package has nothing for pipx to use, so this is an error.
         for dep, dependent_apps in package_metadata.app_paths_of_dependencies.items():
@@ -319,32 +323,19 @@ def run_post_install_actions(
         if venv.safe_to_remove():
             venv.remove_venv()
 
-        if package_metadata.app_paths_of_dependencies:
-            raise PipxError(
-                f"No apps associated with package {display_name}. "
-                "Try again with '--include-deps' to include apps of dependent packages, "
-                "which are listed above. "
-                "If you are attempting to install a library, pipx should not be used. "
-                "Consider using pip or a similar tool instead."
-            )
-        else:
-            raise PipxError(
-                f"No apps associated with package {display_name}. "
-                "If you are attempting to install a library, pipx should not be used. "
-                "Consider using pip or a similar tool instead."
-            )
-
-    if package_metadata.apps:
-        pass
-    elif package_metadata.apps_of_dependencies and include_dependencies:
-        pass
-    else:
-        # No apps associated with this package and we aren't including dependencies.
-        # This package has nothing for pipx to use, so this is an error.
+        raise PipxError(
+            f"No apps associated with package {display_name}. "
+            "Try again with '--include-deps' to include apps of dependent packages, "
+            "which are listed above. "
+            "If you are attempting to install a library, pipx should not be used. "
+            "Consider using pip or a similar tool instead."
+        )
+    if not package_metadata.apps and not package_metadata.apps_of_dependencies:
         if venv.safe_to_remove():
             venv.remove_venv()
+
         raise PipxError(
-            f"No apps associated with package {display_name} or its dependencies. "
+            f"No apps associated with package {display_name}. "
             "If you are attempting to install a library, pipx should not be used. "
             "Consider using pip or a similar tool instead."
         )

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -1,7 +1,6 @@
 import logging
 import site
 import sys
-import textwrap
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -10,6 +9,7 @@ import userpath  # type: ignore
 from pipx import constants
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojies import stars
+from pipx.utils import wrap
 
 
 def get_pipx_user_bin_path() -> Optional[Path]:
@@ -60,29 +60,21 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
 
     if force or (not in_current_path and not need_shell_restart):
         userpath.append(location_str)
-        print(
-            textwrap.fill(
-                f"Success! Added {location_str} to the PATH environment variable.",
-                subsequent_indent="    ",
-            )
-        )
+        print(wrap(f"Success! Added {location_str} to the PATH environment variable.",))
         path_added = True
         need_shell_restart = userpath.need_shell_restart(location_str)
     elif not in_current_path and need_shell_restart:
         print(
-            textwrap.fill(
-                f"{location_str} has been been added to PATH, but you "
-                "need to open a new terminal or re-login for this PATH "
-                "change to take effect.",
-                subsequent_indent="    ",
+            wrap(
+                f"""
+                {location_str} has been been added to PATH, but you need to
+                open a new terminal or re-login for this PATH change to take
+                effect.
+                """,
             )
         )
     else:
-        print(
-            textwrap.fill(
-                f"{location_str} is already in PATH.", subsequent_indent="    "
-            )
-        )
+        print(wrap(f"{location_str} is already in PATH."))
 
     return (path_added, need_shell_restart)
 
@@ -108,28 +100,37 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
 
     if path_added:
         print(
-            textwrap.fill(
-                "Consider adding shell completions for pipx. "
-                "Run 'pipx completions' for instructions."
+            wrap(
+                """
+                Consider adding shell completions for pipx.  Run 'pipx
+                completions' for instructions.
+                """,
+                subsequent_indent="",
             )
             + "\n"
         )
     elif not need_shell_restart:
         sys.stdout.flush()
         logging.warning(
-            textwrap.fill(
-                "All pipx binary directories have been added to PATH. "
-                "If you are sure you want to proceed, try again with "
-                "the '--force' flag."
+            wrap(
+                """
+                All pipx binary directories have been added to PATH.  If you
+                are sure you want to proceed, try again with the '--force'
+                flag.
+                """,
+                subsequent_indent="",
             )
             + "\n"
         )
 
     if need_shell_restart:
         print(
-            textwrap.fill(
-                "You will need to open a new terminal or re-login for "
-                "the PATH changes to take effect."
+            wrap(
+                """
+                You will need to open a new terminal or re-login for the PATH
+                changes to take effect.
+                """,
+                subsequent_indent="",
             )
             + "\n"
         )

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -8,7 +8,7 @@ import userpath  # type: ignore
 
 from pipx import constants
 from pipx.constants import EXIT_CODE_OK, ExitCode
-from pipx.emojies import stars
+from pipx.emojies import hazard, stars
 from pipx.util import pipx_wrap
 
 
@@ -120,8 +120,8 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
         sys.stdout.flush()
         logging.warning(
             pipx_wrap(
-                """
-                All pipx binary directories have been added to PATH. If you
+                f"""
+                {hazard}  All pipx binary directories have been added to PATH. If you
                 are sure you want to proceed, try again with the '--force'
                 flag.
                 """

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -108,7 +108,7 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
         print(
             wrap(
                 """
-                Consider adding shell completions for pipx.  Run 'pipx
+                Consider adding shell completions for pipx. Run 'pipx
                 completions' for instructions.
                 """
             )
@@ -119,7 +119,7 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
         logging.warning(
             wrap(
                 """
-                All pipx binary directories have been added to PATH.  If you
+                All pipx binary directories have been added to PATH. If you
                 are sure you want to proceed, try again with the '--force'
                 flag.
                 """

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -9,7 +9,7 @@ import userpath  # type: ignore
 from pipx import constants
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojies import stars
-from pipx.utils import wrap
+from pipx.util import wrap
 
 
 def get_pipx_user_bin_path() -> Optional[Path]:

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -60,7 +60,12 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
 
     if force or (not in_current_path and not need_shell_restart):
         userpath.append(location_str)
-        print(wrap(f"Success! Added {location_str} to the PATH environment variable.",))
+        print(
+            wrap(
+                f"Success! Added {location_str} to the PATH environment variable.",
+                subsequent_indent=" " * 4,
+            )
+        )
         path_added = True
         need_shell_restart = userpath.need_shell_restart(location_str)
     elif not in_current_path and need_shell_restart:
@@ -71,10 +76,11 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
                 open a new terminal or re-login for this PATH change to take
                 effect.
                 """,
+                subsequent_indent=" " * 4,
             )
         )
     else:
-        print(wrap(f"{location_str} is already in PATH."))
+        print(wrap(f"{location_str} is already in PATH.", subsequent_indent=" " * 4))
 
     return (path_added, need_shell_restart)
 

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -9,7 +9,7 @@ import userpath  # type: ignore
 from pipx import constants
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojies import stars
-from pipx.util import wrap
+from pipx.util import pipx_wrap
 
 
 def get_pipx_user_bin_path() -> Optional[Path]:
@@ -61,7 +61,7 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
     if force or (not in_current_path and not need_shell_restart):
         userpath.append(location_str)
         print(
-            wrap(
+            pipx_wrap(
                 f"Success! Added {location_str} to the PATH environment variable.",
                 subsequent_indent=" " * 4,
             )
@@ -70,7 +70,7 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
         need_shell_restart = userpath.need_shell_restart(location_str)
     elif not in_current_path and need_shell_restart:
         print(
-            wrap(
+            pipx_wrap(
                 f"""
                 {location_str} has been been added to PATH, but you need to
                 open a new terminal or re-login for this PATH change to take
@@ -80,7 +80,9 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
             )
         )
     else:
-        print(wrap(f"{location_str} is already in PATH.", subsequent_indent=" " * 4))
+        print(
+            pipx_wrap(f"{location_str} is already in PATH.", subsequent_indent=" " * 4)
+        )
 
     return (path_added, need_shell_restart)
 
@@ -106,7 +108,7 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
 
     if path_added:
         print(
-            wrap(
+            pipx_wrap(
                 """
                 Consider adding shell completions for pipx. Run 'pipx
                 completions' for instructions.
@@ -117,7 +119,7 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
     elif not need_shell_restart:
         sys.stdout.flush()
         logging.warning(
-            wrap(
+            pipx_wrap(
                 """
                 All pipx binary directories have been added to PATH. If you
                 are sure you want to proceed, try again with the '--force'
@@ -129,7 +131,7 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
 
     if need_shell_restart:
         print(
-            wrap(
+            pipx_wrap(
                 """
                 You will need to open a new terminal or re-login for the PATH
                 changes to take effect.

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -110,8 +110,7 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
                 """
                 Consider adding shell completions for pipx.  Run 'pipx
                 completions' for instructions.
-                """,
-                subsequent_indent="",
+                """
             )
             + "\n"
         )
@@ -123,8 +122,7 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
                 All pipx binary directories have been added to PATH.  If you
                 are sure you want to proceed, try again with the '--force'
                 flag.
-                """,
-                subsequent_indent="",
+                """
             )
             + "\n"
         )
@@ -135,8 +133,7 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
                 """
                 You will need to open a new terminal or re-login for the PATH
                 changes to take effect.
-                """,
-                subsequent_indent="",
+                """
             )
             + "\n"
         )

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -27,7 +27,7 @@ def inject_dep(
             wrap(
                 f"""\
                 Can't inject {package_spec!r} into nonexistent Virtual
-                Environment {str(venv_dir)!r}.  Be sure to install the package
+                Environment {venv_dir.name!r}.  Be sure to install the package
                 first with pipx install {venv_dir.name!r} before injecting into
                 it.
                 """,

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -27,7 +27,7 @@ def inject_dep(
             wrap(
                 f"""\
                 Can't inject {package_spec!r} into nonexistent Virtual
-                Environment {venv_dir.name!r}.  Be sure to install the package
+                Environment {venv_dir.name!r}. Be sure to install the package
                 first with 'pipx install {venv_dir.name}' before injecting into
                 it.
                 """
@@ -38,10 +38,15 @@ def inject_dep(
 
     if not venv.package_metadata:
         raise PipxError(
-            f"Can't inject {package_spec!r} into Virtual Environment {venv.name!r}.\n"
-            f"    {venv.name!r} has missing internal pipx metadata.\n"
-            "    It was likely installed using a pipx version before 0.15.0.0.\n"
-            f"    Please uninstall and install {venv.name!r}, or reinstall-all to fix."
+            wrap(
+                f"""
+                Can't inject {package_spec!r} into Virtual Environment
+                {venv.name!r}. {venv.name!r} has missing internal pipx
+                metadata. It was likely installed using a pipx version before
+                0.15.0.0. Please uninstall and install {venv.name!r}, or
+                reinstall-all to fix.
+                """
+            )
         )
 
     # package_spec is anything pip-installable, including package_name, vcs spec,

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -1,5 +1,4 @@
 import sys
-import textwrap
 from pathlib import Path
 from typing import List, Optional
 
@@ -8,7 +7,7 @@ from pipx.colors import bold
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK, ExitCode
 from pipx.emojies import stars
-from pipx.util import PipxError
+from pipx.util import PipxError, wrap
 from pipx.venv import Venv
 
 
@@ -25,13 +24,14 @@ def inject_dep(
 ) -> bool:
     if not venv_dir.exists() or not next(venv_dir.iterdir()):
         raise PipxError(
-            textwrap.dedent(
+            wrap(
                 f"""\
                 Can't inject {package_spec!r} into nonexistent Virtual
                 Environment {str(venv_dir)!r}.  Be sure to install the package
                 first with pipx install {venv_dir.name!r} before injecting into
                 it.
-                """
+                """,
+                subsequent_indent="",
             )
         )
 

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -28,10 +28,9 @@ def inject_dep(
                 f"""\
                 Can't inject {package_spec!r} into nonexistent Virtual
                 Environment {venv_dir.name!r}.  Be sure to install the package
-                first with pipx install {venv_dir.name!r} before injecting into
+                first with 'pipx install {venv_dir.name}' before injecting into
                 it.
-                """,
-                subsequent_indent="",
+                """
             )
         )
 

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -27,9 +27,11 @@ def inject_dep(
         raise PipxError(
             textwrap.dedent(
                 f"""\
-            Can't inject {package_spec!r} into nonexistent Virtual Environment {str(venv_dir)!r}.
-            Be sure to install the package first with pipx install {venv_dir.name!r}
-            before injecting into it."""
+                Can't inject {package_spec!r} into nonexistent Virtual
+                Environment {str(venv_dir)!r}.  Be sure to install the package
+                first with pipx install {venv_dir.name!r} before injecting into
+                it.
+                """
             )
         )
 

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -25,7 +25,7 @@ def inject_dep(
     if not venv_dir.exists() or not next(venv_dir.iterdir()):
         raise PipxError(
             wrap(
-                f"""\
+                f"""
                 Can't inject {package_spec!r} into nonexistent Virtual
                 Environment {venv_dir.name!r}. Be sure to install the package
                 first with 'pipx install {venv_dir.name}' before injecting into

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -7,7 +7,7 @@ from pipx.colors import bold
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INJECT_ERROR, EXIT_CODE_OK, ExitCode
 from pipx.emojies import stars
-from pipx.util import PipxError, wrap
+from pipx.util import PipxError
 from pipx.venv import Venv
 
 
@@ -24,29 +24,23 @@ def inject_dep(
 ) -> bool:
     if not venv_dir.exists() or not next(venv_dir.iterdir()):
         raise PipxError(
-            wrap(
-                f"""
-                Can't inject {package_spec!r} into nonexistent Virtual
-                Environment {venv_dir.name!r}. Be sure to install the package
-                first with 'pipx install {venv_dir.name}' before injecting into
-                it.
-                """
-            )
+            f"""
+            Can't inject {package_spec!r} into nonexistent Virtual Environment
+            {venv_dir.name!r}. Be sure to install the package first with 'pipx
+            install {venv_dir.name}' before injecting into it.
+            """
         )
 
     venv = Venv(venv_dir, verbose=verbose)
 
     if not venv.package_metadata:
         raise PipxError(
-            wrap(
-                f"""
-                Can't inject {package_spec!r} into Virtual Environment
-                {venv.name!r}. {venv.name!r} has missing internal pipx
-                metadata. It was likely installed using a pipx version before
-                0.15.0.0. Please uninstall and install {venv.name!r}, or
-                reinstall-all to fix.
-                """
-            )
+            f"""
+            Can't inject {package_spec!r} into Virtual Environment
+            {venv.name!r}. {venv.name!r} has missing internal pipx metadata. It
+            was likely installed using a pipx version before 0.15.0.0. Please
+            uninstall and install {venv.name!r}, or reinstall-all to fix.
+            """
         )
 
     # package_spec is anything pip-installable, including package_name, vcs spec,

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from pipx import constants
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INSTALL_VENV_EXISTS, EXIT_CODE_OK, ExitCode
-from pipx.util import wrap
+from pipx.util import pipx_wrap
 from pipx.venv import Venv, VenvContainer
 
 
@@ -45,7 +45,7 @@ def install(
             print(f"Installing to existing venv {venv.name!r}")
         else:
             print(
-                wrap(
+                pipx_wrap(
                     f"""
                     {venv.name!r} already seems to be installed. Not modifying
                     existing installation in {str(venv_dir)!r}. Pass '--force'

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -47,8 +47,8 @@ def install(
             print(
                 wrap(
                     f"""
-                    {venv.name!r} already seems to be installed.  Not modifying
-                    existing installation in {str(venv_dir)!r}.  Pass '--force'
+                    {venv.name!r} already seems to be installed. Not modifying
+                    existing installation in {str(venv_dir)!r}. Pass '--force'
                     to force installation.
                     """
                 )

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from pipx import constants
 from pipx.commands.common import package_name_from_spec, run_post_install_actions
 from pipx.constants import EXIT_CODE_INSTALL_VENV_EXISTS, EXIT_CODE_OK, ExitCode
+from pipx.util import wrap
 from pipx.venv import Venv, VenvContainer
 
 
@@ -44,9 +45,13 @@ def install(
             print(f"Installing to existing venv {venv.name!r}")
         else:
             print(
-                f"{venv.name!r} already seems to be installed. "
-                f"Not modifying existing installation in {str(venv_dir)!r}. "
-                "Pass '--force' to force installation."
+                wrap(
+                    f"""
+                    {venv.name!r} already seems to be installed.  Not modifying
+                    existing installation in {str(venv_dir)!r}.  Pass '--force'
+                    to force installation.
+                    """
+                )
             )
             return EXIT_CODE_INSTALL_VENV_EXISTS
 
@@ -70,7 +75,7 @@ def install(
             force=force,
         )
     except (Exception, KeyboardInterrupt):
-        print("")
+        print()
         venv.remove_venv()
         raise
 

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -10,7 +10,7 @@ from pipx.commands.install import install
 from pipx.commands.uninstall import uninstall
 from pipx.constants import EXIT_CODE_OK, EXIT_CODE_REINSTALL_VENV_NONEXISTENT, ExitCode
 from pipx.emojies import sleep
-from pipx.util import PipxError
+from pipx.util import PipxError, wrap
 from pipx.venv import Venv, VenvContainer
 
 
@@ -104,7 +104,7 @@ def reinstall_all(
             failed.append(venv_dir.name)
     if len(failed) > 0:
         raise PipxError(
-            f"The following package(s) failed to reinstall: {', '.join(failed)}"
+            wrap(f"The following package(s) failed to reinstall: {', '.join(failed)}")
         )
     # Any failure to install will raise PipxError, otherwise success
     return EXIT_CODE_OK

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -10,7 +10,7 @@ from pipx.commands.install import install
 from pipx.commands.uninstall import uninstall
 from pipx.constants import EXIT_CODE_OK, EXIT_CODE_REINSTALL_VENV_NONEXISTENT, ExitCode
 from pipx.emojies import sleep
-from pipx.util import PipxError, wrap
+from pipx.util import PipxError
 from pipx.venv import Venv, VenvContainer
 
 
@@ -104,7 +104,7 @@ def reinstall_all(
             failed.append(venv_dir.name)
     if len(failed) > 0:
         raise PipxError(
-            wrap(f"The following package(s) failed to reinstall: {', '.join(failed)}")
+            f"The following package(s) failed to reinstall: {', '.join(failed)}"
         )
     # Any failure to install will raise PipxError, otherwise success
     return EXIT_CODE_OK

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -19,6 +19,7 @@ from pipx.util import (
     get_pypackage_bin_path,
     rmdir,
     run_pypackage_bin,
+    wrap,
 )
 from pipx.venv import Venv
 
@@ -43,8 +44,13 @@ def run(
     if urllib.parse.urlparse(app).scheme:
         if not app.endswith(".py"):
             raise PipxError(
-                "pipx will only execute apps from the internet directly if "
-                "they end with '.py'. To run from an SVN, try pipx --spec URL BINARY"
+                wrap(
+                    """
+                    pipx will only execute apps from the internet directly if
+                    they end with '.py'. To run from an SVN, try pipx --spec
+                    URL BINARY
+                    """
+                )
             )
         logging.info("Detected url. Downloading and executing as a Python file.")
 
@@ -72,9 +78,13 @@ def run(
         run_pypackage_bin(pypackage_bin_path, app_args)
     if pypackages:
         raise PipxError(
-            f"'--pypackages' flag was passed, but {str(pypackage_bin_path)!r} was "
-            "not found. See https://github.com/cs01/pythonloc to learn how to "
-            "install here, or omit the flag."
+            wrap(
+                f"""
+                '--pypackages' flag was passed, but {str(pypackage_bin_path)!r}
+                was not found. See https://github.com/cs01/pythonloc to learn
+                how to install here, or omit the flag.
+                """
+            )
         )
 
     venv_dir = _get_temporary_venv_path(package_or_url, python, pip_args, venv_args)
@@ -136,9 +146,12 @@ def _download_and_run(
     if not (venv.bin_path / app).exists():
         apps = venv.pipx_metadata.main_package.apps
         raise PipxError(
-            f"'{app}' executable script not found in package '{package_or_url}'. "
-            "Available executable scripts: "
-            f"{', '.join(b for b in apps)}"
+            wrap(
+                f"""
+                '{app}' executable script not found in package '{package_or_url}'.
+                Available executable scripts: {', '.join(b for b in apps)}
+                """
+            )
         )
 
     if not use_cache:

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -17,9 +17,9 @@ from pipx.util import (
     PipxError,
     exec_app,
     get_pypackage_bin_path,
+    pipx_wrap,
     rmdir,
     run_pypackage_bin,
-    wrap,
 )
 from pipx.venv import Venv
 
@@ -44,13 +44,10 @@ def run(
     if urllib.parse.urlparse(app).scheme:
         if not app.endswith(".py"):
             raise PipxError(
-                wrap(
-                    """
-                    pipx will only execute apps from the internet directly if
-                    they end with '.py'. To run from an SVN, try pipx --spec
-                    URL BINARY
-                    """
-                )
+                """
+                pipx will only execute apps from the internet directly if they
+                end with '.py'. To run from an SVN, try pipx --spec URL BINARY
+                """
             )
         logging.info("Detected url. Downloading and executing as a Python file.")
 
@@ -60,7 +57,7 @@ def run(
 
     elif which(app):
         logging.warning(
-            wrap(
+            pipx_wrap(
                 f"""
                 {hazard}  {app} is already on your PATH and installed at
                 {which(app)}. Downloading and running anyway.
@@ -82,13 +79,11 @@ def run(
         run_pypackage_bin(pypackage_bin_path, app_args)
     if pypackages:
         raise PipxError(
-            wrap(
-                f"""
-                '--pypackages' flag was passed, but {str(pypackage_bin_path)!r}
-                was not found. See https://github.com/cs01/pythonloc to learn
-                how to install here, or omit the flag.
-                """
-            )
+            f"""
+            '--pypackages' flag was passed, but {str(pypackage_bin_path)!r} was
+            not found. See https://github.com/cs01/pythonloc to learn how to
+            install here, or omit the flag.
+            """
         )
 
     venv_dir = _get_temporary_venv_path(package_or_url, python, pip_args, venv_args)
@@ -150,12 +145,10 @@ def _download_and_run(
     if not (venv.bin_path / app).exists():
         apps = venv.pipx_metadata.main_package.apps
         raise PipxError(
-            wrap(
-                f"""
-                '{app}' executable script not found in package '{package_or_url}'.
-                Available executable scripts: {', '.join(b for b in apps)}
-                """
-            )
+            f"""
+            '{app}' executable script not found in package '{package_or_url}'.
+            Available executable scripts: {', '.join(b for b in apps)}
+            """
         )
 
     if not use_cache:

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -60,9 +60,13 @@ def run(
 
     elif which(app):
         logging.warning(
-            f"{hazard}  {app} is already on your PATH and installed at "
-            f"{which(app)}. Downloading and "
-            "running anyway."
+            wrap(
+                f"""
+                {hazard}  {app} is already on your PATH and installed at
+                {which(app)}. Downloading and running anyway.
+                """,
+                subsequent_indent=" " * 4,
+            )
         )
 
     if WINDOWS and not app.endswith(".exe"):

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -8,7 +8,7 @@ from pipx.commands.common import expose_apps_globally
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojies import sleep
 from pipx.package_specifier import parse_specifier_for_upgrade
-from pipx.util import PipxError, wrap
+from pipx.util import PipxError, pipx_wrap
 from pipx.venv import Venv, VenvContainer
 
 
@@ -66,7 +66,7 @@ def _upgrade_package(
             pass
         else:
             print(
-                wrap(
+                pipx_wrap(
                     f"""
                     {display_name} is already at latest version {old_version}
                     (location: {str(venv.root)})
@@ -76,7 +76,7 @@ def _upgrade_package(
         return 0
     else:
         print(
-            wrap(
+            pipx_wrap(
                 f"""
                 upgraded package {display_name} from {old_version} to
                 {new_version} (location: {str(venv.root)})
@@ -98,12 +98,10 @@ def _upgrade_venv(
     """Returns number of packages with changed versions."""
     if not venv_dir.is_dir():
         raise PipxError(
-            wrap(
-                f"""
-                Package is not installed. Expected to find {str(venv_dir)}, but
-                it does not exist.
-                """
-            )
+            f"""
+            Package is not installed. Expected to find {str(venv_dir)}, but it
+            does not exist.
+            """
         )
 
     venv = Venv(venv_dir, verbose=verbose)
@@ -112,7 +110,8 @@ def _upgrade_venv(
         raise PipxError(
             f"Not upgrading {red(bold(venv_dir.name))}. It has missing internal pipx metadata.\n"
             f"It was likely installed using a pipx version before 0.15.0.0.\n"
-            f"Please uninstall and install this package to fix."
+            f"Please uninstall and install this package to fix.",
+            wrap=False,
         )
 
     # Upgrade shared libraries (pip, setuptools and wheel)
@@ -209,7 +208,8 @@ def upgrade_all(
     if venv_error:
         raise PipxError(
             "\nSome packages encountered errors during upgrade.\n"
-            "    See specific error messages above."
+            "    See specific error messages above.",
+            wrap=False,
         )
 
     return EXIT_CODE_OK

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -8,7 +8,7 @@ from pipx.commands.common import expose_apps_globally
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojies import sleep
 from pipx.package_specifier import parse_specifier_for_upgrade
-from pipx.util import PipxError
+from pipx.util import PipxError, wrap
 from pipx.venv import Venv, VenvContainer
 
 
@@ -90,8 +90,12 @@ def _upgrade_venv(
     """Returns number of packages with changed versions."""
     if not venv_dir.is_dir():
         raise PipxError(
-            f"Package is not installed. Expected to find {str(venv_dir)}, "
-            "but it does not exist."
+            wrap(
+                f"""
+                Package is not installed. Expected to find {str(venv_dir)}, but
+                it does not exist.
+                """
+            )
         )
 
     venv = Venv(venv_dir, verbose=verbose)

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -111,8 +111,8 @@ def _upgrade_venv(
     if not venv.package_metadata:
         raise PipxError(
             f"Not upgrading {red(bold(venv_dir.name))}. It has missing internal pipx metadata.\n"
-            f"    It was likely installed using a pipx version before 0.15.0.0.\n"
-            f"    Please uninstall and install this package to fix."
+            f"It was likely installed using a pipx version before 0.15.0.0.\n"
+            f"Please uninstall and install this package to fix."
         )
 
     # Upgrade shared libraries (pip, setuptools and wheel)

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -66,14 +66,22 @@ def _upgrade_package(
             pass
         else:
             print(
-                f"{display_name} is already at latest version {old_version} "
-                f"(location: {str(venv.root)})"
+                wrap(
+                    f"""
+                    {display_name} is already at latest version {old_version}
+                    (location: {str(venv.root)})
+                    """
+                )
             )
         return 0
     else:
         print(
-            f"upgraded package {display_name} from {old_version} to {new_version} "
-            f"(location: {str(venv.root)})"
+            wrap(
+                f"""
+                upgraded package {display_name} from {old_version} to
+                {new_version} (location: {str(venv.root)})
+                """
+            )
         )
         return 1
 

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -98,7 +98,7 @@ def _upgrade_venv(
 
     if not venv.package_metadata:
         raise PipxError(
-            f"Not upgrading {red(bold(venv_dir.name))}.  It has missing internal pipx metadata.\n"
+            f"Not upgrading {red(bold(venv_dir.name))}. It has missing internal pipx metadata.\n"
             f"    It was likely installed using a pipx version before 0.15.0.0.\n"
             f"    Please uninstall and install this package to fix."
         )

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -111,7 +111,7 @@ def _upgrade_venv(
             f"Not upgrading {red(bold(venv_dir.name))}. It has missing internal pipx metadata.\n"
             f"It was likely installed using a pipx version before 0.15.0.0.\n"
             f"Please uninstall and install this package to fix.",
-            wrap=False,
+            wrap_message=False,
         )
 
     # Upgrade shared libraries (pip, setuptools and wheel)
@@ -209,7 +209,7 @@ def upgrade_all(
         raise PipxError(
             "\nSome packages encountered errors during upgrade.\n"
             "    See specific error messages above.",
-            wrap=False,
+            wrap_message=False,
         )
 
     return EXIT_CODE_OK

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 from pipx.constants import WINDOWS
-from pipx.util import PipxError
+from pipx.util import PipxError, wrap
 
 
 def has_venv() -> bool:
@@ -36,7 +36,7 @@ def _find_default_windows_python() -> str:
         return py
     python = shutil.which("python")
     if python is None:
-        raise PipxError("no suitable Python found")
+        raise PipxError("No suitable Python found")
 
     # If the path contains "WindowsApps", it's the store python
     if "WindowsApps" not in python:
@@ -46,14 +46,14 @@ def _find_default_windows_python() -> str:
     # https://twitter.com/zooba/status/1212454929379581952
 
     proc = subprocess.run(
-        [python, "-V"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        [python, "-V"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
     )
     if proc.returncode != 0:
         # Cover the 9009 return code pre-emptively.
-        raise PipxError("no suitable Python found")
+        raise PipxError("No suitable Python found")
     if not proc.stdout.strip():
         # A real Python should print version, Windows Store stub won't.
-        raise PipxError("no suitable Python found")
+        raise PipxError("No suitable Python found")
     return python  # This executable seems to work.
 
 
@@ -67,7 +67,9 @@ def _get_sys_executable() -> str:
 def _get_absolute_python_interpreter(env_python: str) -> str:
     which_python = shutil.which(env_python)
     if not which_python:
-        raise PipxError(f"Default python interpreter {repr(env_python)} is invalid")
+        raise PipxError(
+            wrap(f"Default python interpreter {repr(env_python)} is invalid.")
+        )
     return which_python
 
 

--- a/src/pipx/interpreter.py
+++ b/src/pipx/interpreter.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 from pipx.constants import WINDOWS
-from pipx.util import PipxError, wrap
+from pipx.util import PipxError
 
 
 def has_venv() -> bool:
@@ -67,9 +67,7 @@ def _get_sys_executable() -> str:
 def _get_absolute_python_interpreter(env_python: str) -> str:
     which_python = shutil.which(env_python)
     if not which_python:
-        raise PipxError(
-            wrap(f"Default python interpreter {repr(env_python)} is invalid.")
-        )
+        raise PipxError(f"Default python interpreter {repr(env_python)} is invalid.")
     return which_python
 
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -43,7 +43,7 @@ PIPX_DESCRIPTION = textwrap.dedent(
     Install and execute apps from Python packages.
 
     Binaries can either be installed globally into isolated Virtual Environments
-    or run directly in an temporary Virtual Environment.
+    or run directly in a temporary Virtual Environment.
 
     Virtual Environment location is {str(constants.PIPX_LOCAL_VENVS)}.
     Symlinks to apps are placed in {str(constants.LOCAL_BIN_DIR)}.

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -31,7 +31,7 @@ def print_version() -> None:
 
 
 SPEC_HELP = textwrap.dedent(
-    """
+    """\
     The package name or specific installation source passed to pip.
     Runs `pip install -U SPEC`.
     For example `--spec mypackage==2.0.0` or `--spec  git+https://github.com/user/repo.git@branch`

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -20,6 +20,7 @@ from pipx import commands, constants
 from pipx.animate import hide_cursor, show_cursor
 from pipx.colors import bold, green
 from pipx.constants import ExitCode
+from pipx.emojies import hazard
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.util import PipxError, mkdir, pipx_wrap
 from pipx.venv import VenvContainer
@@ -694,7 +695,7 @@ def setup(args: argparse.Namespace) -> None:
         logging.warning(
             pipx_wrap(
                 f"""
-                A virtual environment for pipx was detected at
+                {hazard}  A virtual environment for pipx was detected at
                 {str(old_pipx_venv_location)}. The 'pipx-app' package has been
                 renamed back to 'pipx'
                 (https://github.com/pipxproject/pipx/issues/82).

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -254,7 +254,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
             return commands.ensure_pipx_paths(force=args.force)
         except Exception as e:
             logging.debug("Uncaught Exception:", exc_info=True)
-            raise PipxError(str(e), wrap=False)
+            raise PipxError(str(e), wrap_message=False)
     elif args.command == "completions":
         print(constants.completion_instructions)
         return ExitCode(0)

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -21,7 +21,7 @@ from pipx.animate import hide_cursor, show_cursor
 from pipx.colors import bold, green
 from pipx.constants import ExitCode
 from pipx.interpreter import DEFAULT_PYTHON
-from pipx.util import PipxError, mkdir, wrap
+from pipx.util import PipxError, mkdir, pipx_wrap
 from pipx.venv import VenvContainer
 from pipx.version import __version__
 
@@ -50,7 +50,7 @@ PIPX_DESCRIPTION = textwrap.dedent(
 
     """
 )
-PIPX_DESCRIPTION += wrap(
+PIPX_DESCRIPTION += pipx_wrap(
     """
     optional environment variables:
       PIPX_HOME             Overrides default pipx location. Virtual Environments will be installed to $PIPX_HOME/venvs.
@@ -253,7 +253,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
             return commands.ensure_pipx_paths(force=args.force)
         except Exception as e:
             logging.debug("Uncaught Exception:", exc_info=True)
-            raise PipxError(e)
+            raise PipxError(str(e), wrap=False)
     elif args.command == "completions":
         print(constants.completion_instructions)
         return ExitCode(0)
@@ -692,7 +692,7 @@ def setup(args: argparse.Namespace) -> None:
     old_pipx_venv_location = constants.PIPX_LOCAL_VENVS / "pipx-app"
     if old_pipx_venv_location.exists():
         logging.warning(
-            wrap(
+            pipx_wrap(
                 f"""
                 A virtual environment for pipx was detected at
                 {str(old_pipx_venv_location)}. The 'pipx-app' package has been

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -692,9 +692,15 @@ def setup(args: argparse.Namespace) -> None:
     old_pipx_venv_location = constants.PIPX_LOCAL_VENVS / "pipx-app"
     if old_pipx_venv_location.exists():
         logging.warning(
-            "A virtual environment for pipx was detected at "
-            f"{str(old_pipx_venv_location)}. The 'pipx-app' package has been renamed "
-            "back to 'pipx' (https://github.com/pipxproject/pipx/issues/82)."
+            wrap(
+                f"""
+                A virtual environment for pipx was detected at
+                {str(old_pipx_venv_location)}. The 'pipx-app' package has been
+                renamed back to 'pipx'
+                (https://github.com/pipxproject/pipx/issues/82).
+                """,
+                subsequent_indent=" " * 4,
+            )
         )
 
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -502,9 +502,9 @@ def _add_run(subparsers) -> None:
             since they can re-use the cached Virtual Environment.
 
             In support of PEP 582 'run' will use apps found in a local __pypackages__
-             directory, if present. Please note that this behavior is experimental,
-             and is a acts as a companion tool to pythonloc. It may be modified or
-             removed in the future. See https://github.com/cs01/pythonloc.
+            directory, if present. Please note that this behavior is experimental,
+            and acts as a companion tool to pythonloc. It may be modified or
+            removed in the future. See https://github.com/cs01/pythonloc.
             """
         ),
     )

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -7,7 +7,6 @@ import logging
 import os
 import re
 import shlex
-import shutil
 import sys
 import textwrap
 import time
@@ -22,7 +21,7 @@ from pipx.animate import hide_cursor, show_cursor
 from pipx.colors import bold, green
 from pipx.constants import ExitCode
 from pipx.interpreter import DEFAULT_PYTHON
-from pipx.util import PipxError, mkdir
+from pipx.util import PipxError, mkdir, wrap
 from pipx.venv import VenvContainer
 from pipx.version import __version__
 
@@ -31,22 +30,9 @@ def print_version() -> None:
     print(__version__)
 
 
-def indented_wrap(
-    text: str, subsequent_indent: str = "", split: str = "\n", **kwargs
-) -> str:
-    text = textwrap.dedent(text).strip()
-    minimum_width = 40
-    width = max(shutil.get_terminal_size((80, 40)).columns, minimum_width) - 2
-    return "\n".join(
-        [
-            textwrap.fill(line, width=width, subsequent_indent=subsequent_indent)
-            for line in text.splitlines()
-        ]
-    )
-
-
 SPEC_HELP = textwrap.dedent(
-    """The package name or specific installation source passed to pip.
+    """
+    The package name or specific installation source passed to pip.
     Runs `pip install -U SPEC`.
     For example `--spec mypackage==2.0.0` or `--spec  git+https://github.com/user/repo.git@branch`
     """
@@ -54,26 +40,28 @@ SPEC_HELP = textwrap.dedent(
 
 PIPX_DESCRIPTION = textwrap.dedent(
     f"""
-        Install and execute apps from Python packages.
+    Install and execute apps from Python packages.
 
-        Binaries can either be installed globally into isolated Virtual Environments
-        or run directly in an temporary Virtual Environment.
+    Binaries can either be installed globally into isolated Virtual Environments
+    or run directly in an temporary Virtual Environment.
 
-        Virtual Environment location is {str(constants.PIPX_LOCAL_VENVS)}.
-        Symlinks to apps are placed in {str(constants.LOCAL_BIN_DIR)}.
+    Virtual Environment location is {str(constants.PIPX_LOCAL_VENVS)}.
+    Symlinks to apps are placed in {str(constants.LOCAL_BIN_DIR)}.
 
-        """
+    """
 )
 PIPX_DESCRIPTION += "\n"
-PIPX_DESCRIPTION += indented_wrap(
+
+PIPX_DESCRIPTION += wrap(
     """
-        optional environment variables:
-          PIPX_HOME             Overrides default pipx location. Virtual Environments will be installed to $PIPX_HOME/venvs.
-          PIPX_BIN_DIR          Overrides location of app installations. Apps are symlinked or copied here.
-          USE_EMOJI             Overrides emoji behavior. Default value varies based on platform.
-          PIPX_DEFAULT_PYTHON   Overrides default python used for commands.
+    optional environment variables:
+      PIPX_HOME             Overrides default pipx location. Virtual Environments will be installed to $PIPX_HOME/venvs.
+      PIPX_BIN_DIR          Overrides location of app installations. Apps are symlinked or copied here.
+      USE_EMOJI             Overrides emoji behavior. Default value varies based on platform.
+      PIPX_DEFAULT_PYTHON   Overrides default python used for commands.
     """,
-    " " * 24,  # match the indent of argparse options
+    subsequent_indent=" " * 24,  # match the indent of argparse options
+    keep_newlines=True,
 )
 
 DOC_DEFAULT_PYTHON = os.getenv("PIPX__DOC_DEFAULT_PYTHON", DEFAULT_PYTHON)
@@ -435,12 +423,12 @@ def _add_reinstall(subparsers, venv_completer) -> None:
         help="Reinstall a package",
         description=textwrap.dedent(
             """
-        Reinstalls a package.
+            Reinstalls a package.
 
-        Package is uninstalled, then installed with pipx install PACKAGE
-        with the same options used in the original install of PACKAGE.
+            Package is uninstalled, then installed with pipx install PACKAGE
+            with the same options used in the original install of PACKAGE.
 
-        """
+            """
         ),
     )
     p.add_argument("package").completer = venv_completer
@@ -462,14 +450,14 @@ def _add_reinstall_all(subparsers) -> None:
         help="Reinstall all packages",
         description=textwrap.dedent(
             """
-        Reinstalls all packages.
+            Reinstalls all packages.
 
-        Packages are uninstalled, then installed with pipx install PACKAGE
-        with the same options used in the original install of PACKAGE.
-        This is useful if you upgraded to a new version of Python and want
-        all your packages to use the latest as well.
+            Packages are uninstalled, then installed with pipx install PACKAGE
+            with the same options used in the original install of PACKAGE.
+            This is useful if you upgraded to a new version of Python and want
+            all your packages to use the latest as well.
 
-        """
+            """
         ),
     )
     p.add_argument(
@@ -509,17 +497,17 @@ def _add_run(subparsers) -> None:
         ),
         description=textwrap.dedent(
             f"""
-        Download the latest version of a package to a temporary virtual environment,
-        then run an app from it. The environment will be cached
-        and re-used for up to {constants.TEMP_VENV_EXPIRATION_THRESHOLD_DAYS} days. This
-        means subsequent calls to 'run' for the same package will be faster
-        since they can re-use the cached Virtual Environment.
+            Download the latest version of a package to a temporary virtual environment,
+            then run an app from it. The environment will be cached
+            and re-used for up to {constants.TEMP_VENV_EXPIRATION_THRESHOLD_DAYS} days. This
+            means subsequent calls to 'run' for the same package will be faster
+            since they can re-use the cached Virtual Environment.
 
-        In support of PEP 582 'run' will use apps found in a local __pypackages__
-         directory, if present. Please note that this behavior is experimental,
-         and is a acts as a companion tool to pythonloc. It may be modified or
-         removed in the future. See https://github.com/cs01/pythonloc.
-        """
+            In support of PEP 582 'run' will use apps found in a local __pypackages__
+             directory, if present. Please note that this behavior is experimental,
+             and is a acts as a companion tool to pythonloc. It may be modified or
+             removed in the future. See https://github.com/cs01/pythonloc.
+            """
         ),
     )
     p.add_argument(

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -246,7 +246,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
         )
     elif args.command == "runpip":
         if not venv_dir:
-            raise PipxError("developer error: venv dir is not defined")
+            raise PipxError("Developer error: venv_dir is not defined.")
         return commands.run_pip(package, venv_dir, args.pipargs, args.verbose)
     elif args.command == "ensurepath":
         try:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -50,8 +50,6 @@ PIPX_DESCRIPTION = textwrap.dedent(
 
     """
 )
-PIPX_DESCRIPTION += "\n"
-
 PIPX_DESCRIPTION += wrap(
     """
     optional environment variables:

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -16,7 +16,7 @@ from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 
 from pipx.emojies import hazard
-from pipx.util import PipxError, wrap
+from pipx.util import PipxError, pipx_wrap
 
 
 class ParsedPackage(NamedTuple):
@@ -104,7 +104,7 @@ def _parsed_package_to_package_or_url(
     if parsed_package.valid_pep508 is not None:
         if parsed_package.valid_pep508.marker is not None:
             logging.warning(
-                wrap(
+                pipx_wrap(
                     f"""
                     {hazard}  Ignoring environment markers
                     ({parsed_package.valid_pep508.marker}) in package
@@ -143,7 +143,7 @@ def parse_specifier_for_install(
     )
     if "--editable" in pip_args and not parsed_package.valid_local_path:
         logging.warning(
-            wrap(
+            pipx_wrap(
                 f"""
                 {hazard}  Ignoring --editable install option. pipx disallows it
                 for anything but a local path, to avoid having to create a new
@@ -210,7 +210,7 @@ def fix_package_name(package_or_url: str, package: str) -> str:
 
     if canonicalize_name(package_req.name) != canonicalize_name(package):
         logging.warning(
-            wrap(
+            pipx_wrap(
                 f"""
                 {hazard}  Name supplied in package specifier was
                 {package_req.name!r} but package found has name {package!r}.

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -27,8 +27,7 @@ class ParsedPackage(NamedTuple):
 
 
 def _split_path_extras(package_spec: str) -> Tuple[str, str]:
-    """Returns (path, extras_string)
-    """
+    """Returns (path, extras_string)"""
     package_spec_extras_re = re.search(r"(.+)(\[.+\])", package_spec)
     if package_spec_extras_re:
         return (package_spec_extras_re.group(1), package_spec_extras_re.group(2))
@@ -37,8 +36,7 @@ def _split_path_extras(package_spec: str) -> Tuple[str, str]:
 
 
 def _parse_specifier(package_spec: str) -> ParsedPackage:
-    """Parse package_spec as would be given to pipx
-    """
+    """Parse package_spec as would be given to pipx"""
     # If package_spec is valid pypi name, pip will always treat it as a
     #       pypi package, not checking for local path.
     #       We replicate pypi precedence here (only non-valid-pypi names
@@ -212,7 +210,7 @@ def fix_package_name(package_or_url: str, package: str) -> str:
             textwrap.fill(
                 f"{hazard}  Name supplied in package specifier was "
                 f"{package_req.name!r} but package found has name "
-                f"{package!r}.  Using {package!r}.",
+                f"{package!r}. Using {package!r}.",
                 subsequent_indent="    ",
             )
         )

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -8,7 +8,6 @@
 
 import logging
 import re
-import textwrap
 from pathlib import Path
 from typing import List, NamedTuple, Optional, Tuple
 
@@ -17,7 +16,7 @@ from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 
 from pipx.emojies import hazard
-from pipx.util import PipxError
+from pipx.util import PipxError, wrap
 
 
 class ParsedPackage(NamedTuple):
@@ -105,11 +104,13 @@ def _parsed_package_to_package_or_url(
     if parsed_package.valid_pep508 is not None:
         if parsed_package.valid_pep508.marker is not None:
             logging.warning(
-                textwrap.fill(
-                    f"{hazard}  Ignoring environment markers "
-                    f"({parsed_package.valid_pep508.marker}) in package "
-                    "specification. Use pipx options to specify this type of "
-                    "information.",
+                wrap(
+                    f"""
+                    {hazard}  Ignoring environment markers
+                    ({parsed_package.valid_pep508.marker}) in package
+                    specification. Use pipx options to specify this type of
+                    information.
+                    """,
                     subsequent_indent=" " * 4,
                 )
             )
@@ -142,10 +143,12 @@ def parse_specifier_for_install(
     )
     if "--editable" in pip_args and not parsed_package.valid_local_path:
         logging.warning(
-            textwrap.fill(
-                f"{hazard}  Ignoring --editable install option. pipx disallows it "
-                "for anything but a local path, to avoid having to create a new "
-                "src/ directory.",
+            wrap(
+                f"""
+                {hazard}  Ignoring --editable install option. pipx disallows it
+                for anything but a local path, to avoid having to create a new
+                src/ directory.
+                """,
                 subsequent_indent=" " * 4,
             )
         )
@@ -207,10 +210,12 @@ def fix_package_name(package_or_url: str, package: str) -> str:
 
     if canonicalize_name(package_req.name) != canonicalize_name(package):
         logging.warning(
-            textwrap.fill(
-                f"{hazard}  Name supplied in package specifier was "
-                f"{package_req.name!r} but package found has name "
-                f"{package!r}. Using {package!r}.",
+            wrap(
+                f"""
+                {hazard}  Name supplied in package specifier was
+                {package_req.name!r} but package found has name {package!r}.
+                Using {package!r}.
+                """,
                 subsequent_indent=" " * 4,
             )
         )

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -110,7 +110,7 @@ def _parsed_package_to_package_or_url(
                     f"({parsed_package.valid_pep508.marker}) in package "
                     "specification. Use pipx options to specify this type of "
                     "information.",
-                    subsequent_indent="    ",
+                    subsequent_indent=" " * 4,
                 )
             )
         package_or_url = package_or_url_from_pep508(
@@ -146,7 +146,7 @@ def parse_specifier_for_install(
                 f"{hazard}  Ignoring --editable install option. pipx disallows it "
                 "for anything but a local path, to avoid having to create a new "
                 "src/ directory.",
-                subsequent_indent="    ",
+                subsequent_indent=" " * 4,
             )
         )
         pip_args.remove("--editable")
@@ -211,7 +211,7 @@ def fix_package_name(package_or_url: str, package: str) -> str:
                 f"{hazard}  Name supplied in package specifier was "
                 f"{package_req.name!r} but package found has name "
                 f"{package!r}. Using {package!r}.",
-                subsequent_indent="    ",
+                subsequent_indent=" " * 4,
             )
         )
     package_req.name = package

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
+from pipx.emojies import hazard
 from pipx.util import PipxError, pipx_wrap
 
 PIPX_INFO_FILENAME = "pipx_metadata.json"
@@ -131,9 +132,10 @@ class PipxMetadata:
             logging.warning(
                 pipx_wrap(
                     f"""
-                    Unable to write {PIPX_INFO_FILENAME} to {self.venv_dir}.
-                    This may cause future pipx operations involving
-                    {self.venv_dir.name} to fail or behave incorrectly.
+                    {hazard}  Unable to write {PIPX_INFO_FILENAME} to
+                    {self.venv_dir}.  This may cause future pipx operations
+                    involving {self.venv_dir.name} to fail or behave
+                    incorrectly.
                     """,
                     subsequent_indent=" " * 4,
                 )
@@ -150,9 +152,10 @@ class PipxMetadata:
                 logging.warning(
                     pipx_wrap(
                         f"""
-                        Unable to read {PIPX_INFO_FILENAME} in {self.venv_dir}.
-                        This may cause this or future pipx operations involving
-                        {self.venv_dir.name} to fail or behave incorrectly.
+                        {hazard}  Unable to read {PIPX_INFO_FILENAME} in
+                        {self.venv_dir}.  This may cause this or future pipx
+                        operations involving {self.venv_dir.name} to fail or
+                        behave incorrectly.
                         """,
                         subsequent_indent=" " * 4,
                     )

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -93,7 +93,7 @@ class PipxMetadata:
                 wrap(
                     f"""
                     {self.venv_dir.name}: Unknown metadata version
-                    {metadata_dict['pipx_metadata_version']}.  Perhaps it was
+                    {metadata_dict['pipx_metadata_version']}. Perhaps it was
                     installed with a later version of pipx.
                     """
                 )

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import textwrap
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
@@ -132,11 +131,13 @@ class PipxMetadata:
                 )
         except IOError:
             logging.warning(
-                textwrap.fill(
-                    f"Unable to write {PIPX_INFO_FILENAME} to {self.venv_dir}. "
-                    f"This may cause future pipx operations involving "
-                    f"{self.venv_dir.name} to fail or behave incorrectly.",
-                    width=79,
+                wrap(
+                    f"""
+                    Unable to write {PIPX_INFO_FILENAME} to {self.venv_dir}.
+                    This may cause future pipx operations involving
+                    {self.venv_dir.name} to fail or behave incorrectly.
+                    """,
+                    subsequent_indent=" " * 4,
                 )
             )
 
@@ -149,11 +150,13 @@ class PipxMetadata:
         except IOError:  # Reset self if problem reading
             if verbose:
                 logging.warning(
-                    textwrap.fill(
-                        f"Unable to read {PIPX_INFO_FILENAME} in {self.venv_dir}. "
-                        f"This may cause this or future pipx operations involving "
-                        f"{self.venv_dir.name} to fail or behave incorrectly.",
-                        width=79,
+                    wrap(
+                        f"""
+                        Unable to read {PIPX_INFO_FILENAME} in {self.venv_dir}.
+                        This may cause this or future pipx operations involving
+                        {self.venv_dir.name} to fail or behave incorrectly.
+                        """,
+                        subsequent_indent=" " * 4,
                     )
                 )
             return

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
-from pipx.util import PipxError, wrap
+from pipx.util import PipxError, pipx_wrap
 
 PIPX_INFO_FILENAME = "pipx_metadata.json"
 
@@ -90,13 +90,11 @@ class PipxMetadata:
             return metadata_dict
         else:
             raise PipxError(
-                wrap(
-                    f"""
-                    {self.venv_dir.name}: Unknown metadata version
-                    {metadata_dict['pipx_metadata_version']}. Perhaps it was
-                    installed with a later version of pipx.
-                    """
-                )
+                f"""
+                {self.venv_dir.name}: Unknown metadata version
+                {metadata_dict['pipx_metadata_version']}. Perhaps it was
+                installed with a later version of pipx.
+                """
             )
 
     def from_dict(self, input_dict: Dict[str, Any]) -> None:
@@ -131,7 +129,7 @@ class PipxMetadata:
                 )
         except IOError:
             logging.warning(
-                wrap(
+                pipx_wrap(
                     f"""
                     Unable to write {PIPX_INFO_FILENAME} to {self.venv_dir}.
                     This may cause future pipx operations involving
@@ -150,7 +148,7 @@ class PipxMetadata:
         except IOError:  # Reset self if problem reading
             if verbose:
                 logging.warning(
-                    wrap(
+                    pipx_wrap(
                         f"""
                         Unable to read {PIPX_INFO_FILENAME} in {self.venv_dir}.
                         This may cause this or future pipx operations involving

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -4,7 +4,7 @@ import textwrap
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
-from pipx.util import PipxError
+from pipx.util import PipxError, wrap
 
 PIPX_INFO_FILENAME = "pipx_metadata.json"
 
@@ -91,9 +91,13 @@ class PipxMetadata:
             return metadata_dict
         else:
             raise PipxError(
-                f"{self.venv_dir.name}: Unknown metadata version "
-                f"{metadata_dict['pipx_metadata_version']}. "
-                "Perhaps it was installed with a later version of pipx."
+                wrap(
+                    f"""
+                    {self.venv_dir.name}: Unknown metadata version
+                    {metadata_dict['pipx_metadata_version']}.  Perhaps it was
+                    installed with a later version of pipx.
+                    """
+                )
             )
 
     def from_dict(self, input_dict: Dict[str, Any]) -> None:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -12,7 +12,11 @@ from pipx.constants import WINDOWS
 
 
 class PipxError(Exception):
-    pass
+    def __init__(self, message: str, wrap: bool = True):
+        if wrap:
+            super().__init__(pipx_wrap(message))
+        else:
+            super().__init__(message)
 
 
 def rmdir(path: Path) -> None:
@@ -178,7 +182,9 @@ def full_package_description(package: str, package_spec: str) -> str:
 # Errors are a single block of text and can have no subsequent_indent
 # Other blocks of text should get 4 spaces as subsequent_indent to
 #   differentiate them from previous and subsequent blocks of text
-def wrap(text: str, subsequent_indent: str = "", keep_newlines: bool = False) -> str:
+def pipx_wrap(
+    text: str, subsequent_indent: str = "", keep_newlines: bool = False
+) -> str:
     """Dedent, strip, wrap to shell width. Don't break on hyphens, only spaces"""
     minimum_width = 40
     width = max(shutil.get_terminal_size((80, 40)).columns, minimum_width) - 2

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
@@ -172,3 +173,21 @@ def full_package_description(package: str, package_spec: str) -> str:
         return package
     else:
         return f"{package} from spec {package_spec!r}"
+
+
+def wrap(
+    text: str, subsequent_indent: str = "    ", keep_newlines: bool = False
+) -> str:
+    minimum_width = 40
+    width = max(shutil.get_terminal_size((80, 40)).columns, minimum_width) - 2
+
+    text = textwrap.dedent(text).strip()
+    if keep_newlines:
+        return "\n".join(
+            [
+                textwrap.fill(line, width=width, subsequent_indent=subsequent_indent)
+                for line in text.splitlines()
+            ]
+        )
+    else:
+        return textwrap.fill(text, width=width, subsequent_indent=subsequent_indent)

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -178,10 +178,8 @@ def full_package_description(package: str, package_spec: str) -> str:
 # Errors are a single block of text and can have no subsequent_indent
 # Other blocks of text should get 4 spaces as subsequent_indent to
 #   differentiate them from previous and subsequent blocks of text
-def wrap(
-    text: str, subsequent_indent: str = "    ", keep_newlines: bool = False
-) -> str:
-    """Dedent, strip, wrap to shell width, default subsequent indent of 4 spaces"""
+def wrap(text: str, subsequent_indent: str = "", keep_newlines: bool = False) -> str:
+    """Dedent, strip, wrap to shell width"""
     minimum_width = 40
     width = max(shutil.get_terminal_size((80, 40)).columns, minimum_width) - 2
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -175,6 +175,9 @@ def full_package_description(package: str, package_spec: str) -> str:
         return f"{package} from spec {package_spec!r}"
 
 
+# Errors are a single block of text and can have no subsequent_indent
+# Other blocks of text should get 4 spaces as subsequent_indent to
+#   differentiate them from previous and subsequent blocks of text
 def wrap(
     text: str, subsequent_indent: str = "    ", keep_newlines: bool = False
 ) -> str:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -179,7 +179,7 @@ def full_package_description(package: str, package_spec: str) -> str:
 # Other blocks of text should get 4 spaces as subsequent_indent to
 #   differentiate them from previous and subsequent blocks of text
 def wrap(text: str, subsequent_indent: str = "", keep_newlines: bool = False) -> str:
-    """Dedent, strip, wrap to shell width.  Don't break on hyphens, only spaces"""
+    """Dedent, strip, wrap to shell width. Don't break on hyphens, only spaces"""
     minimum_width = 40
     width = max(shutil.get_terminal_size((80, 40)).columns, minimum_width) - 2
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -12,8 +12,8 @@ from pipx.constants import WINDOWS
 
 
 class PipxError(Exception):
-    def __init__(self, message: str, wrap: bool = True):
-        if wrap:
+    def __init__(self, message: str, wrap_message: bool = True):
+        if wrap_message:
             super().__init__(pipx_wrap(message))
         else:
             super().__init__(message)

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -179,7 +179,7 @@ def full_package_description(package: str, package_spec: str) -> str:
 # Other blocks of text should get 4 spaces as subsequent_indent to
 #   differentiate them from previous and subsequent blocks of text
 def wrap(text: str, subsequent_indent: str = "", keep_newlines: bool = False) -> str:
-    """Dedent, strip, wrap to shell width"""
+    """Dedent, strip, wrap to shell width.  Don't break on hyphens, only spaces"""
     minimum_width = 40
     width = max(shutil.get_terminal_size((80, 40)).columns, minimum_width) - 2
 
@@ -187,9 +187,19 @@ def wrap(text: str, subsequent_indent: str = "", keep_newlines: bool = False) ->
     if keep_newlines:
         return "\n".join(
             [
-                textwrap.fill(line, width=width, subsequent_indent=subsequent_indent)
+                textwrap.fill(
+                    line,
+                    width=width,
+                    subsequent_indent=subsequent_indent,
+                    break_on_hyphens=False,
+                )
                 for line in text.splitlines()
             ]
         )
     else:
-        return textwrap.fill(text, width=width, subsequent_indent=subsequent_indent)
+        return textwrap.fill(
+            text,
+            width=width,
+            subsequent_indent=subsequent_indent,
+            break_on_hyphens=False,
+        )

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -178,6 +178,7 @@ def full_package_description(package: str, package_spec: str) -> str:
 def wrap(
     text: str, subsequent_indent: str = "    ", keep_newlines: bool = False
 ) -> str:
+    """Dedent, strip, wrap to shell width, default subsequent indent of 4 spaces"""
     minimum_width = 40
     width = max(shutil.get_terminal_size((80, 40)).columns, minimum_width) - 2
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -179,9 +179,6 @@ def full_package_description(package: str, package_spec: str) -> str:
         return f"{package} from spec {package_spec!r}"
 
 
-# Errors are a single block of text and can have no subsequent_indent
-# Other blocks of text should get 4 spaces as subsequent_indent to
-#   differentiate them from previous and subsequent blocks of text
 def pipx_wrap(
     text: str, subsequent_indent: str = "", keep_newlines: bool = False
 ) -> str:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -110,7 +110,7 @@ class Venv:
                         """
                     )
                     + f"\n  pipx install {self.root.name} --force",
-                    wrap=False,
+                    wrap_message=False,
                 )
 
     @property
@@ -247,7 +247,7 @@ class Venv:
                 f"{full_package_description(package, package_or_url)}.\n"
                 f"Check the name or spec for errors, and verify that it can "
                 f"be installed with pip.",
-                wrap=False,
+                wrap_message=False,
             )
 
     def install_package_no_deps(self, package_or_url: str, pip_args: List[str]) -> str:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -177,8 +177,13 @@ class Venv:
             rmdir(self.root)
         else:
             logging.warning(
-                f"Not removing existing venv {self.root} because "
-                "it was not created in this session"
+                wrap(
+                    f"""
+                    Not removing existing venv {self.root} because it was not
+                    created in this session
+                    """,
+                    subsequent_indent=" " * 4,
+                )
             )
 
     def upgrade_packaging_libraries(self, pip_args: List[str]) -> None:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -22,10 +22,10 @@ from pipx.util import (
     full_package_description,
     get_site_packages,
     get_venv_paths,
+    pipx_wrap,
     rmdir,
     run_subprocess,
     run_verify,
-    wrap,
 )
 
 venv_metadata_inspector_raw = pkgutil.get_data("pipx", "venv_metadata_inspector.py")
@@ -101,14 +101,15 @@ class Venv:
 
             if not shared_libs.is_valid:
                 raise PipxError(
-                    wrap(
+                    pipx_wrap(
                         f"""
                         Error: pipx's shared venv {shared_libs.root} is invalid
                         and needs re-installation. To fix this, install or
                         reinstall a package. For example:
                         """
                     )
-                    + f"\n  pipx install {self.root.name} --force"
+                    + f"\n  pipx install {self.root.name} --force",
+                    wrap=False,
                 )
 
     @property
@@ -177,7 +178,7 @@ class Venv:
             rmdir(self.root)
         else:
             logging.warning(
-                wrap(
+                pipx_wrap(
                     f"""
                     Not removing existing venv {self.root} because it was not
                     created in this session
@@ -225,8 +226,7 @@ class Venv:
         except PipxError as e:
             logging.info(e)
             raise PipxError(
-                f"Error installing "
-                f"{full_package_description(package, package_or_url)}."
+                f"Error installing {full_package_description(package, package_or_url)}."
             )
 
         self._update_package_metadata(
@@ -245,7 +245,8 @@ class Venv:
                 f"Unable to install "
                 f"{full_package_description(package, package_or_url)}.\n"
                 f"Check the name or spec for errors, and verify that it can "
-                f"be installed with pip."
+                f"be installed with pip.",
+                wrap=False,
             )
 
     def install_package_no_deps(self, package_or_url: str, pip_args: List[str]) -> str:
@@ -259,12 +260,10 @@ class Venv:
         except PipxError as e:
             logging.info(e)
             raise PipxError(
-                wrap(
-                    f"""
-                    Cannot determine package name from spec {package_or_url!r}.
-                    Check package spec for errors.
-                    """
-                )
+                f"""
+                Cannot determine package name from spec {package_or_url!r}.
+                Check package spec for errors.
+                """
             )
 
         installed_packages = self.list_installed_packages() - old_package_set
@@ -275,12 +274,10 @@ class Venv:
             logging.info(f"old_package_set = {old_package_set}")
             logging.info(f"install_packages = {installed_packages}")
             raise PipxError(
-                wrap(
-                    f"""
-                    Cannot determine package name from spec {package_or_url!r}.
-                    Check package spec for errors.
-                    """
-                )
+                f"""
+                Cannot determine package name from spec {package_or_url!r}.
+                Check package spec for errors.
+                """
             )
 
         return package

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -25,6 +25,7 @@ from pipx.util import (
     rmdir,
     run_subprocess,
     run_verify,
+    wrap,
 )
 
 venv_metadata_inspector_raw = pkgutil.get_data("pipx", "venv_metadata_inspector.py")
@@ -100,10 +101,14 @@ class Venv:
 
             if not shared_libs.is_valid:
                 raise PipxError(
-                    f"Error: pipx's shared venv {shared_libs.root} is invalid and "
-                    "needs re-installation. To fix this, install or reinstall a "
-                    "package. For example,\n"
-                    f"  pipx install {self.root.name} --force"
+                    wrap(
+                        f"""
+                        Error: pipx's shared venv {shared_libs.root} is invalid
+                        and needs re-installation. To fix this, install or
+                        reinstall a package. For example:
+                        """
+                    )
+                    + f"\n  pipx install {self.root.name} --force"
                 )
 
     @property
@@ -249,8 +254,12 @@ class Venv:
         except PipxError as e:
             logging.info(e)
             raise PipxError(
-                f"Cannot determine package name from spec {package_or_url!r}. "
-                f"Check package spec for errors."
+                wrap(
+                    f"""
+                    Cannot determine package name from spec {package_or_url!r}.
+                    Check package spec for errors.
+                    """
+                )
             )
 
         installed_packages = self.list_installed_packages() - old_package_set
@@ -261,8 +270,12 @@ class Venv:
             logging.info(f"old_package_set = {old_package_set}")
             logging.info(f"install_packages = {installed_packages}")
             raise PipxError(
-                f"Cannot determine package name from spec {package_or_url!r}. "
-                f"Check package spec for errors."
+                wrap(
+                    f"""
+                    Cannot determine package name from spec {package_or_url!r}.
+                    Check package spec for errors.
+                    """
+                )
             )
 
         return package

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -8,6 +8,7 @@ from packaging.utils import canonicalize_name
 
 from pipx.animate import animate
 from pipx.constants import PIPX_SHARED_PTH, ExitCode
+from pipx.emojies import hazard
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.package_specifier import (
     fix_package_name,
@@ -180,8 +181,8 @@ class Venv:
             logging.warning(
                 pipx_wrap(
                     f"""
-                    Not removing existing venv {self.root} because it was not
-                    created in this session
+                    {hazard}  Not removing existing venv {self.root} because it
+                    was not created in this session
                     """,
                     subsequent_indent=" " * 4,
                 )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -64,8 +64,7 @@ def unwrap_log_text(log_text: str):
     with any spaces assume it is due to an indented pipx wrapped message.
     """
 
-    log_text = re.sub(r"([^-])\n\s+", r"\1 ", log_text)
-    log_text = re.sub(r"(-)\n\s+", r"\1", log_text)
+    return re.sub(r"\n\s+", " ", log_text)
     return log_text
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -54,6 +55,18 @@ def which_python(python_exe: str) -> Optional[str]:
     else:
         # pyenv on system, but pyenv has no path to python_exe
         return None
+
+
+def unwrap_log_text(log_text: str):
+    """Remove line-break + indent space from log messages
+
+    Captured log lines always start with the 'severity' so if a line starts
+    with any spaces assume it is due to an indented pipx wrapped message.
+    """
+
+    log_text = re.sub(r"([^-])\n\s+", r"\1 ", log_text)
+    log_text = re.sub(r"(-)\n\s+", r"\1", log_text)
+    return log_text
 
 
 def _mock_legacy_package_info(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -65,7 +65,6 @@ def unwrap_log_text(log_text: str):
     """
 
     return re.sub(r"\n\s+", " ", log_text)
-    return log_text
 
 
 def _mock_legacy_package_info(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest  # type: ignore
 
-from helpers import run_pipx_cli, which_python
+from helpers import run_pipx_cli, unwrap_log_text, which_python
 from pipx import constants
 
 PYTHON3_5 = which_python("python3.5")
@@ -114,11 +114,13 @@ def test_include_deps(pipx_temp_env, capsys):
 
 def test_path_warning(pipx_temp_env, capsys, monkeypatch, caplog):
     assert not run_pipx_cli(["install", "pycowsay"])
-    assert "is not on your PATH environment variable" not in caplog.text
+    assert "is not on your PATH environment variable" not in unwrap_log_text(
+        caplog.text
+    )
 
     monkeypatch.setenv("PATH", "")
     assert not run_pipx_cli(["install", "pycowsay", "--force"])
-    assert "is not on your PATH environment variable" in caplog.text
+    assert "is not on your PATH environment variable" in unwrap_log_text(caplog.text)
 
 
 def test_existing_symlink_points_to_existing_wrong_location_warning(
@@ -131,14 +133,14 @@ def test_existing_symlink_points_to_existing_wrong_location_warning(
     (constants.LOCAL_BIN_DIR / "pycowsay").symlink_to(os.devnull)
     assert not run_pipx_cli(["install", "pycowsay"])
     captured = capsys.readouterr()
-    assert "File exists at" in caplog.text
+    assert "File exists at" in unwrap_log_text(caplog.text)
     assert "symlink missing or pointing to unexpected location" in captured.out
     # bin dir was on path, so the warning should NOT appear (even though the symlink
     # pointed to the wrong location)
     assert "is not on your PATH environment variable" not in captured.err
 
 
-def test_existing_symlink_points_to_nothing(pipx_temp_env, caplog, capsys):
+def test_existing_symlink_points_to_nothing(pipx_temp_env, capsys):
     if sys.platform.startswith("win"):
         pytest.skip("pipx does not use symlinks on Windows")
 
@@ -158,9 +160,7 @@ def test_install_python3_5(pipx_temp_env):
         pytest.skip("python3.5 not on PATH")
 
 
-def test_pip_args_forwarded_to_package_name_determination(
-    pipx_temp_env, caplog, capsys
-):
+def test_pip_args_forwarded_to_package_name_determination(pipx_temp_env, capsys):
     assert run_pipx_cli(
         [
             "install",

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -17,7 +17,6 @@ def test_upgrade_legacy_venv(pipx_temp_env, capsys, metadata_version):
     if metadata_version is None:
         assert run_pipx_cli(["upgrade", "pycowsay"])
         captured = capsys.readouterr()
-        print(captured.err)
         assert (
             "Not upgrading pycowsay. It has missing internal pipx metadata."
             in captured.err

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -17,8 +17,9 @@ def test_upgrade_legacy_venv(pipx_temp_env, capsys, metadata_version):
     if metadata_version is None:
         assert run_pipx_cli(["upgrade", "pycowsay"])
         captured = capsys.readouterr()
+        print(captured.err)
         assert (
-            "Not upgrading pycowsay.  It has missing internal pipx metadata."
+            "Not upgrading pycowsay. It has missing internal pipx metadata."
             in captured.err
         )
     else:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Added function `pipx_wrap` basically taken from what was `indented_wrap` from main.py.  This function:
* gets the current terminal window width if possible to use for word-wrapping
* dedents input message
* strips linefeeds of input message (So triple quotes can start with `"""` and not `"""\`)
* does a `textwrap.fill()` which word-wraps ONLY on spaces, and not on hyphens (to not break in the middle of a file path)
* takes argument `subsequent_indent` to allow control of the indent of lines after first line
* takes argument `keep_newlines` to allow wrapping every newline-terminated line separately

`PipxError` Exception now uses `pipx_wrap` to wrap the message supplied to it by default, unless optional argument `message_wrap=False`.  It uses no `subsequent_indent` since there should be no text following an error.

I unified the formatting of `logging.warning`s to always use the `{hazard}` emoji (some were missing) and to use `pipx_wrap` with `subsequent_indent=" " * 4` to allow the wrapped warning to stand apart from further text.

I went through all of the `PipxError`s and `logging.warning`s in the code to unify the code formatting of the messages, taking advantage of the auto-wrapped `PipxError` and `pipx_wrap`.

I refined some of the code formatting for our `main.py` help text, and verified that `pipx --help` looks the same as it did before.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
