### PR TITLE
Prevent pipx from erroneously listing other apps installed outside of pipx

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 dev
 
 - Make sure log files are utf-8 encoded to preven Unicode encoding errors from occurring with emojis. (#646)
+- Fixed issue which made pipx incorrectly list apps as part of a venv when they were not installed by pipx.
 
 0.16.1.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 dev
 
 - Make sure log files are utf-8 encoded to preven Unicode encoding errors from occurring with emojis. (#646)
-- Fixed issue which made pipx incorrectly list apps as part of a venv when they were not installed by pipx.
+- Fixed issue which made pipx incorrectly list apps as part of a venv when they were not installed by pipx. (#650)
 
 0.16.1.0
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -78,7 +78,6 @@ def _can_symlink(local_bin_dir: Path) -> bool:
                 _can_symlink_cache[local_bin_dir] = True
             except (OSError, NotImplementedError):
                 _can_symlink_cache[local_bin_dir] = False
-
     return _can_symlink_cache[local_bin_dir]
 
 
@@ -194,7 +193,10 @@ def get_venv_summary(
             VenvProblems(not_installed=True),
         )
 
-    apps = package_metadata.apps + package_metadata.apps_of_dependencies
+    apps = package_metadata.apps
+    if package_metadata.include_dependencies:
+        apps += package_metadata.apps_of_dependencies
+
     exposed_app_paths = _get_exposed_app_paths_for_package(
         venv.bin_path, apps, constants.LOCAL_BIN_DIR
     )
@@ -238,7 +240,7 @@ def _get_exposed_app_paths_for_package(
             # Windows, we use a less strict check if we don't have a symlink.
             if _can_symlink(local_bin_dir) and b.is_symlink():
                 is_same_file = b.resolve().parent.samefile(venv_bin_path)
-            else:
+            elif not _can_symlink(local_bin_dir):
                 is_same_file = b.name in package_binary_names
 
             if is_same_file:

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -78,6 +78,7 @@ def _can_symlink(local_bin_dir: Path) -> bool:
                 _can_symlink_cache[local_bin_dir] = True
             except (OSError, NotImplementedError):
                 _can_symlink_cache[local_bin_dir] = False
+
     return _can_symlink_cache[local_bin_dir]
 
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Closes #564, #548.

This fixes some code goofs that allowed pipx to proclaim that pre-existing binaries in `~/.local/bin` were part of a pipx install when they were in fact installed previously using `pip install --user`.

First fix is not to search for apps of dependencies if we didn't include dependencies on install.

Second fix is to fall back to checking non-symlinks only on non-symlink systems.  Previously we would check non-symlinks always if we encountered a file that was not a symlink, which was not the intent of the if statement.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running:
```
pip install --user pipx
pip install --user keyring
pipx install twine
```

pipx should only list the app 'twine' associated with venv 'twine'.  'keyring' is a dependency and should not be listed.

This PR:
```
> pipx install twine
  installed package twine 3.4.1, Python 3.9.0
  These apps are now globally available
    - twine
done! ✨ 🌟 ✨
> pipx list
venvs are in /home/mclapp/.local/pipx/venvs
apps are exposed on your $PATH at /home/mclapp/.local/bin
   package twine 3.4.1, Python 3.9.0
    - twine
```

pipx 0.16.1.0
```shell
> pipx install twine  
  installed package twine 3.4.1, Python 3.9.0
  These apps are now globally available
    - keyring
    - twine
done! ✨ 🌟 ✨
> pipx list
venvs are in /home/mclapp/.local/pipx/venvs
apps are exposed on your $PATH at /home/mclapp/.local/bin
   package twine 3.4.1, Python 3.9.0
    - keyring
    - twine
```