### PR TITLE
Allow `pipx run --pypackages` to function again.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ dev
 - Sped up `pipx list` (#624).
 - pip errors no longer stream to the shell when pip fails during a pipx install.  pip's output is now saved to a log file.  In the shell, pipx will tell you the location of the log file and attempt to summarize why pip failed. (#625)
 - For `reinstall-all`, fixed bug where missing python executable would cause error. (#634)
+- Fix regression which prevented pipx from working with pythonloc (and `__pypackages__` folder).
 
 0.16.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ dev
 - Sped up `pipx list` (#624).
 - pip errors no longer stream to the shell when pip fails during a pipx install.  pip's output is now saved to a log file.  In the shell, pipx will tell you the location of the log file and attempt to summarize why pip failed. (#625)
 - For `reinstall-all`, fixed bug where missing python executable would cause error. (#634)
-- Fix regression which prevented pipx from working with pythonloc (and `__pypackages__` folder).
+- Fix regression which prevented pipx from working with pythonloc (and `__pypackages__` folder). (#636)
 
 0.16.0.0
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -99,11 +99,9 @@ def _fix_subprocess_env(env: Dict[str, str]) -> Dict[str, str]:
     # Remove PYTHONPATH because some platforms (macOS with Homebrew) add pipx
     #   directories to it, and can make it appear to venvs as though pipx
     #   dependencies are in the venv path (#233)
-    # Leave in paths enabling feature `pipx run --pypackages` to work (#623)
     # Remove __PYVENV_LAUNCHER__ because it can cause the wrong python binary
     #   to be used (#334)
     env_blocklist = ["PYTHONPATH", "__PYVENV_LAUNCHER__"]
-    env.pop("__PYVENV_LAUNCHER__", None)
     for env_to_remove in env_blocklist:
         env.pop(env_to_remove, None)
 

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -67,7 +67,11 @@ def run_pypackage_bin(bin_path: Path, args: List[str]) -> NoReturn:
         env = dict(os.environ)
         env["PYTHONPATH"] = os.path.pathsep.join(
             [".", str(bin_path.parent.parent)]
-            + os.getenv("PYTHONPATH", "").split(os.path.pathsep)
+            + (
+                os.getenv("PYTHONPATH", "").split(os.path.pathsep)
+                if os.getenv("PYTHONPATH")
+                else []
+            )
         )
         return env
 
@@ -104,11 +108,19 @@ def _fix_subprocess_env(env: Dict[str, str]) -> Dict[str, str]:
     # Remove PYTHONPATH because some platforms (macOS with Homebrew) add pipx
     #   directories to it, and can make it appear to venvs as though pipx
     #   dependencies are in the venv path (#233)
+    # Leave in paths starting with "__pypackages__" to let pipx feature
+    #   `pipx run --pypackages` continue to work (#623)
+    if "PYTHONPATH" in env:
+        print(env["PYTHONPATH"])
+        python_path = env["PYTHONPATH"].split(os.path.pathsep)
+        if python_path[0] == "." and Path(python_path[1]).relative_to("__pypackages__"):
+            env["PYTHONPATH"] = os.path.pathsep.join(python_path[:2])
+        else:
+            env.pop("PYTHONPATH", None)
+    print(env.get("PYTHONPATH"))
     # Remove __PYVENV_LAUNCHER__ because it can cause the wrong python binary
     #   to be used (#334)
-    env_blocklist = ["PYTHONPATH", "__PYVENV_LAUNCHER__"]
-    for env_to_remove in env_blocklist:
-        env.pop(env_to_remove, None)
+    env.pop("__PYVENV_LAUNCHER__", None)
 
     env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
     # Make sure that Python writes output in UTF-8

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -63,19 +63,17 @@ def get_pypackage_bin_path(binary_name: str) -> Path:
 
 
 def run_pypackage_bin(bin_path: Path, args: List[str]) -> NoReturn:
-    def _get_env() -> Dict[str, str]:
-        env = dict(os.environ)
-        env["PYTHONPATH"] = os.path.pathsep.join(
-            [".", str(bin_path.parent.parent)]
-            + (
-                os.getenv("PYTHONPATH", "").split(os.path.pathsep)
-                if os.getenv("PYTHONPATH")
-                else []
-            )
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.path.pathsep.join(
+        [".", str(bin_path.parent.parent)]
+        + (
+            os.getenv("PYTHONPATH", "").split(os.path.pathsep)
+            if os.getenv("PYTHONPATH")
+            else []
         )
-        return env
+    )
 
-    exec_app([str(bin_path.resolve())] + args, env=_get_env())
+    exec_app([str(bin_path.resolve())] + args, env=env)
 
 
 if WINDOWS:
@@ -108,16 +106,13 @@ def _fix_subprocess_env(env: Dict[str, str]) -> Dict[str, str]:
     # Remove PYTHONPATH because some platforms (macOS with Homebrew) add pipx
     #   directories to it, and can make it appear to venvs as though pipx
     #   dependencies are in the venv path (#233)
-    # Leave in paths starting with "__pypackages__" to let pipx feature
-    #   `pipx run --pypackages` continue to work (#623)
+    # Leave in paths enabling feature `pipx run --pypackages` to work (#623)
     if "PYTHONPATH" in env:
-        print(env["PYTHONPATH"])
         python_path = env["PYTHONPATH"].split(os.path.pathsep)
         if python_path[0] == "." and Path(python_path[1]).relative_to("__pypackages__"):
             env["PYTHONPATH"] = os.path.pathsep.join(python_path[:2])
         else:
             env.pop("PYTHONPATH", None)
-    print(env.get("PYTHONPATH"))
     # Remove __PYVENV_LAUNCHER__ because it can cause the wrong python binary
     #   to be used (#334)
     env.pop("__PYVENV_LAUNCHER__", None)

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -109,7 +109,11 @@ def _fix_subprocess_env(env: Dict[str, str]) -> Dict[str, str]:
     # Leave in paths enabling feature `pipx run --pypackages` to work (#623)
     if "PYTHONPATH" in env:
         python_path = env["PYTHONPATH"].split(os.path.pathsep)
-        if python_path[0] == "." and Path(python_path[1]).relative_to("__pypackages__"):
+        if (
+            len(python_path) >= 2
+            and python_path[0] == "."
+            and Path(python_path[1]).relative_to("__pypackages__")
+        ):
             env["PYTHONPATH"] = os.path.pathsep.join(python_path[:2])
         else:
             env.pop("PYTHONPATH", None)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Closes #623 .

Due to a regression with PR #252 in order to fix Issue #233, using pipx with pythonloc (using the local `__pypackages__` folder) stopped working.

To use packages in the local `__pypackages__` folder with `pipx run --pypackages`, pipx adds the appropriate folders to `PYTHONPATH`.  Unfortunately the code from the previous PR removes `PYTHONPATH` before running it, nullifying the effect of pipx's own code.

This PR selectively allows only the two paths added by the pypackages code in pipx to `PYTHONPATH` to remain, removing `PYTHONPATH` or other directories in `PYTHONPATH` otherwise.

The code got a little less clean, but we should support operation of our own features (!)

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running

From report in Issue #623:
```
pipx install piploc
piploc install flask
pipx run --pypackages flask
```

pipx 0.16.0.0 shows error, this PR runs as expected.