### PR TITLE
Lint fix and upgrades

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,4 @@ repos:
   rev: v0.812
   hooks:
   - id: mypy
-    args: ['--ignore-missing-imports', '--strict-equality','--no-implicit-optional','--warn-unused-ignores']
+    args: ['--ignore-missing-imports', '--strict-equality','--no-implicit-optional']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,12 @@ repos:
     additional_dependencies: [
         'flake8-bugbear==20.11.1'
     ]
-# must include --ignore-missing-imports for mypy.  It is included by default
-#   if no arguments are supplied, but we must supply it ourselves since we
-#   specify args
+# mypy args:
+#   must include --ignore-missing-imports for mypy.  It is included by default
+#     if no arguments are supplied, but we must supply it ourselves since we
+#     specify args
+#   cannot use --warn-unused-ignores because it conflicts with
+#     --ignore-missing-imports
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.812
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   #- id: trailing-whitespace
   #- id: check-yaml
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.7.0
+  rev: 5.8.0
   hooks:
   - id: isort
     args: ['--profile','black']
@@ -22,14 +22,14 @@ repos:
   hooks:
   - id: black
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
+  rev: 3.9.0
   hooks:
   - id: flake8
     additional_dependencies: [
         'flake8-bugbear==20.11.1'
     ]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.800
+  rev: v0.812
   hooks:
   - id: mypy
     args: ['--strict-equality','--no-implicit-optional','--warn-unused-ignores']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,11 @@ repos:
     additional_dependencies: [
         'flake8-bugbear==20.11.1'
     ]
+# must include --ignore-missing-imports for mypy.  It is included by default
+#   if no arguments are supplied, but we must supply it ourselves since we
+#   specify args
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.812
   hooks:
   - id: mypy
-    args: ['--strict-equality','--no-implicit-optional','--warn-unused-ignores']
+    args: ['--ignore-missing-imports', '--strict-equality','--no-implicit-optional','--warn-unused-ignores']

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,12 +9,12 @@ PYTHON_DEFAULT_VERSION = "3.9"
 DOC_DEPENDENCIES = [".", "jinja2", "mkdocs", "mkdocs-material"]
 LINT_DEPENDENCIES = [
     "black==19.10b0",
-    "flake8",
-    "flake8-bugbear",
-    "mypy",
-    "check-manifest",
+    "flake8==3.9.0",
+    "flake8-bugbear==21.3.2",
+    "mypy==0.812",
+    "check-manifest==0.46",
     "packaging>=20.0",
-    "isort",
+    "isort==5.8.0",
 ]
 # Packages whose dependencies need an intact system PATH to compile
 # pytest setup clears PATH.  So pre-build some wheels to the pip cache.

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import pytest  # type: ignore
+import pytest
 
 from pipx.package_specifier import (
     fix_package_name,
@@ -99,7 +99,7 @@ def test_fix_package_name(package_spec_in, package_name, package_spec_out):
             "my-project[cli]@ git+ssh://git@bitbucket.org/my-company/myproject.git",
             True,
         ),
-        ("path/doesnt/exist", "non-existent-path", False,),
+        ("path/doesnt/exist", "non-existent-path", False),
         (
             "https:/github.com/ambv/black/archive/18.9b0.zip",
             "URL-syntax-error-slash",
@@ -168,7 +168,7 @@ def test_parse_specifier_for_metadata(
             "my-project[cli]@ git+ssh://git@bitbucket.org/my-company/myproject.git",
             True,
         ),
-        ("path/doesnt/exist", "non-existent-path", False,),
+        ("path/doesnt/exist", "non-existent-path", False),
         (
             "https:/github.com/ambv/black/archive/18.9b0.zip",
             "URL-syntax-error-slash",
@@ -193,7 +193,7 @@ def test_parse_specifier_for_upgrade(
     "package_spec_in,pip_args_in,package_spec_expected,pip_args_expected,warning_str",
     [
         ('pipx==0.15.0;python_version>="3.6"', [], "pipx==0.15.0", [], None),
-        ("pipx==0.15.0", ["--editable"], "pipx==0.15.0", [], "Ignoring --editable",),
+        ("pipx==0.15.0", ["--editable"], "pipx==0.15.0", [], "Ignoring --editable"),
         (
             'pipx==0.15.0;python_version>="3.6"',
             [],

--- a/tests/test_package_specifier.py
+++ b/tests/test_package_specifier.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import pytest
+import pytest  # type: ignore
 
 from pipx.package_specifier import (
     fix_package_name,


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
Something strange was going on where the mypy hook in our pre-commit setup was having problems that weren't real, and not present in the mypy in nox lint or CI lint.

I finally traced it back to the fact that the pre-commit mypy plugin needs to use `--ignore-missing-imports`, and it uses that by default **unless** you specify `args` for mypy in `.pre-commit.yaml`.  Recently I added args to the mypy section of `.pre-commit.yaml` which ended up eliminating that default switch.  So the main benefit of this PR is to add back an explicit `--ignore-missing-imports` switch to the pre-commit mypy args to make up for the fact that it isn't being added by default anymore.

I had to remove `--warn-unused-ignores` from the pre-commit mypy hook because it is incompatible with `--ignore-missing-imports`.

I also upgraded all the versions of the pre-commit lint tools.

I specified the same versions of the lint tools and locked them down for our nox setup in `noxfile.py`.  They used to be unversioned.  Hopefully this makes our lint setup more deterministic (especially if there is an existing `.nox` venv that might not get upgraded for a particular user.)

As a random extra I fixed some formatting issues (unnecessary trailing commas) in `tests/test_package_specifier.py`

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
