### PR TITLE
Add text color capability for Windows

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- Support text colors on Windows.
 
 0.16.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 dev
 
-- Support text colors on Windows.
+- Support text colors on Windows. (#612)
 
 0.16.0.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ include_package_data = true
 zip_safe = true
 python_requires = >=3.6
 install_requires =
+    colorama>=0.4.4
     userpath>=1.4.1
     argcomplete>=1.9.4, <2.0
     packaging>=20.0

--- a/src/pipx/colors.py
+++ b/src/pipx/colors.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Callable
 
-import colorama
+import colorama  # type: ignore
 
 PRINT_COLOR = sys.stdout.isatty()
 

--- a/src/pipx/colors.py
+++ b/src/pipx/colors.py
@@ -1,9 +1,12 @@
 import sys
 from typing import Callable
 
-from pipx.constants import WINDOWS
+import colorama
 
-PRINT_COLOR = not WINDOWS and sys.stdout.isatty()
+PRINT_COLOR = sys.stdout.isatty()
+
+if PRINT_COLOR:
+    colorama.init()
 
 
 class c:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
With colorama it is ridiculously easy to support text color output on Windows, so I added it with this PR.  It adds polish and brings the Windows experience in line with other platforms.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx list --verbose
```
On Windows both the bold list formatting and the green of the verbose output show up.  (They don't with existing pipx.)
