### PR TITLE
Drop .exe appending on Windows

### DIFF
--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -327,8 +327,8 @@ class Venv:
         pip_list = json.loads(cmd_run.stdout.strip())
         return set([x["name"] for x in pip_list])
 
-    def run_app(self, app: str, app_args: List[str]) -> NoReturn:
-        exec_app([str(self.bin_path / app)] + app_args)
+    def run_app(self, app: str, filename: str, app_args: List[str]) -> NoReturn:
+        exec_app([str(self.bin_path / filename)] + app_args)
 
     def _upgrade_package_no_metadata(self, package: str, pip_args: List[str]) -> None:
         with animate(


### PR DESCRIPTION
This makes `Venv.run_app()` and code path along it accept an additional argument, so we can distinguish between the "real" name (filename) of an app, and the name supplied by the user.
    
This makes the code simpler, espacially when dealing with the proposed `[pipx.run]` entry points.