### PR TITLE
Mention that pipx requires pip 19+ to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pipx ensurepath
 
 Upgrade pipx with `brew update && brew upgrade pipx`.
 
-Otherwise, install via pip:
+Otherwise, install via pip (requires pip 19.0 or later):
 
 ```
 python3 -m pip install --user pipx

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ brew install pipx
 pipx ensurepath
 ```
 
-Otherwise, install via pip:
+Otherwise, install via pip (requires pip 19.0 or later):
 
 ```
 python3 -m pip install --user pipx


### PR DESCRIPTION
Technically pipx *can* be installed with earlier pip versions if directly from wheel, or from source with setuptools 30.3+ and wheel installed, but that description is probably too confusing for most.