### PR TITLE
Remove python 3.5 references, tests

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ dev
 - Fixed issue which made pipx incorrectly list apps as part of a venv when they were not installed by pipx. (#650)
 - Fixed old regression that would prevent pipx uninstall from cleaning up linked binaries if the venv was old and did not have pipx metadata. (#651)
 - Fixed bugs with suffixed-venvs on Windows.  Now properly summarizes install, and actually uninstalls associated binaries for suffixed-venvs. (#653)
+- Change venv minimum python version to 3.6, removing python 3.5 which is End of Life.
 
 0.16.1.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ dev
 - Fixed issue which made pipx incorrectly list apps as part of a venv when they were not installed by pipx. (#650)
 - Fixed old regression that would prevent pipx uninstall from cleaning up linked binaries if the venv was old and did not have pipx metadata. (#651)
 - Fixed bugs with suffixed-venvs on Windows.  Now properly summarizes install, and actually uninstalls associated binaries for suffixed-venvs. (#653)
-- Change venv minimum python version to 3.6, removing python 3.5 which is End of Life.
+- Change venv minimum python version to 3.6, removing python 3.5 which is End of Life. (#666)
 
 0.16.1.0
 

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -322,7 +322,7 @@ def _add_install(subparsers: argparse._SubParsersAction) -> None:
         default=DEFAULT_PYTHON,
         help=(
             "The Python executable used to create the Virtual Environment and run the "
-            "associated app/apps. Must be v3.5+."
+            "associated app/apps. Must be v3.6+."
         ),
     )
     add_pip_venv_args(p)
@@ -442,7 +442,7 @@ def _add_reinstall(subparsers, venv_completer: VenvCompleter) -> None:
         default=DEFAULT_PYTHON,
         help=(
             "The Python executable used to recreate the Virtual Environment "
-            "and run the associated app/apps. Must be v3.5+."
+            "and run the associated app/apps. Must be v3.6+."
         ),
     )
     p.add_argument("--verbose", action="store_true")
@@ -470,7 +470,7 @@ def _add_reinstall_all(subparsers: argparse._SubParsersAction) -> None:
         default=DEFAULT_PYTHON,
         help=(
             "The Python executable used to recreate the Virtual Environment "
-            "and run the associated app/apps. Must be v3.5+."
+            "and run the associated app/apps. Must be v3.6+."
         ),
     )
     p.add_argument("--skip", nargs="+", default=[], help="skip these packages")
@@ -537,7 +537,7 @@ def _add_run(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument(
         "--python",
         default=DEFAULT_PYTHON,
-        help="The Python version to run package's CLI app with. Must be v3.5+.",
+        help="The Python version to run package's CLI app with. Must be v3.6+.",
     )
     add_pip_venv_args(p)
     p.set_defaults(subparser=p)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,10 +1,8 @@
 import json
 import os
 import re
-import subprocess
 import sys
 from pathlib import Path
-from shutil import which
 from typing import Any, Dict, List, Optional
 from unittest import mock
 
@@ -43,24 +41,6 @@ def app_name(app: str) -> str:
 def run_pipx_cli(pipx_args: List[str]) -> int:
     with mock.patch.object(sys, "argv", ["pipx"] + pipx_args):
         return main.cli()
-
-
-def which_python(python_exe: str) -> Optional[str]:
-    try:
-        pyenv_which = subprocess.run(
-            ["pyenv", "which", python_exe],
-            stdout=subprocess.PIPE,
-            universal_newlines=True,
-        )
-    except FileNotFoundError:
-        # no pyenv on system
-        return which(python_exe)
-
-    if pyenv_which.returncode == 0:
-        return pyenv_which.stdout.strip()
-    else:
-        # pyenv on system, but pyenv has no path to python_exe
-        return None
 
 
 def unwrap_log_text(log_text: str):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6,11 +6,10 @@ from unittest import mock
 
 import pytest  # type: ignore
 
-from helpers import app_name, run_pipx_cli, unwrap_log_text, which_python
+from helpers import app_name, run_pipx_cli, unwrap_log_text
 from package_info import PKG
 from pipx import constants
 
-PYTHON3_5 = which_python("python3.5")
 TEST_DATA_PATH = "./testdata/test_package_specifier"
 
 
@@ -189,13 +188,6 @@ def test_existing_symlink_points_to_nothing(pipx_temp_env, capsys):
     # pipx should realize the symlink points to nothing and replace it,
     # so no warning should be present
     assert "symlink missing or pointing to unexpected location" not in captured.out
-
-
-def test_install_python3_5(pipx_temp_env):
-    if PYTHON3_5:
-        assert not run_pipx_cli(["install", "cowsay", "--python", PYTHON3_5])
-    else:
-        pytest.skip("python3.5 not on PATH")
 
 
 def test_pip_args_forwarded_to_package_name_determination(pipx_temp_env, capsys):


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Python 3.5 is End of Life.  This PR changes the help text to make the minimum python for venvs now Python 3.6.  It also removes the custom code in the tests to test install of a pipx package using python 3.5.  (It was likely that that code never ran in CI anyway, because it required the availability of a python3.5 binary.)

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
pipx install --help
```

This PR:
```
> pipx install --help       
usage: pipx install [-h] [--include-deps] [--verbose] [--force]
                    [--suffix SUFFIX] [--python PYTHON]
                    [--system-site-packages] [--index-url INDEX_URL]
                    [--editable] [--pip-args PIP_ARGS]
                    package_spec

The install command is the preferred way to globally install apps
from python packages on your system. It creates an isolated virtual
environment for the package, then ensures the package's apps are
accessible on your $PATH.

The result: apps you can run from anywhere, located in packages
you can cleanly upgrade or uninstall. Guaranteed to not have
dependency version conflicts or interfere with your OS's python
packages. 'sudo' is not required to do this.

pipx install PACKAGE_NAME
pipx install --python PYTHON PACKAGE_NAME
pipx install VCS_URL
pipx install ./LOCAL_PATH
pipx install ZIP_FILE
pipx install TAR_GZ_FILE

The PACKAGE_SPEC argument is passed directly to `pip install`.

The default virtual environment location is /Users/mclapp/.local/pipx
and can be overridden by setting the environment variable `PIPX_HOME`
(Virtual Environments will be installed to `$PIPX_HOME/venvs`).

The default app location is /Users/mclapp/.local/bin and can be
overridden by setting the environment variable `PIPX_BIN_DIR`.

The default python executable used to install a package is
/Users/mclapp/git/pipx/venv39/bin/python3 and can be overridden
by setting the environment variable `PIPX_DEFAULT_PYTHON`.

positional arguments:
  package_spec          package name or pip installation spec

optional arguments:
  -h, --help            show this help message and exit
  --include-deps        Include apps of dependent packages
  --verbose
  --force, -f           Modify existing virtual environment and files in
                        PIPX_BIN_DIR
  --suffix SUFFIX       Optional suffix for virtual environment and executable
                        names. NOTE: The suffix feature is experimental and
                        subject to change.
  --python PYTHON       The Python executable used to create the Virtual
                        Environment and run the associated app/apps. Must be
                        v3.6+.
  --system-site-packages
                        Give the virtual environment access to the system
                        site-packages dir.
  --index-url INDEX_URL, -i INDEX_URL
                        Base URL of Python Package Index
  --editable, -e        Install a project in editable mode
  --pip-args PIP_ARGS   Arbitrary pip arguments to pass directly to pip
                        install/upgrade commands
```

pipx v0.16.1.0:
```
> pipx install --help
usage: pipx install [-h] [--include-deps] [--verbose] [--force]
                    [--suffix SUFFIX] [--python PYTHON]
                    [--system-site-packages] [--index-url INDEX_URL]
                    [--editable] [--pip-args PIP_ARGS]
                    package_spec

The install command is the preferred way to globally install apps
from python packages on your system. It creates an isolated virtual
environment for the package, then ensures the package's apps are
accessible on your $PATH.

The result: apps you can run from anywhere, located in packages
you can cleanly upgrade or uninstall. Guaranteed to not have
dependency version conflicts or interfere with your OS's python
packages. 'sudo' is not required to do this.

pipx install PACKAGE_NAME
pipx install --python PYTHON PACKAGE_NAME
pipx install VCS_URL
pipx install ./LOCAL_PATH
pipx install ZIP_FILE
pipx install TAR_GZ_FILE

The PACKAGE_SPEC argument is passed directly to `pip install`.

The default virtual environment location is /Users/mclapp/.local/pipx
and can be overridden by setting the environment variable `PIPX_HOME`
(Virtual Environments will be installed to `$PIPX_HOME/venvs`).

The default app location is /Users/mclapp/.local/bin and can be
overridden by setting the environment variable `PIPX_BIN_DIR`.

The default python executable used to install a package is
/usr/local/opt/python@3.9/bin/python3.9 and can be overridden
by setting the environment variable `PIPX_DEFAULT_PYTHON`.

positional arguments:
  package_spec          package name or pip installation spec

optional arguments:
  -h, --help            show this help message and exit
  --include-deps        Include apps of dependent packages
  --verbose
  --force, -f           Modify existing virtual environment and files in
                        PIPX_BIN_DIR
  --suffix SUFFIX       Optional suffix for virtual environment and executable
                        names. NOTE: The suffix feature is experimental and
                        subject to change.
  --python PYTHON       The Python executable used to create the Virtual
                        Environment and run the associated app/apps. Must be
                        v3.5+.
  --system-site-packages
                        Give the virtual environment access to the system
                        site-packages dir.
  --index-url INDEX_URL, -i INDEX_URL
                        Base URL of Python Package Index
  --editable, -e        Install a project in editable mode
  --pip-args PIP_ARGS   Arbitrary pip arguments to pass directly to pip
                        install/upgrade commands
```