### PR TITLE
Only log shared libs' age once per run

### DIFF
--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -770,7 +770,7 @@ def cli() -> ExitCode:
         logger.debug("Uncaught Exception:", exc_info=True)
         raise
     finally:
-        logger.info("pipx finished.")
+        logger.debug("pipx finished.")
         show_cursor()
 
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -770,6 +770,7 @@ def cli() -> ExitCode:
         logger.debug("Uncaught Exception:", exc_info=True)
         raise
     finally:
+        logger.info("pipx finished.")
         show_cursor()
 
 

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -30,7 +30,7 @@ class _SharedLibs:
         # i.e. python_path is ~/.local/pipx/shared/python
         self._site_packages: Optional[Path] = None
         self.has_been_updated_this_run = False
-        self.has_been_checked_this_run = False
+        self.has_been_logged_this_run = False
 
     @property
     def site_packages(self) -> Path:
@@ -57,19 +57,20 @@ class _SharedLibs:
 
     @property
     def needs_upgrade(self) -> bool:
-        if self.has_been_updated_this_run or self.has_been_checked_this_run:
+        if self.has_been_updated_this_run:
             return False
-        self.has_been_checked_this_run = True
 
         if not self.pip_path.is_file():
             return True
 
         now = time.time()
         time_since_last_update_sec = now - self.pip_path.stat().st_mtime
-        logger.info(
-            f"Time since last upgrade of shared libs, in seconds: {time_since_last_update_sec:.0f}. "
-            f"Upgrade will be run by pipx if greater than {SHARED_LIBS_MAX_AGE_SEC:.0f}."
-        )
+        if not self.has_been_logged_this_run:
+            logger.info(
+                f"Time since last upgrade of shared libs, in seconds: {time_since_last_update_sec:.0f}. "
+                f"Upgrade will be run by pipx if greater than {SHARED_LIBS_MAX_AGE_SEC:.0f}."
+            )
+            self.has_been_logged_this_run = True
         return time_since_last_update_sec > SHARED_LIBS_MAX_AGE_SEC
 
     def upgrade(

--- a/src/pipx/shared_libs.py
+++ b/src/pipx/shared_libs.py
@@ -30,6 +30,7 @@ class _SharedLibs:
         # i.e. python_path is ~/.local/pipx/shared/python
         self._site_packages: Optional[Path] = None
         self.has_been_updated_this_run = False
+        self.has_been_checked_this_run = False
 
     @property
     def site_packages(self) -> Path:
@@ -56,8 +57,9 @@ class _SharedLibs:
 
     @property
     def needs_upgrade(self) -> bool:
-        if self.has_been_updated_this_run:
+        if self.has_been_updated_this_run or self.has_been_checked_this_run:
             return False
+        self.has_been_checked_this_run = True
 
         if not self.pip_path.is_file():
             return True


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
This makes sure that pipx writes log info about the age of the shared libs only once per run.  It reduces unnecessary and distracting noise in the log file or `--verbose` output.

Currently this can happen every time a venv is instanced, which can end up with dozens of identical log messages like:
```
   110.1ms (needs_upgrade:70): Time since last upgrade of shared libs, in seconds: 10515. Upgrade will be run by pipx if greater than 2592000.
   110.7ms (needs_upgrade:70): Time since last upgrade of shared libs, in seconds: 10515. Upgrade will be run by pipx if greater than 2592000.
   111.3ms (needs_upgrade:70): Time since last upgrade of shared libs, in seconds: 10515. Upgrade will be run by pipx if greater than 2592000.
[...]
```

In addition, I added a `debug`-level log message at the very end of a pipx command run before exit, useful in the log file to show how long the entire pipx command took:
```
   144.5ms (cli:773): pipx finished.
```

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx list --verbose
```

This PR:
```shell
> pipx list --verbose
pipx >(setup:714): pipx version is 0.16.1.0.1.dev0
pipx >(setup:715): Default python interpreter is '/Users/mclapp/git/pipx/venv39/bin/python3'
venvs are in /Users/mclapp/.local/pipx/venvs
apps are exposed on your $PATH at /Users/mclapp/.local/bin
pipx >(needs_upgrade:69): Time since last upgrade of shared libs, in seconds: 11141. Upgrade will be run by pipx if greater than 2592000.
   package black 20.8b1 (black-new), Python 3.9.2
    - black-new
    - black-primer-new
    - blackd-new
   package durank 0.2.0, Python 3.9.2
    - durank
   package finddup 0.2.0, Python 3.9.2
    - finddup
   package flake8 3.8.4, Python 3.9.2
    - flake8
   package nox 2020.12.31, Python 3.9.2
    - nox
    - tox-to-nox
   package pycowsay 0.0.0.1, Python 3.9.2
    - pycowsay
   package pylint 2.7.4, Python 3.9.2
    - epylint
    - pylint
    - pyreverse
    - symilar
   package pythonloc 0.1.2.1, Python 3.9.2
    - pipfreezeloc
    - piploc
    - pythonloc
   package pytivo 0.5.0, Python 3.9.2
    - pytivo
   package vulture 2.2, Python 3.9.2
    - vulture
   package zipls 0.3.0, Python 3.9.2
    - zipls
```

pipx v0.16.1.0:
```shell
> pipx list --verbose
pipx >(setup:711): pipx version is 0.16.1.0
pipx >(setup:712): Default python interpreter is '/usr/local/opt/python@3.9/bin/python3.9'
venvs are in /Users/mclapp/.local/pipx/venvs
apps are exposed on your $PATH at /Users/mclapp/.local/bin
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
   package black 20.8b1 (black-new), Python 3.9.2
    - black-new
    - black-primer-new
    - blackd-new
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
   package durank 0.2.0, Python 3.9.2
    - durank
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
   package finddup 0.2.0, Python 3.9.2
    - finddup
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
   package flake8 3.8.4, Python 3.9.2
    - flake8
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
   package nox 2020.12.31, Python 3.9.2
    - nox
    - tox-to-nox
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
   package pycowsay 0.0.0.1, Python 3.9.2
    - pycowsay
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
   package pylint 2.7.4, Python 3.9.2
    - epylint
    - pylint
    - pyreverse
    - symilar
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
   package pythonloc 0.1.2.1, Python 3.9.2
    - pipfreezeloc
    - piploc
    - pythonloc
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
   package pytivo 0.5.0, Python 3.9.2
    - pytivo
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
   package vulture 2.2, Python 3.9.2
    - vulture
pipx >(needs_upgrade:67): Time since last upgrade of shared libs, in seconds: 11173. Upgrade will be run by pipx if greater than 2592000.
   package zipls 0.3.0, Python 3.9.2
    - zipls
```
