### PR TITLE
Upgrade all pre-commit plugins except black.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,14 +6,14 @@
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.4.0
   hooks:
   - id: end-of-file-fixer
   - id: check-added-large-files
   #- id: trailing-whitespace
   #- id: check-yaml
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.4.2
+  rev: 5.7.0
   hooks:
   - id: isort
     args: ['--profile','black']
@@ -22,13 +22,13 @@ repos:
   hooks:
   - id: black
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.3
+  rev: 3.8.4
   hooks:
   - id: flake8
     additional_dependencies: [
-        'flake8-bugbear==20.1.4'
+        'flake8-bugbear==20.11.1'
     ]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.782
+  rev: v0.800
   hooks:
   - id: mypy


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Upgrade pre-commit plugins.  `black` is kept at `19.10b0` to match the nox `black` version.  All other plugins are updated to their latest version.

I'm waiting to upgrade black until a version with [`--skip-magic-trailing-comma`](https://github.com/psf/black/pull/1824) is released.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
