### PR TITLE
Fix suffixed venv uninstall, and fix suffixed venv install summary.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 dev
 
 - Make sure log files are utf-8 encoded to preven Unicode encoding errors from occurring with emojis. (#646)
+- Fixed bugs with suffixed-venvs on Windows.  Now properly summarizes install, and actually uninstalls associated binaries for suffixed-venvs.
 
 0.16.1.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 dev
 
 - Make sure log files are utf-8 encoded to preven Unicode encoding errors from occurring with emojis. (#646)
-- Fixed bugs with suffixed-venvs on Windows.  Now properly summarizes install, and actually uninstalls associated binaries for suffixed-venvs.
+- Fixed bugs with suffixed-venvs on Windows.  Now properly summarizes install, and actually uninstalls associated binaries for suffixed-venvs. (#653)
 
 0.16.1.0
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -196,7 +196,9 @@ def get_venv_summary(
 
     apps = package_metadata.apps + package_metadata.apps_of_dependencies
     exposed_app_paths = _get_exposed_app_paths_for_package(
-        venv.bin_path, apps, constants.LOCAL_BIN_DIR
+        venv.bin_path,
+        [add_suffix(app, package_metadata.suffix) for app in apps],
+        constants.LOCAL_BIN_DIR,
     )
     exposed_binary_names = sorted(p.name for p in exposed_app_paths)
     unavailable_binary_names = sorted(

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -37,7 +37,7 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
 
     suffix = ""
 
-    if venv.pipx_metadata.main_package.package is not None:
+    if venv.pipx_metadata.main_package is not None:
         app_paths: List[Path] = []
         for viewed_package in venv.package_metadata.values():
             app_paths += viewed_package.app_paths
@@ -49,7 +49,7 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
         if venv.python_path.is_file():
             # has a valid python interpreter and can get metadata about the package
             # In pre-metadata-pipx venv_dir.name is name of main package
-            metadata = venv.get_venv_metadata_for_package(venv_dir.name, set())
+            metadata = venv.get_venv_metadata_for_package(venv_dir.name)
             app_paths = metadata.app_paths
             for dep_paths in metadata.app_paths_of_dependencies.values():
                 app_paths += dep_paths

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -37,7 +37,7 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
 
     suffix = ""
 
-    if venv.pipx_metadata.main_package is not None:
+    if venv.pipx_metadata.main_package.package is not None:
         app_paths: List[Path] = []
         for viewed_package in venv.package_metadata.values():
             app_paths += viewed_package.app_paths
@@ -49,7 +49,7 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
         if venv.python_path.is_file():
             # has a valid python interpreter and can get metadata about the package
             # In pre-metadata-pipx venv_dir.name is name of main package
-            metadata = venv.get_venv_metadata_for_package(venv_dir.name)
+            metadata = venv.get_venv_metadata_for_package(venv_dir.name, set())
             app_paths = metadata.app_paths
             for dep_paths in metadata.app_paths_of_dependencies.values():
                 app_paths += dep_paths

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -35,12 +35,15 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
 
     venv = Venv(venv_dir, verbose=verbose)
 
+    suffix = ""
+
     if venv.pipx_metadata.main_package is not None:
         app_paths: List[Path] = []
         for viewed_package in venv.package_metadata.values():
             app_paths += viewed_package.app_paths
             for dep_paths in viewed_package.app_paths_of_dependencies.values():
                 app_paths += dep_paths
+        suffix = venv.pipx_metadata.main_package.suffix
     else:
         # fallback if not metadata from pipx_metadata.json
         if venv.python_path.is_file():
@@ -69,7 +72,8 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
     for filepath in local_bin_dir.iterdir():
         if WINDOWS:
             for b in app_paths:
-                if filepath.exists() and filepath.name == b.name:
+                bin_name = b.stem + suffix + b.suffix
+                if filepath.exists() and filepath.name == bin_name:
                     filepath.unlink()
         else:
             symlink = filepath

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -53,7 +53,9 @@ def test_uninstall_suffix(pipx_temp_env, capsys):
 @pytest.mark.parametrize("metadata_version", ["0.1"])
 def test_uninstall_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
     name = "pbr"
-    suffix = "_a"
+    # legacy uninstall on Windows only works with "canonical name characters"
+    #   in suffix
+    suffix = "-a"
     executable_path = constants.LOCAL_BIN_DIR / app_name(f"{name}{suffix}")
 
     assert not run_pipx_cli(["install", "pbr", f"--suffix={suffix}"])

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,6 +1,8 @@
+import sys
+
 import pytest  # type: ignore
 
-from helpers import mock_legacy_venv, run_pipx_cli
+from helpers import app_name, mock_legacy_venv, run_pipx_cli
 from package_info import PKG
 from pipx import constants, util
 
@@ -22,35 +24,46 @@ def test_uninstall_circular_deps(pipx_temp_env, capsys):
 
 @pytest.mark.parametrize("metadata_version", [None, "0.1"])
 def test_uninstall_legacy_venv(pipx_temp_env, capsys, metadata_version):
+    executable_path = constants.LOCAL_BIN_DIR / app_name("pycowsay")
+
     assert not run_pipx_cli(["install", "pycowsay"])
+    assert executable_path.exists()
+
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)
     assert not run_pipx_cli(["uninstall", "pycowsay"])
+    # Also use is_symlink to check for broken symlink.
+    #   exists() returns False if symlink exists but target doesn't exist
+    assert not executable_path.exists() and not executable_path.is_symlink()
 
 
 def test_uninstall_suffix(pipx_temp_env, capsys):
     name = "pbr"
     suffix = "_a"
-    executable = f"{name}{suffix}{'.exe' if constants.WINDOWS else ''}"
+    executable_path = constants.LOCAL_BIN_DIR / app_name(f"{name}{suffix}")
 
     assert not run_pipx_cli(["install", "pbr", f"--suffix={suffix}"])
-    assert (constants.LOCAL_BIN_DIR / executable).exists()
+    assert executable_path.exists()
 
     assert not run_pipx_cli(["uninstall", f"{name}{suffix}"])
-    assert not (constants.LOCAL_BIN_DIR / executable).exists()
+    # Also use is_symlink to check for broken symlink.
+    #   exists() returns False if symlink exists but target doesn't exist
+    assert not executable_path.exists() and not executable_path.is_symlink()
 
 
 @pytest.mark.parametrize("metadata_version", ["0.1"])
 def test_uninstall_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
     name = "pbr"
     suffix = "_a"
-    executable = f"{name}{suffix}{'.exe' if constants.WINDOWS else ''}"
+    executable_path = constants.LOCAL_BIN_DIR / app_name(f"{name}{suffix}")
 
     assert not run_pipx_cli(["install", "pbr", f"--suffix={suffix}"])
     mock_legacy_venv(f"{name}{suffix}", metadata_version=metadata_version)
-    assert (constants.LOCAL_BIN_DIR / executable).exists()
+    assert executable_path.exists()
 
     assert not run_pipx_cli(["uninstall", f"{name}{suffix}"])
-    assert not (constants.LOCAL_BIN_DIR / executable).exists()
+    # Also use is_symlink to check for broken symlink.
+    #   exists() returns False if symlink exists but target doesn't exist
+    assert not executable_path.exists() and not executable_path.is_symlink()
 
 
 def test_uninstall_with_missing_interpreter(pipx_temp_env, capsys):
@@ -62,3 +75,24 @@ def test_uninstall_with_missing_interpreter(pipx_temp_env, capsys):
     assert not python_path.is_file()
 
     assert not run_pipx_cli(["uninstall", "pycowsay"])
+
+
+@pytest.mark.parametrize("metadata_version", [None, "0.1"])
+def test_uninstall_with_missing_interpreter_legacy_venv(
+    pipx_temp_env, capsys, metadata_version
+):
+    executable_path = constants.LOCAL_BIN_DIR / app_name("pycowsay")
+
+    assert not run_pipx_cli(["install", "pycowsay"])
+    assert executable_path.exists()
+
+    mock_legacy_venv("pycowsay", metadata_version=metadata_version)
+    _, venv_python_path = util.get_venv_paths(constants.PIPX_LOCAL_VENVS / "pycowsay")
+    venv_python_path.unlink()
+
+    assert not run_pipx_cli(["uninstall", "pycowsay"])
+    # On Windows we cannot remove app binaries if no metadata and no python
+    if not sys.platform.startswith("win"):
+        # Also use is_symlink to check for broken symlink.
+        #   exists() returns False if symlink exists but target doesn't exist
+        assert not executable_path.exists() and not executable_path.is_symlink()


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Closes #652 .

On non-symlinked filesystems like typical Windows filesystems, pipx didn't actually delete apps in the local binary dir associated with a suffixed venv.  This fixes that.

Also, when summarizing an install, on a non-symlink filesystem (Windows) we would normally not properly handle the installed binaries, reporting each app with `(symlink missing or pointing to unexpected location)`

Also updated tests to test the functionality that we now do correctly.

## Test plan

**On Windows!**

### Install
This PR:
```shell
> pipx install pycowsay --suffix _a
done!
creating virtual environment...
installing pycowsay...
  installed package pycowsay 0.0.0.1 (pycowsay_a), Python 3.9.1
  These apps are now globally available
    - pycowsay_a.exe
```

pipx 0.16.1.0
```shell
> pipx install pycowsay --suffix _a
  Overwriting file C:\Users\mclapp\.local\bin\pycowsay_a.exe with C:\Users\mclapp\.local\pipx\venvs\pycowsay-a\Scripts\pycowsay.exe
done!
creating virtual environment...
installing pycowsay...
  installed package pycowsay 0.0.0.1 (pycowsay_a), Python 3.9.1
    - pycowsay_a.exe (symlink missing or pointing to unexpected location)

```

### Uninstall
This PR:
```shell
> pipx uninstall pycowsay_a
uninstalled pycowsay_a!
> ls ~/.local/bin/pycowsay_a.exe
ls: cannot access '/c/Users/mclapp/.local/bin/pycowsay_a.exe': No such file or directory
```

pipx 0.16.1.0
```shell
> pipx uninstall pycowsay_a
uninstalled pycowsay_a!
> ls ~/.local/bin/pycowsay_a.exe
/c/Users/mclapp/.local/bin/pycowsay_a.exe*

```