### PR TITLE
Fix UnboundLocalError: local variable 'is_same_file' referenced before assignment

### DIFF
--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -241,6 +241,7 @@ def _get_exposed_app_paths_for_package(
             # is not a reliable way to determine if the symlink exists.
             # We always use the stricter check on non-Windows systems. On
             # Windows, we use a less strict check if we don't have a symlink.
+            is_same_file = False
             if _can_symlink(local_bin_dir) and b.is_symlink():
                 is_same_file = b.resolve().parent.samefile(venv_bin_path)
             elif not _can_symlink(local_bin_dir):


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes

Fixes:

```
pipx install py-spy

Traceback (most recent call last):
  File "/home/patrick/.local/bin/pipx", line 8, in <module>
    sys.exit(cli())
  File "/home/patrick/.local/lib/python3.9/site-packages/pipx/main.py", line 762, in cli
    return run_pipx_command(parsed_pipx_args)
  File "/home/patrick/.local/lib/python3.9/site-packages/pipx/main.py", line 193, in run_pipx_command
    return commands.install(
  File "/home/patrick/.local/lib/python3.9/site-packages/pipx/commands/install.py", line 69, in install
    run_post_install_actions(
  File "/home/patrick/.local/lib/python3.9/site-packages/pipx/commands/common.py", line 377, in run_post_install_actions
    package_summary, _ = get_venv_summary(
  File "/home/patrick/.local/lib/python3.9/site-packages/pipx/commands/common.py", line 201, in get_venv_summary
    exposed_app_paths = _get_exposed_app_paths_for_package(
  File "/home/patrick/.local/lib/python3.9/site-packages/pipx/commands/common.py", line 249, in _get_exposed_app_paths_for_package
    if is_same_file:
UnboundLocalError: local variable 'is_same_file' referenced before assignment
```

Related: https://github.com/pipxproject/pipx/pull/650/files#r611018560


## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# pipx install py-spy
```
