### PR TITLE
Fix post-release development versioning

### DIFF
--- a/scripts/pipx_postrelease.py
+++ b/scripts/pipx_postrelease.py
@@ -9,7 +9,10 @@ from pipx_release import copy_file_replace_line, python_mypy_ok
 def fix_version_py(current_version_list: List[str]) -> bool:
     version_code_file = Path("src/pipx/version.py")
     new_version_code_file = Path("src/pipx/version.py.new")
-    new_version_list = current_version_list + ['"dev0"']
+    # Version with "dev0" suffix precedes version without "dev0" suffix,
+    #   so to follow previous version we must add to version number before
+    #   appending "dev0".
+    new_version_list = current_version_list + ['"1"', '"dev0"']
 
     copy_file_replace_line(
         version_code_file,

--- a/scripts/pipx_postrelease.py
+++ b/scripts/pipx_postrelease.py
@@ -12,7 +12,7 @@ def fix_version_py(current_version_list: List[str]) -> bool:
     # Version with "dev0" suffix precedes version without "dev0" suffix,
     #   so to follow previous version we must add to version number before
     #   appending "dev0".
-    new_version_list = current_version_list + ['"1"', '"dev0"']
+    new_version_list = current_version_list + ["1", '"dev0"']
 
     copy_file_replace_line(
         version_code_file,

--- a/src/pipx/version.py
+++ b/src/pipx/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 16, 0, 0, "dev0")
+__version_info__ = (0, 16, 0, 0, 1, "dev0")
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
For the post-release procedure / script, we append "dev0" so the version from git `master` is different than the released version.

The way we currently do this (just append "dev0" onto last released version) is wrong, because in the [PEP 440](https://www.python.org/dev/peps/pep-0440/#developmental-releases) scheme, `<version>.dev0` actually **precedes** `<version>`.

To fix this in the most expedient way, I changed the post-release script to append ".1.dev0" to the last release version instead of ".dev0".  This ensures proper version ordering, at least with regard to the last released version.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
