### PR TITLE
In `reinstall-all` if shared_lib python is invalid, create it instead of upgrading to avoid error.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ dev
 - Better platform unicode detection to avoid errors and allow showing emojis when possible. (#614)
 - Don't emit show cursor or hide cursor codes if STDERR is not a tty. (#620)
 - Sped up `pipx list` (#624).
-- For `reinstall-all`, fixed bug where missing python executable would cause error.
+- For `reinstall-all`, fixed bug where missing python executable would cause error. (#634)
 
 0.16.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ dev
 - Better platform unicode detection to avoid errors and allow showing emojis when possible. (#614)
 - Don't emit show cursor or hide cursor codes if STDERR is not a tty. (#620)
 - Sped up `pipx list` (#624).
+- For `reinstall-all`, fixed bug where missing python executable would cause error.
 
 0.16.0.0
 

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -84,7 +84,10 @@ def reinstall_all(
     skip: Sequence[str],
 ) -> ExitCode:
     """Returns pipx exit code."""
-    pipx.shared_libs.shared_libs.upgrade(verbose=verbose)
+    if pipx.shared_libs.shared_libs.is_valid:
+        pipx.shared_libs.shared_libs.upgrade(verbose=verbose)
+    else:
+        pipx.shared_libs.shared_libs.create(verbose=verbose)
 
     failed: List[str] = []
     for venv_dir in venv_container.iter_venv_dirs():

--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -84,10 +84,7 @@ def reinstall_all(
     skip: Sequence[str],
 ) -> ExitCode:
     """Returns pipx exit code."""
-    if pipx.shared_libs.shared_libs.is_valid:
-        pipx.shared_libs.shared_libs.upgrade(verbose=verbose)
-    else:
-        pipx.shared_libs.shared_libs.create(verbose=verbose)
+    pipx.shared_libs.shared_libs.upgrade(verbose=verbose)
 
     failed: List[str] = []
     for venv_dir in venv_container.iter_venv_dirs():

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -73,6 +73,10 @@ class _SharedLibs:
     def upgrade(
         self, *, pip_args: Optional[List[str]] = None, verbose: bool = False
     ) -> None:
+        if not self.is_valid:
+            self.create(verbose=verbose)
+            return
+
         # Don't try to upgrade multiple times per run
         if self.has_been_updated_this_run:
             logger.info(f"Already upgraded libraries in {self.root}")


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Closes #633.

#554 introduced a regression where `pipx reinstall-all` would try to upgrade the shared_libs without verifying that they were still valid (i.e. their python link still existed).  If the python did not exist, this would output an error.

This PR first checks if the shared_libs are valid: if they are, it forces an upgrade, if they are not, it instead creates (or re-creates) the shared libs.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
rm ~/.local/pipx/shared/bin/python3
ln -s /path/that/does/not/exist ~/.local/pipx/shared/bin/python3
pipx reinstall-all
```

This PR:
(no error)

pipx 0.16.0.0:
```
Failed to upgrade shared libraries
Traceback (most recent call last):
  File "/usr/local/Cellar/pipx/0.16.0.0/libexec/lib/python3.9/site-packages/pipx/shared_libs.py", line 92, in upgrade
    upgrade_process = run_subprocess(
  File "/usr/local/Cellar/pipx/0.16.0.0/libexec/lib/python3.9/site-packages/pipx/util.py", line 123, in run_subprocess
    completed_process = subprocess.run(
  File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 501, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 947, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 1819, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/mclapp/.local/pipx/shared/bin/python'

[...]
```