### PR TITLE
Add more types to codebase, update pre-commit mypy options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,4 @@ repos:
   rev: v0.800
   hooks:
   - id: mypy
+    args: ['--strict-equality','--no-implicit-optional','--warn-unused-ignores']

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -13,7 +13,7 @@ import textwrap
 import time
 import urllib.parse
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Callable, Dict, List
 
 import argcomplete  # type: ignore
 from packaging.utils import canonicalize_name
@@ -30,6 +30,8 @@ from pipx.venv import VenvContainer
 from pipx.version import __version__
 
 logger = logging.getLogger(__name__)
+
+VenvCompleter = Callable[[str], List[str]]
 
 
 def print_version() -> None:
@@ -115,7 +117,7 @@ class InstalledVenvsCompleter:
     def __init__(self, venv_container: VenvContainer) -> None:
         self.packages = [str(p.name) for p in sorted(venv_container.iter_venv_dirs())]
 
-    def use(self, prefix: str, **kwargs) -> List[str]:
+    def use(self, prefix: str, **kwargs: Any) -> List[str]:
         return [
             f"{prefix}{x[len(prefix):]}"
             for x in self.packages
@@ -291,7 +293,7 @@ def add_include_dependencies(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _add_install(subparsers) -> None:
+def _add_install(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser(
         "install",
         help="Install a package",
@@ -326,7 +328,7 @@ def _add_install(subparsers) -> None:
     add_pip_venv_args(p)
 
 
-def _add_inject(subparsers, venv_completer) -> None:
+def _add_inject(subparsers, venv_completer: VenvCompleter) -> None:
     p = subparsers.add_parser(
         "inject",
         help="Install packages into an existing Virtual Environment",
@@ -357,7 +359,7 @@ def _add_inject(subparsers, venv_completer) -> None:
     p.add_argument("--verbose", action="store_true")
 
 
-def _add_upgrade(subparsers, venv_completer) -> None:
+def _add_upgrade(subparsers, venv_completer: VenvCompleter) -> None:
     p = subparsers.add_parser(
         "upgrade",
         help="Upgrade a package",
@@ -379,7 +381,7 @@ def _add_upgrade(subparsers, venv_completer) -> None:
     p.add_argument("--verbose", action="store_true")
 
 
-def _add_upgrade_all(subparsers) -> None:
+def _add_upgrade_all(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser(
         "upgrade-all",
         help="Upgrade all packages. Runs `pip install -U <pkgname>` for each package.",
@@ -400,7 +402,7 @@ def _add_upgrade_all(subparsers) -> None:
     p.add_argument("--verbose", action="store_true")
 
 
-def _add_uninstall(subparsers, venv_completer) -> None:
+def _add_uninstall(subparsers, venv_completer: VenvCompleter) -> None:
     p = subparsers.add_parser(
         "uninstall",
         help="Uninstall a package",
@@ -410,7 +412,7 @@ def _add_uninstall(subparsers, venv_completer) -> None:
     p.add_argument("--verbose", action="store_true")
 
 
-def _add_uninstall_all(subparsers) -> None:
+def _add_uninstall_all(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser(
         "uninstall-all",
         help="Uninstall all packages",
@@ -419,7 +421,7 @@ def _add_uninstall_all(subparsers) -> None:
     p.add_argument("--verbose", action="store_true")
 
 
-def _add_reinstall(subparsers, venv_completer) -> None:
+def _add_reinstall(subparsers, venv_completer: VenvCompleter) -> None:
     p = subparsers.add_parser(
         "reinstall",
         formatter_class=LineWrapRawTextHelpFormatter,
@@ -446,7 +448,7 @@ def _add_reinstall(subparsers, venv_completer) -> None:
     p.add_argument("--verbose", action="store_true")
 
 
-def _add_reinstall_all(subparsers) -> None:
+def _add_reinstall_all(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser(
         "reinstall-all",
         formatter_class=LineWrapRawTextHelpFormatter,
@@ -475,7 +477,7 @@ def _add_reinstall_all(subparsers) -> None:
     p.add_argument("--verbose", action="store_true")
 
 
-def _add_list(subparsers) -> None:
+def _add_list(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser(
         "list",
         help="List installed packages",
@@ -489,7 +491,7 @@ def _add_list(subparsers) -> None:
     p.add_argument("--verbose", action="store_true")
 
 
-def _add_run(subparsers) -> None:
+def _add_run(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser(
         "run",
         formatter_class=LineWrapRawTextHelpFormatter,
@@ -546,7 +548,7 @@ def _add_run(subparsers) -> None:
     p.usage = re.sub(r"\.\.\.", "app ...", p.usage)
 
 
-def _add_runpip(subparsers, venv_completer) -> None:
+def _add_runpip(subparsers, venv_completer: VenvCompleter) -> None:
     p = subparsers.add_parser(
         "runpip",
         help="Run pip in an existing pipx-managed Virtual Environment",
@@ -565,7 +567,7 @@ def _add_runpip(subparsers, venv_completer) -> None:
     p.add_argument("--verbose", action="store_true")
 
 
-def _add_ensurepath(subparsers) -> None:
+def _add_ensurepath(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser(
         "ensurepath",
         help=(

--- a/src/pipx/pipx_metadata_file.py
+++ b/src/pipx/pipx_metadata_file.py
@@ -13,7 +13,7 @@ PIPX_INFO_FILENAME = "pipx_metadata.json"
 
 
 class JsonEncoderHandlesPath(json.JSONEncoder):
-    def default(self, obj):
+    def default(self, obj: Any) -> Any:
         # only handles what json.JSONEncoder doesn't understand by default
         if isinstance(obj, Path):
             return {"__type__": "Path", "__Path__": str(obj)}

--- a/src/pipx/util.py
+++ b/src/pipx/util.py
@@ -125,7 +125,7 @@ def run_subprocess(
     log_cmd_str: Optional[str] = None,
     log_stdout: bool = True,
     log_stderr: bool = True,
-) -> subprocess.CompletedProcess:
+) -> "subprocess.CompletedProcess[str]":
     """Run arbitrary command as subprocess, capturing stderr and stout"""
     env = dict(os.environ)
     env = _fix_subprocess_env(env)
@@ -154,7 +154,7 @@ def run_subprocess(
 
 
 def subprocess_post_check(
-    completed_process: subprocess.CompletedProcess, raise_error: bool = True
+    completed_process: "subprocess.CompletedProcess[str]", raise_error: bool = True
 ) -> None:
     if completed_process.returncode:
         if completed_process.stdout is not None:
@@ -291,7 +291,7 @@ def analyze_pip_output(pip_stdout: str, pip_stderr: str) -> None:
 
 
 def subprocess_post_check_handle_pip_error(
-    completed_process: subprocess.CompletedProcess,
+    completed_process: "subprocess.CompletedProcess[str]",
 ) -> None:
     if completed_process.returncode:
         logger.info(f"{' '.join(completed_process.args)!r} failed")

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -427,7 +427,7 @@ class Venv:
             suffix=suffix,
         )
 
-    def _run_pip(self, cmd: List[str]) -> CompletedProcess:
+    def _run_pip(self, cmd: List[str]) -> "CompletedProcess[str]":
         cmd = [str(self.python_path), "-m", "pip"] + cmd
         if not self.verbose:
             cmd.append("-q")


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
This adds more types to more successfully satisfy `mypy --strict`.  It also brings the mypy options in `pre-commit-config.yml` in sync with the mypy options in `noxfile.py`.

Using string literal types is a useful way to take advantage of some parametric types without breaking previous python versions runtimes.  (e.g. `"Callable[str]"`)

I used the underscore-marked private object `argparse._SubParsersAction` to type some functions.  I have seen other projects use the same type, so I decided it was probably ok.

Unfortunately, `argcomplete` is untyped and does tricks to the argparse objects that are not type-announced, so I couldn't find a way to properly type a few subparser objects without extensive gymnastics, so I let them be.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
