### PR TITLE
Use python 3.9 as default python.

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -14,7 +14,7 @@ on:
 
 # If changing default-python be sure to change job "tests" matrix: include: also
 env:
-  default-python: 3.8
+  default-python: 3.9
 
 jobs:
   lint:
@@ -57,9 +57,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
         include:
           - os: windows-latest
-            python-version: 3.8
+            python-version: 3.9
           - os: macos-latest
-            python-version: 3.8
+            python-version: 3.9
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  default-python: 3.8
+  default-python: 3.9
 
 jobs:
   testpypi-publish:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  default-python: 3.8
+  default-python: 3.9
 
 jobs:
   build:

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import nox  # type: ignore
 
 PYTHON_ALL_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
-PYTHON_DEFAULT_VERSION = "3.8"
+PYTHON_DEFAULT_VERSION = "3.9"
 DOC_DEPENDENCIES = [".", "jinja2", "mkdocs", "mkdocs-material"]
 LINT_DEPENDENCIES = [
     "black==19.10b0",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes

This makes Python 3.9 the new default python for all the single-python tests like "lint", "docs", and Windows and macOS functional tests.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running