### PR TITLE
Ensure log file encoding is utf-8

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 dev
 
-- Make sure log files are utf-8 encoded to preven Unicode encoding errors from occurring with emojis.
+- Make sure log files are utf-8 encoded to preven Unicode encoding errors from occurring with emojis. (#646)
 
 0.16.1.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- Make sure log files are utf-8 encoded to preven Unicode encoding errors from occurring with emojis.
 
 0.16.1.0
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -690,6 +690,7 @@ def setup_logging(verbose: bool) -> None:
                 "class": "logging.FileHandler",
                 "formatter": "file",
                 "filename": str(pipx.constants.pipx_log_file),
+                "encoding": "utf-8",
                 "level": "DEBUG",
             },
         },


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Makes sure that `utf-8` encoding is used for log files, to prevent `UnicodeEncodeError`s from occurring with emoji.

This was a problem on Windows with Python < 3.9.

Closes #645 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx install -e pycowsay
```
This PR in Windows Powershell Python3.7:
```
> pipx install -e pycowsay
⚠️  Ignoring --editable install option. pipx disallows it for anything but a local path, to avoid having to create a
    new src/ directory.
  installed package pycowsay 0.0.0.1, Python 3.7.9
  These apps are now globally available
    - pycowsay.exe
done! ✨ 🌟 ✨
```
pipx 0.16.1.0 in Windows Powershell Python 3.7
```
> pipx install -e pycowsay
    new src/ directory.
--- Logging error ---
Traceback (most recent call last):
  File "C:\Program Files\Python37\lib\logging\__init__.py", line 1028, in emit
    stream.write(msg + self.terminator)
  File "C:\Program Files\Python37\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 46-47: character maps to <undefined>
Call stack:
  File "C:\Users\mclapp\git\pipx\venv3.7\Scripts\pipx-script.py", line 33, in <module>
    sys.exit(load_entry_point('pipx', 'console_scripts', 'pipx')())
  File "c:\users\mclapp\git\pipx\src\pipx\main.py", line 759, in cli
    return run_pipx_command(parsed_pipx_args)
  File "c:\users\mclapp\git\pipx\src\pipx\main.py", line 202, in run_pipx_command
    suffix=args.suffix,
  File "c:\users\mclapp\git\pipx\src\pipx\commands\install.py", line 67, in install
    suffix=suffix,
  File "c:\users\mclapp\git\pipx\src\pipx\venv.py", line 224, in install_package
    package_or_url, pip_args
  File "c:\users\mclapp\git\pipx\src\pipx\package_specifier.py", line 154, in parse_specifier_for_install
    subsequent_indent=" " * 4,
Message: '⚠️  Ignoring --editable install option. pipx disallows it for anything but a local path, to avoid having to create a\n    new src/ directory.'
Arguments: ()
  installed package pycowsay 0.0.0.1, Python 3.7.9
  These apps are now globally available
    - pycowsay.exe
done! ✨ 🌟 ✨
```