### PR TITLE
Fix buggy error handling.

### DIFF
--- a/src/pipx/commands/reinstall.py
+++ b/src/pipx/commands/reinstall.py
@@ -100,8 +100,9 @@ def reinstall_all(
         except PipxError as e:
             print(e, file=sys.stderr)
             failed.append(venv_dir.name)
-        if package_exit != 0:
-            failed.append(venv_dir.name)
+        else:
+            if package_exit != 0:
+                failed.append(venv_dir.name)
     if len(failed) > 0:
         raise PipxError(
             f"The following package(s) failed to reinstall: {', '.join(failed)}"


### PR DESCRIPTION
Fixes this problem:
```
Traceback (most recent call last):
  File "/usr/bin/pipx", line 33, in <module>
    sys.exit(load_entry_point('pipx==0.16.0.0', 'console_scripts', 'pipx')())
  File "/usr/lib/python3.9/site-packages/pipx/main.py", line 752, in cli
    return run_pipx_command(parsed_pipx_args)
  File "/usr/lib/python3.9/site-packages/pipx/main.py", line 245, in run_pipx_command
    return commands.reinstall_all(
  File "/usr/lib/python3.9/site-packages/pipx/commands/reinstall.py", line 103, in reinstall_all
    if package_exit != 0:
UnboundLocalError: local variable 'package_exit' referenced before assignment
```

