### PR TITLE
Remove deprecated --use-feature=2020-resolver because of new pip.

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -25,10 +25,7 @@ def install_package(capsys, pipx_temp_env, caplog, package, package_name=""):
     if not package_name:
         package_name = package
 
-    # TODO: remove "--feature=2020-resolver" when pip 20.3 is released
-    run_pipx_cli(
-        ["install", package, "--verbose", "--pip-args='--use-feature=2020-resolver'"]
-    )
+    run_pipx_cli(["install", package, "--verbose"])
     captured = capsys.readouterr()
     assert f"installed package {package_name}" in captured.out
     if not sys.platform.startswith("win"):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -148,17 +148,8 @@ def test_package_determination(
 
     caplog.set_level(logging.INFO)
 
-    # TODO: remove "--feature=2020-resolver" when pip 20.3 is released
     run_pipx_cli_exit(
-        [
-            "run",
-            "--verbose",
-            "--pip-args='--use-feature=2020-resolver'",
-            "--spec",
-            package_or_url,
-            "--",
-        ]
-        + app_appargs
+        ["run", "--verbose", "--spec", package_or_url, "--"] + app_appargs
     )
 
     assert "Cannot determine package name" not in caplog.text

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -10,15 +10,7 @@ def test_uninstall(pipx_temp_env, capsys):
 
 
 def test_uninstall_multiple_same_app(pipx_temp_env, capsys):
-    # TODO: remove --pip-args when 2020-resolver is default in new pip
-    assert not run_pipx_cli(
-        [
-            "install",
-            "kaggle==1.5.9",
-            "--include-deps",
-            "--pip-args='--use-feature=2020-resolver'",
-        ]
-    )
+    assert not run_pipx_cli(["install", "kaggle==1.5.9", "--include-deps"])
     assert not run_pipx_cli(["uninstall", "kaggle"])
 
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Now that pip is at version > 20.3, we no longer need `--use-feature=2020-resolver` and in addition it is deprecated.

This PR removes it from our tests.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
