### PR TITLE
Fix tests on Windows by using `python -m install --upgrade pip`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -80,7 +80,7 @@ def on_master_no_changes(session):
 
 @nox.session(python=PYTHON_ALL_VERSIONS)
 def tests(session):
-    session.install("--upgrade", "pip")
+    session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     prebuild_wheels(session, PREBUILD_PACKAGES)
     session.install("-e", ".", "pytest", "pytest-cov")
     tests = session.posargs or ["tests"]
@@ -91,7 +91,7 @@ def tests(session):
 @nox.session
 def cover(session):
     """Coverage analysis"""
-    session.install("--upgrade", "pip")
+    session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     session.install("coverage")
     session.run("coverage", "report", "--show-missing", "--fail-under=70")
     session.run("coverage", "erase")
@@ -99,7 +99,7 @@ def cover(session):
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def lint(session):
-    session.install("--upgrade", "pip")
+    session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     session.install(*LINT_DEPENDENCIES)
     files = [str(Path("src") / "pipx"), "tests", "scripts"] + [
         str(p) for p in Path(".").glob("*.py")
@@ -114,14 +114,14 @@ def lint(session):
 
 @nox.session(python=PYTHON_ALL_VERSIONS)
 def develop(session):
-    session.install("--upgrade", "pip")
+    session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     session.install(*DOC_DEPENDENCIES, *LINT_DEPENDENCIES)
     session.install("-e", ".")
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def build(session):
-    session.install("--upgrade", "pip")
+    session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     session.install("build")
     session.run("rm", "-rf", "dist", "build", external=True)
     session.run("python", "-m", "build")
@@ -130,7 +130,7 @@ def build(session):
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def publish(session):
     on_master_no_changes(session)
-    session.install("--upgrade", "pip")
+    session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     session.install("twine")
     build(session)
     print("REMINDER: Has the changelog been updated?")
@@ -139,7 +139,7 @@ def publish(session):
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def build_docs(session):
-    session.install("--upgrade", "pip")
+    session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     session.install(*DOC_DEPENDENCIES)
     session.env[
         "PIPX__DOC_DEFAULT_PYTHON"
@@ -150,7 +150,7 @@ def build_docs(session):
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def publish_docs(session):
-    session.install("--upgrade", "pip")
+    session.run("python", "-m", "pip", "install", "--upgrade", "pip")
     session.install(*DOC_DEPENDENCIES)
     build_docs(session)
     session.run("mkdocs", "gh-deploy")


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Somehow just now (?) Windows tests broke because we are using `pip install --upgrade pip`.  Windows can't upgrade an in-use pip which is open.

Switched to the better form `python -m install --upgrade pip`.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
