### PR TITLE
Speed up `pipx list` by removing multiprocessing code

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@ dev
 - Fix cursor show/hide to work with older versions of Windows. (#610)
 - Support text colors on Windows. (#612)
 - Better platform unicode detection to avoid errors and allow showing emojis when possible. (#614)
-- Sped up `pipx list`.
+- Sped up `pipx list` (#624).
 
 0.16.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ dev
 - Fix cursor show/hide to work with older versions of Windows. (#610)
 - Support text colors on Windows. (#612)
 - Better platform unicode detection to avoid errors and allow showing emojis when possible. (#614)
+- Sped up `pipx list`.
 
 0.16.0.0
 

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -1,6 +1,5 @@
-from functools import partial
 from pathlib import Path
-from typing import Callable, Collection, Optional
+from typing import Collection
 
 from pipx import constants
 from pipx.colors import bold
@@ -9,18 +8,11 @@ from pipx.constants import EXIT_CODE_LIST_PROBLEM, EXIT_CODE_OK, ExitCode
 from pipx.emojis import sleep
 from pipx.venv import VenvContainer
 
-Pool: Optional[Callable]
-try:
-    import multiprocessing.synchronize  # noqa: F401
-    from multiprocessing import Pool
-except ImportError:
-    Pool = None
-
 
 def list_packages(venv_container: VenvContainer, include_injected: bool) -> ExitCode:
     """Returns pipx exit code."""
-    dirs: Collection[Path] = sorted(venv_container.iter_venv_dirs())
-    if not dirs:
+    venv_dirs: Collection[Path] = sorted(venv_container.iter_venv_dirs())
+    if not venv_dirs:
         print(f"nothing has been installed with pipx {sleep}")
         return EXIT_CODE_OK
 
@@ -30,23 +22,12 @@ def list_packages(venv_container: VenvContainer, include_injected: bool) -> Exit
     venv_container.verify_shared_libs()
 
     all_venv_problems = VenvProblems()
-    if Pool:
-        p = Pool()
-        try:
-            for package_summary, venv_problems in p.map(
-                partial(get_package_summary, include_injected=include_injected), dirs
-            ):
-                print(package_summary)
-                all_venv_problems.or_(venv_problems)
-        finally:
-            p.close()
-            p.join()
-    else:
-        for package_summary, venv_problems in map(
-            partial(get_package_summary, include_injected=include_injected), dirs
-        ):
-            print(package_summary)
-            all_venv_problems.or_(venv_problems)
+    for venv_dir in venv_dirs:
+        package_summary, venv_problems = get_package_summary(
+            venv_dir, include_injected=include_injected
+        )
+        print(package_summary)
+        all_venv_problems.or_(venv_problems)
 
     if all_venv_problems.bad_venv_name:
         print(


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Since we are not compute-limited in `pipx list`, parallel code is not appropriate, and in fact makes running pipx list noticeably slower than purely sequential code.

See #616 for some timing benchmarks

This PR removes the multiprocessing code for `pipx list`, and makes it always use fully sequential code.

Closes #616 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running

Unix / macOS;
```shell
> time pipx list
```

Windows:
```shell
> Measure-Command { pipx list }
```