### PR TITLE
Change `pipx ensurepath` to mention pipx in shell rc file comment, not add duplicate paths

### DIFF
--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -91,11 +91,11 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
 
 def ensure_pipx_paths(force: bool) -> ExitCode:
     """Returns pipx exit code."""
-    bin_paths = [constants.LOCAL_BIN_DIR]
+    bin_paths = set([constants.LOCAL_BIN_DIR])
 
     pipx_user_bin_path = get_pipx_user_bin_path()
     if pipx_user_bin_path is not None:
-        bin_paths.append(pipx_user_bin_path)
+        bin_paths.add(pipx_user_bin_path)
 
     path_added = False
     need_shell_restart = False

--- a/src/pipx/commands/ensure_path.py
+++ b/src/pipx/commands/ensure_path.py
@@ -61,7 +61,7 @@ def ensure_path(location: Path, *, force: bool) -> Tuple[bool, bool]:
     in_current_path = userpath.in_current_path(location_str)
 
     if force or (not in_current_path and not need_shell_restart):
-        userpath.append(location_str)
+        userpath.append(location_str, "pipx")
         print(
             pipx_wrap(
                 f"Success! Added {location_str} to the PATH environment variable.",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
This modifies `pipx ensurepath` behavior to
1. In the comment in the shell file before the PATH line added, mention `pipx` instead of `userpath`.
2. In the pipx code, use a set instead of a list of directories to add to the system path, to prevent possible duplicate paths added.

## Test plan

This PR, line in `~/.zshrc` after running `pipx ensurepath`:
```
# Created by `pipx` on 2021-02-16 05:48:56
export PATH="$PATH:/Users/mclapp/.local/bin"
```

Current pipx behavior, line in `~/.zshrc` after running `pipx ensurepath`:
```
# Created by `userpath` on 2021-02-16 06:07:15
export PATH="$PATH:/Users/mclapp/.local/bin"
```