### PR TITLE
Fix show/hide cursor for older Windows

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 dev
 
-- Fix cursor show/hide to work with older versions of Windows.
+- Fix cursor show/hide to work with older versions of Windows. (#610)
 
 0.16.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- Fix cursor show/hide to work with older versions of Windows.
 
 0.16.0.0
 

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -103,10 +103,10 @@ def print_animation(
 # for Windows: https://stackoverflow.com/a/10455937
 def win_cursor(visible: bool) -> None:
     ci = _CursorInfo()
-    handle = ctypes.windll.kernel32.GetStdHandle(-11)  # type: ignore
-    ctypes.windll.kernel32.GetConsoleCursorInfo(handle, ctypes.byref(ci))  # type: ignore
+    handle = ctypes.windll.kernel32.GetStdHandle(-11)  # type: ignore[attr-defined]
+    ctypes.windll.kernel32.GetConsoleCursorInfo(handle, ctypes.byref(ci))  # type: ignore[attr-defined]
     ci.visible = visible
-    ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(ci))  # type: ignore
+    ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(ci))  # type: ignore[attr-defined]
 
 
 def hide_cursor() -> None:

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -4,19 +4,23 @@ from contextlib import contextmanager
 from threading import Event, Thread
 from typing import Generator, List
 
-from pipx.constants import emoji_support
+from pipx.constants import WINDOWS, emoji_support
 
 stderr_is_tty = sys.stderr.isatty()
 
-
-HIDE_CURSOR = "\033[?25l"
-SHOW_CURSOR = "\033[?25h"
 CLEAR_LINE = "\033[K"
 EMOJI_ANIMATION_FRAMES = ["⣷", "⣯", "⣟", "⡿", "⢿", "⣻", "⣽", "⣾"]
 NONEMOJI_ANIMATION_FRAMES = ["", ".", "..", "..."]
 EMOJI_FRAME_PERIOD = 0.1
 NONEMOJI_FRAME_PERIOD = 1
 MINIMUM_COLS_ALLOW_ANIMATION = 16
+
+
+if WINDOWS:
+    import ctypes
+
+    class _CursorInfo(ctypes.Structure):
+        _fields_ = [("size", ctypes.c_int), ("visible", ctypes.c_byte)]
 
 
 def _env_supports_animation() -> bool:
@@ -96,12 +100,29 @@ def print_animation(
                 break
 
 
+# for Windows: https://stackoverflow.com/a/10455937
+def win_cursor(visible: bool) -> None:
+    ci = _CursorInfo()
+    handle = ctypes.windll.kernel32.GetStdHandle(-11)  # type: ignore
+    ctypes.windll.kernel32.GetConsoleCursorInfo(handle, ctypes.byref(ci))  # type: ignore
+    ci.visible = visible
+    ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(ci))  # type: ignore
+
+
 def hide_cursor() -> None:
-    sys.stderr.write(f"{HIDE_CURSOR}")
+    if WINDOWS:
+        win_cursor(visible=False)
+    else:
+        sys.stderr.write("\033[?25l")
+        sys.stderr.flush()
 
 
 def show_cursor() -> None:
-    sys.stderr.write(f"{SHOW_CURSOR}")
+    if WINDOWS:
+        win_cursor(visible=True)
+    else:
+        sys.stderr.write("\033[?25h")
+        sys.stderr.flush()
 
 
 def clear_line() -> None:

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -100,7 +100,8 @@ def print_animation(
                 break
 
 
-# for Windows: https://stackoverflow.com/a/10455937
+# for Windows pre-ANSI-terminal-support (before Windows 10 TH2 (v1511))
+# https://stackoverflow.com/a/10455937
 def win_cursor(visible: bool) -> None:
     ci = _CursorInfo()
     handle = ctypes.windll.kernel32.GetStdHandle(-11)  # type: ignore[attr-defined]

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -169,7 +169,6 @@ def exec_app(
 
     # make sure we show cursor again before handing over control
     show_cursor()
-    sys.stderr.flush()
 
     logger.info("exec_app: " + " ".join([str(c) for c in cmd]))
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Closes #603 .

On Windows, this PR adds and uses the method of showing/hiding the cursor outlined in https://stackoverflow.com/a/10455937


## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
I don't have an older copy of Windows, so if somebody could test this with an old Windows (before Windows 10 TH2 (v1511)) I would be much appreciative.

From #603, all one would need to do would be to see if there are visible ANSI escape codes printed (e.g. `[?25l`,` [?25h`) when executing pipx commands like:

```
pipx --version
```
