### PR TITLE
Update apps_of_dependencies for localstack.

### DIFF
--- a/tests/package_info.py
+++ b/tests/package_info.py
@@ -379,7 +379,8 @@ PKG: Dict[str, Dict[str, Any]] = {
     "localstack": {
         "spec": "localstack==0.12.1",
         "apps": ["localstack", "localstack.bat"],
-        "apps_of_dependencies": _exe_if_win(["chardetect"]) + ["jp.py"],
+        "apps_of_dependencies": _exe_if_win(["chardetect", "dulwich"])
+        + ["jp.py", "dul-receive-pack", "dul-upload-pack"],
     },
     "mackup": {
         "spec": "mackup==0.8.29",


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
This really only has ramifications for the exhaustive "Test all packages (slow)" CI tests that can only be run manually.

The changes update `apps_of_dependencies` for the pypi package `localstack==0.12.1`.

The package `localstack` has a dependency `dulwich` which in a recent version added entry_points.  Even though we pin `localstack` at version 0.12.1, it only specifies a minimum version of `dulwich`, and thus the `apps_of_dependencies` needs to be updated to take into account the recent version of `dulwich` that is now fetched on install of `localstack`.

## Test plan
See the test run where `localstack` installed with `--include-dependencies` fails to verify the apps installed, due to the existing `package_info.py` code:
https://github.com/itsayellow/pipx/actions/runs/757158589

This PR test run, where `localstack` with `--include-depencies` verifies correctly with the new code:
https://github.com/itsayellow/pipx/actions/runs/757543988