### PR TITLE
Naming fixes

### DIFF
--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -156,18 +156,18 @@ def _symlink_package_apps(
             )
 
 
-def get_package_summary(
+def get_venv_summary(
     venv_dir: Path,
     *,
-    package: str = None,
+    package_name: str = None,
     new_install: bool = False,
     include_injected: bool = False,
 ) -> Tuple[str, VenvProblems]:
     venv = Venv(venv_dir)
     python_path = venv.python_path.resolve()
 
-    if package is None:
-        package = venv.main_package_name
+    if package_name is None:
+        package_name = venv.main_package_name
 
     if not python_path.is_file():
         return (
@@ -185,11 +185,11 @@ def get_package_summary(
             VenvProblems(bad_venv_name=True),
         )
 
-    package_metadata = venv.package_metadata[package]
+    package_metadata = venv.package_metadata[package_name]
 
     if package_metadata.package_version is None:
         return (
-            f"   package {red(bold(package))} {red('is not installed')} "
+            f"   package {red(bold(package_name))} {red('is not installed')} "
             f"in the venv {venv_dir.name}",
             VenvProblems(not_installed=True),
         )
@@ -214,7 +214,7 @@ def get_package_summary(
         _get_list_output(
             python_version,
             package_metadata.package_version,
-            package,
+            package_name,
             new_install,
             exposed_binary_names,
             unavailable_binary_names,
@@ -252,7 +252,7 @@ def _get_exposed_app_paths_for_package(
 def _get_list_output(
     python_version: str,
     package_version: str,
-    package: str,
+    package_name: str,
     new_install: bool,
     exposed_binary_names: List[str],
     unavailable_binary_names: List[str],
@@ -260,9 +260,9 @@ def _get_list_output(
     suffix: str = "",
 ) -> str:
     output = []
-    suffix = f" ({bold(shlex.quote(package + suffix))})" if suffix else ""
+    suffix = f" ({bold(shlex.quote(package_name + suffix))})" if suffix else ""
     output.append(
-        f"  {'installed' if new_install else ''} package {bold(shlex.quote(package))}"
+        f"  {'installed' if new_install else ''} package {bold(shlex.quote(package_name))}"
         f" {bold(package_version)}{suffix}, {python_version}"
     )
 
@@ -312,16 +312,16 @@ def package_name_from_spec(
 
 def run_post_install_actions(
     venv: Venv,
-    package: str,
+    package_name: str,
     local_bin_dir: Path,
     venv_dir: Path,
     include_dependencies: bool,
     *,
     force: bool,
 ) -> None:
-    package_metadata = venv.package_metadata[package]
+    package_metadata = venv.package_metadata[package_name]
 
-    display_name = f"{package}{package_metadata.suffix}"
+    display_name = f"{package_name}{package_metadata.suffix}"
 
     if not package_metadata.apps:
         if not package_metadata.apps_of_dependencies:
@@ -369,8 +369,8 @@ def run_post_install_actions(
                 local_bin_dir, app_paths, force=force, suffix=package_metadata.suffix
             )
 
-    package_summary, _ = get_package_summary(
-        venv_dir, package=package, new_install=True
+    package_summary, _ = get_venv_summary(
+        venv_dir, package_name=package_name, new_install=True
     )
     print(package_summary)
     warn_if_not_on_path(local_bin_dir)

--- a/src/pipx/commands/inject.py
+++ b/src/pipx/commands/inject.py
@@ -51,7 +51,7 @@ def inject_dep(
         )
 
     venv.install_package(
-        package=package_name,
+        package_name=package_name,
         package_or_url=package_spec,
         pip_args=pip_args,
         include_dependencies=include_dependencies,

--- a/src/pipx/commands/install.py
+++ b/src/pipx/commands/install.py
@@ -58,7 +58,7 @@ def install(
     try:
         venv.create_venv(venv_args, pip_args)
         venv.install_package(
-            package=package_name,
+            package_name=package_name,
             package_or_url=package_spec,
             pip_args=pip_args,
             include_dependencies=include_dependencies,

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -3,7 +3,7 @@ from typing import Collection
 
 from pipx import constants
 from pipx.colors import bold
-from pipx.commands.common import VenvProblems, get_package_summary
+from pipx.commands.common import VenvProblems, get_venv_summary
 from pipx.constants import EXIT_CODE_LIST_PROBLEM, EXIT_CODE_OK, ExitCode
 from pipx.emojis import sleep
 from pipx.venv import VenvContainer
@@ -23,7 +23,7 @@ def list_packages(venv_container: VenvContainer, include_injected: bool) -> Exit
 
     all_venv_problems = VenvProblems()
     for venv_dir in venv_dirs:
-        package_summary, venv_problems = get_package_summary(
+        package_summary, venv_problems = get_venv_summary(
             venv_dir, include_injected=include_injected
         )
         print(package_summary)

--- a/src/pipx/commands/run.py
+++ b/src/pipx/commands/run.py
@@ -129,14 +129,14 @@ def _download_and_run(
     venv.create_venv(venv_args, pip_args)
 
     if venv.pipx_metadata.main_package.package is not None:
-        package = venv.pipx_metadata.main_package.package
+        package_name = venv.pipx_metadata.main_package.package
     else:
-        package = package_name_from_spec(
+        package_name = package_name_from_spec(
             package_or_url, python, pip_args=pip_args, verbose=verbose
         )
 
     venv.install_package(
-        package=package,
+        package_name=package_name,
         package_or_url=package_or_url,
         pip_args=pip_args,
         include_dependencies=False,

--- a/src/pipx/commands/upgrade.py
+++ b/src/pipx/commands/upgrade.py
@@ -16,23 +16,25 @@ logger = logging.getLogger(__name__)
 
 def _upgrade_package(
     venv: Venv,
-    package: str,
+    package_name: str,
     pip_args: List[str],
     is_main_package: bool,
     force: bool,
     upgrading_all: bool,
 ) -> int:
     """Returns 1 if package version changed, 0 if same version"""
-    package_metadata = venv.package_metadata[package]
+    package_metadata = venv.package_metadata[package_name]
 
     if package_metadata.package_or_url is None:
-        raise PipxError(f"Internal Error: package {package} has corrupt pipx metadata.")
+        raise PipxError(
+            f"Internal Error: package {package_name} has corrupt pipx metadata."
+        )
 
     package_or_url = parse_specifier_for_upgrade(package_metadata.package_or_url)
     old_version = package_metadata.package_version
 
     venv.upgrade_package(
-        package,
+        package_name,
         package_or_url,
         pip_args,
         include_dependencies=package_metadata.include_dependencies,
@@ -41,7 +43,7 @@ def _upgrade_package(
         suffix=package_metadata.suffix,
     )
 
-    package_metadata = venv.package_metadata[package]
+    package_metadata = venv.package_metadata[package_name]
 
     display_name = f"{package_metadata.package}{package_metadata.suffix}"
     new_version = package_metadata.package_version
@@ -121,10 +123,10 @@ def _upgrade_venv(
 
     versions_updated = 0
 
-    package = venv.main_package_name
+    package_name = venv.main_package_name
     versions_updated += _upgrade_package(
         venv,
-        package,
+        package_name,
         pip_args,
         is_main_package=True,
         force=force,
@@ -132,12 +134,12 @@ def _upgrade_venv(
     )
 
     if include_injected:
-        for package in venv.package_metadata:
-            if package == venv.main_package_name:
+        for package_name in venv.package_metadata:
+            if package_name == venv.main_package_name:
                 continue
             versions_updated += _upgrade_package(
                 venv,
-                package,
+                package_name,
                 pip_args,
                 is_main_package=False,
                 force=force,

--- a/src/pipx/package_specifier.py
+++ b/src/pipx/package_specifier.py
@@ -214,24 +214,24 @@ def valid_pypi_name(package_spec: str) -> Optional[str]:
     return canonicalize_name(package_req.name)
 
 
-def fix_package_name(package_or_url: str, package: str) -> str:
+def fix_package_name(package_or_url: str, package_name: str) -> str:
     try:
         package_req = Requirement(package_or_url)
     except InvalidRequirement:
         # not a valid PEP508 package specification
         return package_or_url
 
-    if canonicalize_name(package_req.name) != canonicalize_name(package):
+    if canonicalize_name(package_req.name) != canonicalize_name(package_name):
         logger.warning(
             pipx_wrap(
                 f"""
                 {hazard}  Name supplied in package specifier was
-                {package_req.name!r} but package found has name {package!r}.
-                Using {package!r}.
+                {package_req.name!r} but package found has name {package_name!r}.
+                Using {package_name!r}.
                 """,
                 subsequent_indent=" " * 4,
             )
         )
-    package_req.name = package
+    package_req.name = package_name
 
     return str(package_req)


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
When working on other branches I noticed some areas of the code that could be made clearer through renaming.  Adding them in their own PR to avoid cluttering future PRs.

Renaming clarifications:
* `package` -> `package_name`
* `get_package_summary` -> `get_venv_summary` (returns info about the entire venv, not just one package)

Also, mypy seemed to occasionally actually crash due to the `RelevantSearch` definition in `util.py`.  This was either because of its use of existing keywords (`re`) or because it was a class defined inside a function, or possibly both together.  I've broken the class definition of `RelevantSearch` out to the top-level of the module and avoided existing keywords.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
