### PR TITLE
Don't show / hide cursor if not in tty.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ dev
 - Fix cursor show/hide to work with older versions of Windows. (#610)
 - Support text colors on Windows. (#612)
 - Better platform unicode detection to avoid errors and allow showing emojis when possible. (#614)
+- Don't emit show cursor or hide cursor codes if STDERR is not a tty.
 
 0.16.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@ dev
 - Fix cursor show/hide to work with older versions of Windows. (#610)
 - Support text colors on Windows. (#612)
 - Better platform unicode detection to avoid errors and allow showing emojis when possible. (#614)
-- Don't emit show cursor or hide cursor codes if STDERR is not a tty.
+- Don't emit show cursor or hide cursor codes if STDERR is not a tty. (#620)
 
 0.16.0.0
 

--- a/src/pipx/animate.py
+++ b/src/pipx/animate.py
@@ -112,19 +112,21 @@ def win_cursor(visible: bool) -> None:
 
 
 def hide_cursor() -> None:
-    if WINDOWS:
-        win_cursor(visible=False)
-    else:
-        sys.stderr.write("\033[?25l")
-        sys.stderr.flush()
+    if stderr_is_tty:
+        if WINDOWS:
+            win_cursor(visible=False)
+        else:
+            sys.stderr.write("\033[?25l")
+            sys.stderr.flush()
 
 
 def show_cursor() -> None:
-    if WINDOWS:
-        win_cursor(visible=True)
-    else:
-        sys.stderr.write("\033[?25h")
-        sys.stderr.flush()
+    if stderr_is_tty:
+        if WINDOWS:
+            win_cursor(visible=True)
+        else:
+            sys.stderr.write("\033[?25h")
+            sys.stderr.flush()
 
 
 def clear_line() -> None:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
This prevents `show_cursor()` and `hide_cursor()` from emitting anything if we are not in a tty.  This prevents piped STDERR from showing `[?25l` or `[?25h`

I used `stderr_is_tty` instead of `_env_supports_animation()` so that resizing the terminal in the middle of a pipx run couldn't possibly end up with a hidden cursor afterward.  (i.e. The failure mode in that case would be in the beginning we hid the cursor and `_env_supports_animation()` later changed state so we never show the cursor again.)

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running

This PR:
```shell
> pipx --version 2> stderr.txt
0.16.0.0.1.dev0
> more stderr.txt             
> 
```

pipx 0.16.0.0:
```shell
> pipx --version 2> stderr.txt
0.16.0.0
> more stderr.txt 
ESC[?25lESC[?25h
>
```
