### PR TITLE
Fix and improve logging

### DIFF
--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -20,6 +20,8 @@ from pipx.pipx_metadata_file import PackageInfo
 from pipx.util import WINDOWS, PipxError, mkdir, rmdir
 from pipx.venv import Venv
 
+logger = logging.getLogger(__name__)
+
 
 class VenvProblems:
     def __init__(
@@ -89,7 +91,7 @@ def _copy_package_apps(
         if not dest.parent.is_dir():
             mkdir(dest.parent)
         if dest.exists():
-            logging.warning(f"{hazard}  Overwriting file {str(dest)} with {str(src)}")
+            logger.warning(f"{hazard}  Overwriting file {str(dest)} with {str(src)}")
             dest.unlink()
         if src.exists():
             shutil.copy(src, dest)
@@ -106,7 +108,7 @@ def _symlink_package_apps(
             mkdir(symlink_path.parent)
 
         if force:
-            logging.info(f"Force is true. Removing {str(symlink_path)}.")
+            logger.info(f"Force is true. Removing {str(symlink_path)}.")
             try:
                 symlink_path.unlink()
             except FileNotFoundError:
@@ -118,15 +120,15 @@ def _symlink_package_apps(
         is_symlink = symlink_path.is_symlink()
         if exists:
             if symlink_path.samefile(app_path):
-                logging.info(f"Same path {str(symlink_path)} and {str(app_path)}")
+                logger.info(f"Same path {str(symlink_path)} and {str(app_path)}")
             else:
-                logging.warning(
+                logger.warning(
                     f"{hazard}  File exists at {str(symlink_path)} and points "
                     f"to {symlink_path.resolve()}, not {str(app_path)}. Not modifying."
                 )
             continue
         if is_symlink and not exists:
-            logging.info(
+            logger.info(
                 f"Removing existing symlink {str(symlink_path)} since it "
                 "pointed non-existent location"
             )
@@ -136,7 +138,7 @@ def _symlink_package_apps(
         symlink_path.symlink_to(app_path)
 
         if existing_executable_on_path:
-            logging.warning(
+            logger.warning(
                 f"{hazard}  Note: {app_name_suffixed} was already on your PATH at "
                 f"{existing_executable_on_path}"
             )
@@ -283,8 +285,8 @@ def package_name_from_spec(
         # NOTE: if pypi name and installed package name differ, this means pipx
         #       will use the pypi name
         package_name = pypi_name
-        logging.info(f"Determined package name: {package_name}")
-        logging.info(f"Package name determined in {time.time()-start_time:.1f}s")
+        logger.info(f"Determined package name: {package_name}")
+        logger.info(f"Package name determined in {time.time()-start_time:.1f}s")
         return package_name
 
     # check syntax and clean up spec and pip_args
@@ -297,7 +299,7 @@ def package_name_from_spec(
             package_or_url=package_spec, pip_args=pip_args
         )
 
-    logging.info(f"Package name determined in {time.time()-start_time:.1f}s")
+    logger.info(f"Package name determined in {time.time()-start_time:.1f}s")
     return package_name
 
 
@@ -380,7 +382,7 @@ def run_post_install_actions(
 
 def warn_if_not_on_path(local_bin_dir: Path) -> None:
     if not userpath.in_current_path(str(local_bin_dir)):
-        logging.warning(
+        logger.warning(
             f"{hazard}  Note: {str(local_bin_dir)!r} is not on your PATH environment "
             "variable. These apps will not be globally accessible until "
             "your PATH is updated. Run `pipx ensurepath` to "

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -11,6 +11,8 @@ from pipx import constants
 from pipx.constants import EXIT_CODE_OK, ExitCode
 from pipx.emojies import stars
 
+logger = logging.getLogger(__name__)
+
 
 def get_pipx_user_bin_path() -> Optional[Path]:
     """Returns None if pipx is not installed using `pip --user`
@@ -116,7 +118,7 @@ def ensure_pipx_paths(force: bool) -> ExitCode:
         )
     elif not need_shell_restart:
         sys.stdout.flush()
-        logging.warning(
+        logger.warning(
             textwrap.fill(
                 "All pipx binary directories have been added to PATH. "
                 "If you are sure you want to proceed, try again with "

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -14,6 +14,8 @@ from pipx.emojies import hazard, sleep, stars
 from pipx.util import WINDOWS, rmdir
 from pipx.venv import Venv, VenvContainer
 
+logger = logging.getLogger(__name__)
+
 
 def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
     """Uninstall entire venv_dir, including main package and all injected
@@ -72,7 +74,7 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
             symlink = filepath
             for b in app_paths:
                 if symlink.exists() and b.exists() and symlink.samefile(b):
-                    logging.info(f"removing symlink {str(symlink)}")
+                    logger.info(f"removing symlink {str(symlink)}")
                     symlink.unlink()
 
     rmdir(venv_dir)

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -11,6 +11,8 @@ from pipx.package_specifier import parse_specifier_for_upgrade
 from pipx.util import PipxError
 from pipx.venv import Venv, VenvContainer
 
+logger = logging.getLogger(__name__)
+
 
 def _upgrade_package(
     venv: Venv,
@@ -187,8 +189,8 @@ def upgrade_all(
 
         except PipxError as e:
             venv_error = True
-            logging.error(f"Error encountered when upgrading {venv_dir.name}:")
-            logging.error(f"{e}\n")
+            logger.error(f"Error encountered when upgrading {venv_dir.name}:")
+            logger.error(f"{e}\n")
 
     if venvs_upgraded == 0:
         print(

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -155,7 +155,7 @@ def upgrade(
         force=force,
     )
 
-    # Any error in upgrade will raise PipxError (e.g. from venv._run_pip())
+    # Any error in upgrade will raise PipxError (e.g. from venv.upgrade_package())
     return EXIT_CODE_OK
 
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -681,11 +681,7 @@ def setup_stream_handler(verbose: bool) -> logging.Handler:
     return stream_handler
 
 
-def setup(args: argparse.Namespace) -> None:
-    if "version" in args and args.version:
-        print_version()
-        sys.exit(0)
-
+def setup_logging(verbose: bool) -> None:
     # Setup logging so debug and above go to log file,
     #   info (verbose) or warning (non-verbose) and above go to console
     pipx_root_logger = logging.getLogger("pipx")
@@ -697,9 +693,17 @@ def setup(args: argparse.Namespace) -> None:
         pipx_root_logger.removeHandler(handler)
 
     file_handler = setup_file_handler()
-    stream_handler = setup_stream_handler("verbose" in args and args.verbose)
+    stream_handler = setup_stream_handler(verbose)
     pipx_root_logger.addHandler(file_handler)
     pipx_root_logger.addHandler(stream_handler)
+
+
+def setup(args: argparse.Namespace) -> None:
+    if "version" in args and args.version:
+        print_version()
+        sys.exit(0)
+
+    setup_logging("verbose" in args and args.verbose)
 
     logger.debug(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
     logger.debug(f"{' '.join(sys.argv)}")

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -693,7 +693,7 @@ def setup(args: argparse.Namespace) -> None:
 
     # There should be no existing handlers, if some are found they are
     #   pytest artifacts from previous tests, so remove them
-    for handler in pipx_root_logger.handlers[:]:
+    for handler in pipx_root_logger.handlers.copy():
         pipx_root_logger.removeHandler(handler)
 
     file_handler = setup_file_handler()

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -26,7 +26,7 @@ from pipx.util import PipxError, mkdir
 from pipx.venv import VenvContainer
 from pipx.version import __version__
 
-logger = logging.getLogger("pipx")
+logger = logging.getLogger(__name__)
 
 
 def print_version() -> None:
@@ -688,12 +688,13 @@ def setup(args: argparse.Namespace) -> None:
 
     # Setup logging so debug and above go to log file,
     #   info (verbose) or warning (non-verbose) and above go to console
-    logger.setLevel(logging.DEBUG)
+    pipx_root_logger = logging.getLogger("pipx")
+    pipx_root_logger.setLevel(logging.DEBUG)
 
     file_handler = setup_file_handler()
     stream_handler = setup_stream_handler("verbose" in args and args.verbose)
-    logger.addHandler(file_handler)
-    logger.addHandler(stream_handler)
+    pipx_root_logger.addHandler(file_handler)
+    pipx_root_logger.addHandler(stream_handler)
 
     logger.debug(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
     logger.debug(f"{' '.join(sys.argv)}")

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -662,51 +662,7 @@ def setup_log_file() -> Path:
     return log_file
 
 
-def setup_file_handler() -> logging.Handler:
-    log_file = setup_log_file()
-
-    file_handler = logging.FileHandler(log_file)
-    file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(
-        logging.Formatter(
-            "{relativeCreated: >8.1f}ms ({funcName}:{lineno}): {message}", style="{"
-        )
-    )
-    return file_handler
-
-
-def setup_stream_handler(verbose: bool) -> logging.Handler:
-    stream_handler = logging.StreamHandler()
-    if verbose:
-        pipx_str = bold(green("pipx >")) if sys.stdout.isatty() else "pipx >"
-        stream_handler.setLevel(logging.INFO)
-        stream_handler.setFormatter(
-            logging.Formatter(pipx_str + "({funcName}:{lineno}): {message}", style="{")
-        )
-    else:
-        stream_handler.setLevel(logging.WARNING)
-        stream_handler.setFormatter(logging.Formatter("{message}", style="{"))
-    return stream_handler
-
-
 def setup_logging(verbose: bool) -> None:
-    # Setup logging so debug and above go to log file,
-    #   info (verbose) or warning (non-verbose) and above go to console
-    pipx_root_logger = logging.getLogger("pipx")
-    pipx_root_logger.setLevel(logging.DEBUG)
-
-    # There should be no existing handlers, if some are found they are
-    #   pytest artifacts from previous tests, so remove them
-    for handler in pipx_root_logger.handlers.copy():
-        pipx_root_logger.removeHandler(handler)
-
-    file_handler = setup_file_handler()
-    stream_handler = setup_stream_handler(verbose)
-    pipx_root_logger.addHandler(file_handler)
-    pipx_root_logger.addHandler(stream_handler)
-
-
-def setup_logging2(verbose: bool) -> None:
     pipx_str = bold(green("pipx >")) if sys.stdout.isatty() else "pipx >"
     log_file = setup_log_file()
 
@@ -754,8 +710,7 @@ def setup(args: argparse.Namespace) -> None:
         print_version()
         sys.exit(0)
 
-    # setup_logging("verbose" in args and args.verbose)
-    setup_logging2("verbose" in args and args.verbose)
+    setup_logging("verbose" in args and args.verbose)
 
     logger.debug(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
     logger.debug(f"{' '.join(sys.argv)}")

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -26,7 +26,7 @@ from pipx.util import PipxError, mkdir
 from pipx.venv import VenvContainer
 from pipx.version import __version__
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("pipx")
 
 
 def print_version() -> None:

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -696,6 +696,9 @@ def setup(args: argparse.Namespace) -> None:
     pipx_root_logger.addHandler(file_handler)
     pipx_root_logger.addHandler(stream_handler)
 
+    # DEBUG: DELETEME TODO
+    logger.info(f"len(pipx_root_logger.handlers) = {len(pipx_root_logger.handlers)}")
+
     logger.debug(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
     logger.debug(f"{' '.join(sys.argv)}")
     logger.info(f"pipx version is {__version__}")

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -691,13 +691,15 @@ def setup(args: argparse.Namespace) -> None:
     pipx_root_logger = logging.getLogger("pipx")
     pipx_root_logger.setLevel(logging.DEBUG)
 
+    # There should be no existing handlers, if some are found they are
+    #   pytest artifacts from previous tests, so remove them
+    for handler in pipx_root_logger.handlers[:]:
+        pipx_root_logger.removeHandler(handler)
+
     file_handler = setup_file_handler()
     stream_handler = setup_stream_handler("verbose" in args and args.verbose)
     pipx_root_logger.addHandler(file_handler)
     pipx_root_logger.addHandler(stream_handler)
-
-    # DEBUG: DELETEME TODO
-    logger.info(f"len(pipx_root_logger.handlers) = {len(pipx_root_logger.handlers)}")
 
     logger.debug(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
     logger.debug(f"{' '.join(sys.argv)}")

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -26,6 +26,8 @@ from pipx.util import PipxError, mkdir
 from pipx.venv import VenvContainer
 from pipx.version import __version__
 
+logger = logging.getLogger(__name__)
+
 
 def print_version() -> None:
     print(__version__)
@@ -171,7 +173,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
                     args.spec = args.spec + f"#egg={package}"
 
         venv_dir = venv_container.get_venv_dir(package)
-        logging.info(f"Virtual Environment location is {venv_dir}")
+        logger.info(f"Virtual Environment location is {venv_dir}")
     if "skip" in args:
         skip_list = [canonicalize_name(x) for x in args.skip]
 
@@ -266,7 +268,7 @@ def run_pipx_command(args: argparse.Namespace) -> ExitCode:  # noqa: C901
         try:
             return commands.ensure_pipx_paths(force=args.force)
         except Exception as e:
-            logging.debug("Uncaught Exception:", exc_info=True)
+            logger.debug("Uncaught Exception:", exc_info=True)
             raise PipxError(e)
     elif args.command == "completions":
         print(constants.completion_instructions)
@@ -686,18 +688,17 @@ def setup(args: argparse.Namespace) -> None:
 
     # Setup logging so debug and above go to log file,
     #   info (verbose) or warning (non-verbose) and above go to console
-    root_logger = logging.getLogger()
-    root_logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.DEBUG)
 
     file_handler = setup_file_handler()
     stream_handler = setup_stream_handler("verbose" in args and args.verbose)
-    root_logger.addHandler(file_handler)
-    root_logger.addHandler(stream_handler)
+    logger.addHandler(file_handler)
+    logger.addHandler(stream_handler)
 
-    logging.debug(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
-    logging.debug(f"{' '.join(sys.argv)}")
-    logging.info(f"pipx version is {__version__}")
-    logging.info(f"Default python interpreter is {repr(DEFAULT_PYTHON)}")
+    logger.debug(f"{time.strftime('%Y-%m-%d %H:%M:%S')}")
+    logger.debug(f"{' '.join(sys.argv)}")
+    logger.info(f"pipx version is {__version__}")
+    logger.info(f"Default python interpreter is {repr(DEFAULT_PYTHON)}")
 
     mkdir(constants.PIPX_LOCAL_VENVS)
     mkdir(constants.LOCAL_BIN_DIR)
@@ -705,7 +706,7 @@ def setup(args: argparse.Namespace) -> None:
 
     old_pipx_venv_location = constants.PIPX_LOCAL_VENVS / "pipx-app"
     if old_pipx_venv_location.exists():
-        logging.warning(
+        logger.warning(
             "A virtual environment for pipx was detected at "
             f"{str(old_pipx_venv_location)}. The 'pipx-app' package has been renamed "
             "back to 'pipx' (https://github.com/pipxproject/pipx/issues/82)."
@@ -741,12 +742,12 @@ def cli() -> ExitCode:
         return run_pipx_command(parsed_pipx_args)
     except PipxError as e:
         print(str(e), file=sys.stderr)
-        logging.debug(f"PipxError: {e}", exc_info=True)
+        logger.debug(f"PipxError: {e}", exc_info=True)
         return ExitCode(1)
     except KeyboardInterrupt:
         return ExitCode(1)
     except Exception:
-        logging.debug("Uncaught Exception:", exc_info=True)
+        logger.debug("Uncaught Exception:", exc_info=True)
         raise
     finally:
         show_cursor()

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -19,6 +19,8 @@ from packaging.utils import canonicalize_name
 from pipx.emojies import hazard
 from pipx.util import PipxError
 
+logger = logging.getLogger(__name__)
+
 
 class ParsedPackage(NamedTuple):
     valid_pep508: Optional[Requirement]
@@ -27,8 +29,7 @@ class ParsedPackage(NamedTuple):
 
 
 def _split_path_extras(package_spec: str) -> Tuple[str, str]:
-    """Returns (path, extras_string)
-    """
+    """Returns (path, extras_string)"""
     package_spec_extras_re = re.search(r"(.+)(\[.+\])", package_spec)
     if package_spec_extras_re:
         return (package_spec_extras_re.group(1), package_spec_extras_re.group(2))
@@ -37,8 +38,7 @@ def _split_path_extras(package_spec: str) -> Tuple[str, str]:
 
 
 def _parse_specifier(package_spec: str) -> ParsedPackage:
-    """Parse package_spec as would be given to pipx
-    """
+    """Parse package_spec as would be given to pipx"""
     # If package_spec is valid pypi name, pip will always treat it as a
     #       pypi package, not checking for local path.
     #       We replicate pypi precedence here (only non-valid-pypi names
@@ -106,7 +106,7 @@ def _parsed_package_to_package_or_url(
 ) -> str:
     if parsed_package.valid_pep508 is not None:
         if parsed_package.valid_pep508.marker is not None:
-            logging.warning(
+            logger.warning(
                 textwrap.fill(
                     f"{hazard}  Ignoring environment markers "
                     f"({parsed_package.valid_pep508.marker}) in package "
@@ -124,7 +124,7 @@ def _parsed_package_to_package_or_url(
     elif parsed_package.valid_local_path is not None:
         package_or_url = parsed_package.valid_local_path
 
-    logging.info(f"cleaned package spec: {package_or_url}")
+    logger.info(f"cleaned package spec: {package_or_url}")
     return package_or_url
 
 
@@ -143,7 +143,7 @@ def parse_specifier_for_install(
         parsed_package, remove_version_specifiers=False
     )
     if "--editable" in pip_args and not parsed_package.valid_local_path:
-        logging.warning(
+        logger.warning(
             textwrap.fill(
                 f"{hazard}  Ignoring --editable install option. pipx disallows it "
                 "for anything but a local path, to avoid having to create a new "
@@ -208,7 +208,7 @@ def fix_package_name(package_or_url: str, package: str) -> str:
         return package_or_url
 
     if canonicalize_name(package_req.name) != canonicalize_name(package):
-        logging.warning(
+        logger.warning(
             textwrap.fill(
                 f"{hazard}  Name supplied in package specifier was "
                 f"{package_req.name!r} but package found has name "

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -6,6 +6,9 @@ from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 from pipx.util import PipxError
 
+logger = logging.getLogger(__name__)
+
+
 PIPX_INFO_FILENAME = "pipx_metadata.json"
 
 
@@ -112,7 +115,7 @@ class PipxMetadata:
             or self.main_package.package_or_url is None
             or not self.main_package.include_apps
         ):
-            logging.debug(f"PipxMetadata corrupt:\n{self.to_dict()}")
+            logger.debug(f"PipxMetadata corrupt:\n{self.to_dict()}")
             raise PipxError("Internal Error: PipxMetadata is corrupt, cannot write.")
 
     def write(self) -> None:
@@ -127,7 +130,7 @@ class PipxMetadata:
                     cls=JsonEncoderHandlesPath,
                 )
         except IOError:
-            logging.warning(
+            logger.warning(
                 textwrap.fill(
                     f"Unable to write {PIPX_INFO_FILENAME} to {self.venv_dir}. "
                     f"This may cause future pipx operations involving "
@@ -144,7 +147,7 @@ class PipxMetadata:
                 )
         except IOError:  # Reset self if problem reading
             if verbose:
-                logging.warning(
+                logger.warning(
                     textwrap.fill(
                         f"Unable to read {PIPX_INFO_FILENAME} in {self.venv_dir}. "
                         f"This may cause this or future pipx operations involving "

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -10,6 +10,9 @@ from pipx.constants import WINDOWS
 from pipx.interpreter import DEFAULT_PYTHON
 from pipx.util import get_site_packages, get_venv_paths, run_verify
 
+logger = logging.getLogger(__name__)
+
+
 SHARED_LIBS_MAX_AGE_SEC = datetime.timedelta(days=30).total_seconds()
 
 
@@ -52,7 +55,7 @@ class _SharedLibs:
 
         now = time.time()
         time_since_last_update_sec = now - self.pip_path.stat().st_mtime
-        logging.info(
+        logger.info(
             f"Time since last upgrade of shared libs, in seconds: {time_since_last_update_sec:.0f}. "
             f"Upgrade will be run by pipx if greater than {SHARED_LIBS_MAX_AGE_SEC:.0f}."
         )
@@ -63,13 +66,13 @@ class _SharedLibs:
     ) -> None:
         # Don't try to upgrade multiple times per run
         if self.has_been_updated_this_run:
-            logging.info(f"Already upgraded libraries in {self.root}")
+            logger.info(f"Already upgraded libraries in {self.root}")
             return
 
         if pip_args is None:
             pip_args = []
 
-        logging.info(f"Upgrading shared libraries in {self.root}")
+        logger.info(f"Upgrading shared libraries in {self.root}")
 
         ignored_args = ["--editable"]
         _pip_args = [arg for arg in pip_args if arg not in ignored_args]
@@ -95,7 +98,7 @@ class _SharedLibs:
             self.pip_path.touch()
 
         except Exception:
-            logging.error("Failed to upgrade shared libraries", exc_info=True)
+            logger.error("Failed to upgrade shared libraries", exc_info=True)
 
 
 shared_libs = _SharedLibs()

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -128,7 +128,7 @@ def run_subprocess(
         logger.debug(f"stdout: {completed_process.stdout}".rstrip())
     if capture_stderr:
         logger.debug(f"stderr: {completed_process.stderr}".rstrip())
-    logger.debug(f"returncode: {completed_process.returncode}".rstrip())
+    logger.debug(f"returncode: {completed_process.returncode}")
 
     return completed_process
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -133,23 +133,32 @@ def run_subprocess(
     return completed_process
 
 
-def run_verify(cmd: Sequence[Union[str, Path]]) -> None:
-    """Run arbitrary command as subprocess, raise PipxError if error exit code"""
+# def run_verify(cmd: Sequence[Union[str, Path]]) -> None:
+#    """Run arbitrary command as subprocess, raise PipxError if error exit code"""
+#
+#    returncode = run_subprocess(
+#        cmd, capture_stdout=False, capture_stderr=False
+#    ).returncode
+#
+#    if returncode:
+#        cmd_str = " ".join(str(c) for c in cmd)
+#        raise PipxError(f"{cmd_str!r} failed")
 
-    returncode = run_subprocess(
-        cmd, capture_stdout=False, capture_stderr=False
-    ).returncode
 
-    if returncode:
-        cmd_str = " ".join(str(c) for c in cmd)
-        raise PipxError(f"{cmd_str!r} failed")
-
-
-def print_completed_process(completed_process: subprocess.CompletedProcess):
-    print(completed_process.stdout, file=sys.stdout, end="")
-    print(completed_process.stderr, file=sys.stderr, end="")
+def subprocess_post_check(
+    completed_process: subprocess.CompletedProcess, raise_error: bool = True
+) -> None:
     if completed_process.returncode:
-        logger.info(f"{' '.join(completed_process.args)!r} failed")
+        if completed_process.stdout is not None:
+            print(completed_process.stdout, file=sys.stdout, end="")
+        if completed_process.stderr is not None:
+            print(completed_process.stderr, file=sys.stderr, end="")
+        if raise_error:
+            raise PipxError(
+                f"{' '.join([str(x) for x in completed_process.args])!r} failed"
+            )
+        else:
+            logger.info(f"{' '.join(completed_process.args)!r} failed")
 
 
 def exec_app(cmd: Sequence[Union[str, Path]], env: Dict[str, str] = None) -> None:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -126,7 +126,7 @@ def run_subprocess(
     if capture_stdout:
         logger.debug(f"stdout: {completed_process.stdout}")
     if capture_stderr:
-        logger.debug(f"stderr: {completed_process.stdout}")
+        logger.debug(f"stderr: {completed_process.stderr}")
 
     return completed_process
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -123,10 +123,12 @@ def run_subprocess(
         encoding="utf-8",
         universal_newlines=True,
     )
+
     if capture_stdout:
         logger.debug(f"stdout: {completed_process.stdout}".rstrip())
     if capture_stderr:
         logger.debug(f"stderr: {completed_process.stderr}".rstrip())
+    logger.debug(f"returncode: {completed_process.returncode}".rstrip())
 
     return completed_process
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -124,9 +124,9 @@ def run_subprocess(
         universal_newlines=True,
     )
     if capture_stdout:
-        logger.debug(f"stdout: {completed_process.stdout}")
+        logger.debug(f"stdout: {completed_process.stdout}".rstrip())
     if capture_stderr:
-        logger.debug(f"stderr: {completed_process.stderr}")
+        logger.debug(f"stderr: {completed_process.stderr}".rstrip())
 
     return completed_process
 
@@ -141,6 +141,13 @@ def run_verify(cmd: Sequence[Union[str, Path]]) -> None:
     if returncode:
         cmd_str = " ".join(str(c) for c in cmd)
         raise PipxError(f"{cmd_str!r} failed")
+
+
+def print_completed_process(completed_process: subprocess.CompletedProcess):
+    print(completed_process.stdout, file=sys.stdout, end="")
+    print(completed_process.stderr, file=sys.stderr, end="")
+    if completed_process.returncode:
+        logger.info(f"{' '.join(completed_process.args)!r} failed")
 
 
 def exec_app(cmd: Sequence[Union[str, Path]], env: Dict[str, str] = None) -> None:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -9,13 +9,15 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union
 from pipx.animate import show_cursor
 from pipx.constants import WINDOWS
 
+logger = logging.getLogger(__name__)
+
 
 class PipxError(Exception):
     pass
 
 
 def rmdir(path: Path) -> None:
-    logging.info(f"removing directory {path}")
+    logger.info(f"removing directory {path}")
     try:
         if WINDOWS:
             os.system(f'rmdir /S /Q "{str(path)}"')
@@ -28,7 +30,7 @@ def rmdir(path: Path) -> None:
 def mkdir(path: Path) -> None:
     if path.is_dir():
         return
-    logging.info(f"creating directory {path}")
+    logger.info(f"creating directory {path}")
     path.mkdir(parents=True, exist_ok=True)
 
 
@@ -110,7 +112,7 @@ def run_subprocess(
 
     if log_cmd_str is None:
         log_cmd_str = " ".join(str(c) for c in cmd)
-    logging.info(f"running {log_cmd_str}")
+    logger.info(f"running {log_cmd_str}")
     # windows cannot take Path objects, only strings
     cmd_str_list = [str(c) for c in cmd]
     return subprocess.run(
@@ -150,7 +152,7 @@ def exec_app(cmd: Sequence[Union[str, Path]], env: Dict[str, str] = None) -> Non
     show_cursor()
     sys.stderr.flush()
 
-    logging.info("exec_app: " + " ".join([str(c) for c in cmd]))
+    logger.info("exec_app: " + " ".join([str(c) for c in cmd]))
 
     if WINDOWS:
         sys.exit(

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -133,18 +133,6 @@ def run_subprocess(
     return completed_process
 
 
-# def run_verify(cmd: Sequence[Union[str, Path]]) -> None:
-#    """Run arbitrary command as subprocess, raise PipxError if error exit code"""
-#
-#    returncode = run_subprocess(
-#        cmd, capture_stdout=False, capture_stderr=False
-#    ).returncode
-#
-#    if returncode:
-#        cmd_str = " ".join(str(c) for c in cmd)
-#        raise PipxError(f"{cmd_str!r} failed")
-
-
 def subprocess_post_check(
     completed_process: subprocess.CompletedProcess, raise_error: bool = True
 ) -> None:

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -115,7 +115,7 @@ def run_subprocess(
     logger.info(f"running {log_cmd_str}")
     # windows cannot take Path objects, only strings
     cmd_str_list = [str(c) for c in cmd]
-    return subprocess.run(
+    completed_process = subprocess.run(
         cmd_str_list,
         env=env,
         stdout=subprocess.PIPE if capture_stdout else None,
@@ -123,6 +123,12 @@ def run_subprocess(
         encoding="utf-8",
         universal_newlines=True,
     )
+    if capture_stdout:
+        logger.debug(f"stdout: {completed_process.stdout}")
+    if capture_stderr:
+        logger.debug(f"stderr: {completed_process.stdout}")
+
+    return completed_process
 
 
 def run_verify(cmd: Sequence[Union[str, Path]]) -> None:

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -27,6 +27,8 @@ from pipx.util import (
     run_verify,
 )
 
+logger = logging.getLogger(__name__)
+
 venv_metadata_inspector_raw = pkgutil.get_data("pipx", "venv_metadata_inspector.py")
 assert venv_metadata_inspector_raw is not None, (
     "pipx could not find required file venv_metadata_inspector.py. "
@@ -171,7 +173,7 @@ class Venv:
         if self.safe_to_remove():
             rmdir(self.root)
         else:
-            logging.warning(
+            logger.warning(
                 f"Not removing existing venv {self.root} because "
                 "it was not created in this session"
             )
@@ -213,7 +215,7 @@ class Venv:
                 cmd = ["install"] + pip_args + [package_or_url]
                 self._run_pip(cmd)
         except PipxError as e:
-            logging.info(e)
+            logger.info(e)
             raise PipxError(
                 f"Error installing "
                 f"{full_package_description(package, package_or_url)}."
@@ -247,7 +249,7 @@ class Venv:
                 cmd = ["install"] + ["--no-dependencies"] + pip_args + [package_or_url]
                 self._run_pip(cmd)
         except PipxError as e:
-            logging.info(e)
+            logger.info(e)
             raise PipxError(
                 f"Cannot determine package name from spec {package_or_url!r}. "
                 f"Check package spec for errors."
@@ -256,10 +258,10 @@ class Venv:
         installed_packages = self.list_installed_packages() - old_package_set
         if len(installed_packages) == 1:
             package = installed_packages.pop()
-            logging.info(f"Determined package name: {package}")
+            logger.info(f"Determined package name: {package}")
         else:
-            logging.info(f"old_package_set = {old_package_set}")
-            logging.info(f"install_packages = {installed_packages}")
+            logger.info(f"old_package_set = {old_package_set}")
+            logger.info(f"install_packages = {installed_packages}")
             raise PipxError(
                 f"Cannot determine package name from spec {package_or_url!r}. "
                 f"Check package spec for errors."
@@ -292,8 +294,8 @@ class Venv:
 
         venv_metadata_traceback = data.pop("exception_traceback", None)
         if venv_metadata_traceback is not None:
-            logging.error("Internal error with venv metadata inspection.")
-            logging.info(
+            logger.error("Internal error with venv metadata inspection.")
+            logger.info(
                 f"venv_metadata_inspector.py Traceback:\n{venv_metadata_traceback}"
             )
 
@@ -396,5 +398,5 @@ class Venv:
         ).returncode
         if returncode:
             cmd_str = " ".join(str(c) for c in cmd)
-            logging.error(f"{cmd_str!r} failed")
+            logger.error(f"{cmd_str!r} failed")
         return ExitCode(returncode)

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -26,7 +26,6 @@ from pipx.util import (
     print_completed_process,
     rmdir,
     run_subprocess,
-    run_verify,
 )
 
 logger = logging.getLogger(__name__)
@@ -151,7 +150,13 @@ class Venv:
     def create_venv(self, venv_args: List[str], pip_args: List[str]) -> None:
         with animate("creating virtual environment", self.do_animation):
             cmd = [self.python, "-m", "venv", "--without-pip"]
-            run_verify(cmd + venv_args + [str(self.root)])
+            venv_process = run_subprocess(
+                cmd + venv_args + [str(self.root)],
+                capture_stdout=True,
+                capture_stderr=True,
+            )
+        if venv_process.returncode:
+            raise PipxError(f"{' '.join([str(x) for x in venv_process.args])!r} failed")
         shared_libs.create(self.verbose)
         pipx_pth = get_site_packages(self.python_path) / PIPX_SHARED_PTH
         # write path pointing to the shared libs site-packages directory


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Closes #581 

The main problem that this PR solves is that previously during a pytest session, because `logging` was never getting unloaded, we kept adding logging Handlers to the root logger which were never removed.  As the tests went on, we ended up with many, many stream handlers creating redundant messages, and many file handlers trying (unsuccessfully) to write to closed log files.

This new code uses `logging.config.dictConfig` to setup loggers, handlers, and formatters.  This config API resets all previous logging state (this is what `incremental=False` does).  So at the end of every invocation of `setup_logging`, even in pytest, the result is only 2 handlers attached to the pipx logger.  I've debugged and verified that this is so.

Most of the changes here change our code from using the root logger to using a "pipx" logger.  i.e. using `logger = logging.getLogger(__name__)` at the top of the files and e.g. `logger.info()` instead of `logging.info()` to use the "pipx" logger everywhere and not the root logger.  This allows us to effectively manage our own logger separately from the root logger.  In pytest, the root logger has special pytest handlers added to it.

The other interesting change affects `util.py`, `venv.py`, and `shared_libs.py`.  We now fully log `run_subprocess`, adding `stdout`, `stderr`, and `returncode` to the file logs for each subprocess invocation for all `std*` are captured.  Additionally, to capture more info to the file logs, I removed `run_verify()` (which didn't capture stderr and stdout, but just let them go directly to the console) and replaced it with a call to `run_subprocess` that both captures stderr and stdout and echoes to the console on error.  I tried to replicate the old user-visible behavior, but now allowing capturing subprocess output to the logs in addition.  I split the "verify" part into a separate function `subprocess_post_check()` so that any output could be printed outside of the `animate` context to not screw up the text animation.

I think the main change in behavior from a user standpoint is that piping `pip` errors through pipx to the console now displays errors as plain text color instead of `pip`'s red text color.  I thought that was ok (even better?) because now we get to log the error messages to file.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
