### PR TITLE
Make uninstall on Windows not erroneously uninstall apps from dependencies

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,12 @@
 dev
 
-- Make sure log files are utf-8 encoded to preven Unicode encoding errors from occurring with emojis. (#646)
+- Ensured log files are utf-8 encoded to preven Unicode encoding errors from occurring with emojis. (#646)
 - Fixed issue which made pipx incorrectly list apps as part of a venv when they were not installed by pipx. (#650)
 - Fixed old regression that would prevent pipx uninstall from cleaning up linked binaries if the venv was old and did not have pipx metadata. (#651)
 - Fixed bugs with suffixed-venvs on Windows.  Now properly summarizes install, and actually uninstalls associated binaries for suffixed-venvs. (#653)
-- Add `--json` switch to `pipx list` to output rich json-metadata for all venvs.
-- Change venv minimum python version to 3.6, removing python 3.5 which is End of Life. (#666)
+- Added `--json` switch to `pipx list` to output rich json-metadata for all venvs.
+- Changed venv minimum python version to 3.6, removing python 3.5 which is End of Life. (#666)
+- Fixed bug (#670) where uninstalling a venv could erroneously uninstall other apps from the local binary directory.
 
 0.16.1.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@ dev
 - Fixed bugs with suffixed-venvs on Windows.  Now properly summarizes install, and actually uninstalls associated binaries for suffixed-venvs. (#653)
 - Added `--json` switch to `pipx list` to output rich json-metadata for all venvs.
 - Changed venv minimum python version to 3.6, removing python 3.5 which is End of Life. (#666)
-- Fixed bug (#670) where uninstalling a venv could erroneously uninstall other apps from the local binary directory.
+- Fixed bug #670 where uninstalling a venv could erroneously uninstall other apps from the local binary directory. (#672)
 
 0.16.1.0
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -247,8 +247,8 @@ def get_exposed_app_paths_for_package(
     local_bin_dir: Path,
     package_binary_names: Optional[List[str]] = None,
 ) -> Set[Path]:
-    # package_binary_names is used only if local_bin_path cannot use symlinks
-    #   to look for files with the same name
+    # package_binary_names is used only if local_bin_path cannot use symlinks.
+    # It is necessary for those systems to return app_paths.
     if package_binary_names is None:
         package_binary_names = []
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -248,7 +248,7 @@ def get_exposed_app_paths_for_package(
     package_binary_names: Optional[List[str]] = None,
 ) -> Set[Path]:
     # package_binary_names is used only if local_bin_path cannot use symlinks.
-    # It is necessary for those systems to return app_paths.
+    # It is necessary for non-symlink systems to return valid app_paths.
     if package_binary_names is None:
         package_binary_names = []
 

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -212,8 +212,8 @@ def get_venv_summary(
 
     exposed_app_paths = get_exposed_app_paths_for_package(
         venv.bin_path,
-        [add_suffix(app, package_metadata.suffix) for app in apps],
         constants.LOCAL_BIN_DIR,
+        [add_suffix(app, package_metadata.suffix) for app in apps],
     )
     exposed_binary_names = sorted(p.name for p in exposed_app_paths)
     unavailable_binary_names = sorted(
@@ -243,8 +243,15 @@ def get_venv_summary(
 
 
 def get_exposed_app_paths_for_package(
-    venv_bin_path: Path, package_binary_names: List[str], local_bin_dir: Path
+    venv_bin_path: Path,
+    local_bin_dir: Path,
+    package_binary_names: Optional[List[str]] = None,
 ) -> Set[Path]:
+    # package_binary_names is used only if local_bin_path cannot use symlinks
+    #   to look for files with the same name
+    if package_binary_names is None:
+        package_binary_names = []
+
     bin_symlinks = set()
     for b in local_bin_dir.iterdir():
         try:

--- a/src/pipx/commands/common.py
+++ b/src/pipx/commands/common.py
@@ -52,7 +52,7 @@ class VenvProblems:
 def expose_apps_globally(
     local_bin_dir: Path, app_paths: List[Path], *, force: bool, suffix: str = ""
 ) -> None:
-    if not _can_symlink(local_bin_dir):
+    if not can_symlink(local_bin_dir):
         _copy_package_apps(local_bin_dir, app_paths, suffix=suffix)
     else:
         _symlink_package_apps(local_bin_dir, app_paths, force=force, suffix=suffix)
@@ -61,7 +61,7 @@ def expose_apps_globally(
 _can_symlink_cache: Dict[Path, bool] = {}
 
 
-def _can_symlink(local_bin_dir: Path) -> bool:
+def can_symlink(local_bin_dir: Path) -> bool:
 
     if not WINDOWS:
         # Technically, even on Unix this depends on the filesystem
@@ -210,7 +210,7 @@ def get_venv_summary(
     if package_metadata.include_dependencies:
         apps += package_metadata.apps_of_dependencies
 
-    exposed_app_paths = _get_exposed_app_paths_for_package(
+    exposed_app_paths = get_exposed_app_paths_for_package(
         venv.bin_path,
         [add_suffix(app, package_metadata.suffix) for app in apps],
         constants.LOCAL_BIN_DIR,
@@ -242,7 +242,7 @@ def get_venv_summary(
     )
 
 
-def _get_exposed_app_paths_for_package(
+def get_exposed_app_paths_for_package(
     venv_bin_path: Path, package_binary_names: List[str], local_bin_dir: Path
 ) -> Set[Path]:
     bin_symlinks = set()
@@ -254,9 +254,9 @@ def _get_exposed_app_paths_for_package(
             # We always use the stricter check on non-Windows systems. On
             # Windows, we use a less strict check if we don't have a symlink.
             is_same_file = False
-            if _can_symlink(local_bin_dir) and b.is_symlink():
+            if can_symlink(local_bin_dir) and b.is_symlink():
                 is_same_file = b.resolve().parent.samefile(venv_bin_path)
-            elif not _can_symlink(local_bin_dir):
+            elif not can_symlink(local_bin_dir):
                 is_same_file = b.name in package_binary_names
 
             if is_same_file:

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -124,8 +124,12 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
     bin_dir_app_paths = _get_venv_bin_dir_app_paths(venv, local_bin_dir)
 
     for bin_dir_app_path in bin_dir_app_paths:
-        logger.info(f"removing file {bin_dir_app_path}")
-        bin_dir_app_path.unlink()
+        try:
+            bin_dir_app_path.unlink()
+        except FileNotFoundError:
+            logger.info(f"tried to remove but couldn't find {bin_dir_app_path}")
+        else:
+            logger.info(f"removed file {bin_dir_app_path}")
 
     rmdir(venv_dir)
     print(f"uninstalled {venv.name}! {stars}")

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -108,7 +108,6 @@ def _get_venv_bin_dir_app_paths(venv: Venv, local_bin_dir: Path) -> List[Path]:
             symlink = filepath
             for b in app_paths:
                 if symlink.exists() and b.exists() and symlink.samefile(b):
-                    logger.info(f"removing symlink {str(symlink)}")
                     bin_dir_app_paths.append(symlink)
 
     return bin_dir_app_paths
@@ -134,6 +133,7 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
     bin_dir_app_paths = _get_venv_bin_dir_app_paths(venv, local_bin_dir)
 
     for bin_dir_app_path in bin_dir_app_paths:
+        logger.info(f"removing file {bin_dir_app_path}")
         bin_dir_app_path.unlink()
 
     rmdir(venv_dir)

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 from shutil import which
-from typing import List
+from typing import List, Optional
 
 from pipx import constants
 from pipx.commands.common import (
@@ -24,15 +24,18 @@ from pipx.venv_inspect import VenvMetadata
 logger = logging.getLogger(__name__)
 
 
-def venv_metadata_to_package_info(
+def _venv_metadata_to_package_info(
     venv_metadata: VenvMetadata,
     package_name: str,
-    package_or_url: str,
-    pip_args: List[str],
-    include_apps: bool,
-    include_dependencies: bool,
-    suffix: str,
+    package_or_url: str = "",
+    pip_args: Optional[List[str]] = None,
+    include_apps: bool = True,
+    include_dependencies: bool = False,
+    suffix: str = "",
 ) -> PackageInfo:
+    if pip_args is None:
+        pip_args = []
+
     return PackageInfo(
         package=package_name,
         package_or_url=package_or_url,
@@ -78,14 +81,8 @@ def _get_venv_bin_dir_app_paths(venv: Venv, local_bin_dir: Path) -> List[Path]:
         # not include_dependencies.  Other PackageInfo fields are irrelevant
         # here.
         venv_metadata = venv.get_venv_metadata_for_package(venv.root.name, set())
-        main_package_info = venv_metadata_to_package_info(
-            venv_metadata,
-            package_name=venv.root.name,
-            package_or_url="",
-            pip_args=[],
-            include_apps=True,
-            include_dependencies=False,
-            suffix="",
+        main_package_info = _venv_metadata_to_package_info(
+            venv_metadata, venv.root.name
         )
         bin_dir_app_paths += _get_package_bin_dir_app_paths(
             venv, main_package_info, local_bin_dir

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -65,6 +65,7 @@ def _get_package_bin_dir_app_paths(
 def _get_venv_bin_dir_app_paths(venv: Venv, local_bin_dir: Path) -> List[Path]:
     bin_dir_app_paths: List[Path] = []
     if venv.pipx_metadata.main_package.package is not None:
+        # Valid metadata for venv
         for viewed_package in venv.package_metadata.values():
             bin_dir_app_paths += _get_package_bin_dir_app_paths(
                 venv, viewed_package, local_bin_dir

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -5,9 +5,9 @@ from typing import List
 
 from pipx import constants
 from pipx.commands.common import (
-    _can_symlink,
-    _get_exposed_app_paths_for_package,
     add_suffix,
+    can_symlink,
+    get_exposed_app_paths_for_package,
 )
 from pipx.constants import (
     EXIT_CODE_OK,
@@ -56,7 +56,7 @@ def _get_package_bin_dir_app_paths(
     apps = package_info.apps
     if package_info.include_dependencies:
         apps += package_info.apps_of_dependencies
-    bin_dir_package_app_paths += _get_exposed_app_paths_for_package(
+    bin_dir_package_app_paths += get_exposed_app_paths_for_package(
         venv.bin_path, [add_suffix(app, suffix) for app in apps], local_bin_dir
     )
     return bin_dir_package_app_paths
@@ -97,7 +97,7 @@ def _get_venv_bin_dir_app_paths(venv: Venv, local_bin_dir: Path) -> List[Path]:
         # give up and return and empty list.
         # The heuristic here is any symlink in ~/.local/bin pointing to
         # .local/pipx/venvs/VENV_NAME/bin should be uninstalled.
-        if not _can_symlink(local_bin_dir):
+        if not can_symlink(local_bin_dir):
             return []
 
         apps_linking_to_venv_bin_dir = [

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -4,19 +4,117 @@ from shutil import which
 from typing import List
 
 from pipx import constants
-from pipx.commands.common import _get_exposed_app_paths_for_package, add_suffix
+from pipx.commands.common import (
+    _can_symlink,
+    _get_exposed_app_paths_for_package,
+    add_suffix,
+)
 from pipx.constants import (
     EXIT_CODE_OK,
     EXIT_CODE_UNINSTALL_ERROR,
     EXIT_CODE_UNINSTALL_VENV_NONEXISTENT,
-    WINDOWS,
     ExitCode,
 )
 from pipx.emojis import hazard, sleep, stars
+from pipx.pipx_metadata_file import PackageInfo
 from pipx.util import rmdir
 from pipx.venv import Venv, VenvContainer
+from pipx.venv_inspect import VenvMetadata
 
 logger = logging.getLogger(__name__)
+
+
+def venv_metadata_to_package_info(
+    venv_metadata: VenvMetadata,
+    package_name: str,
+    package_or_url: str,
+    pip_args: List[str],
+    include_apps: bool,
+    include_dependencies: bool,
+    suffix: str,
+) -> PackageInfo:
+    return PackageInfo(
+        package=package_name,
+        package_or_url=package_or_url,
+        pip_args=pip_args,
+        include_apps=include_apps,
+        include_dependencies=include_dependencies,
+        apps=venv_metadata.apps,
+        app_paths=venv_metadata.app_paths,
+        apps_of_dependencies=venv_metadata.apps_of_dependencies,
+        app_paths_of_dependencies=venv_metadata.app_paths_of_dependencies,
+        package_version=venv_metadata.package_version,
+        suffix=suffix,
+    )
+
+
+def _get_package_bin_dir_app_paths(
+    venv: Venv, package_info: PackageInfo, local_bin_dir: Path
+) -> List[Path]:
+    bin_dir_package_app_paths: List[Path] = []
+    suffix = package_info.suffix
+    apps = package_info.apps
+    if package_info.include_dependencies:
+        apps += package_info.apps_of_dependencies
+    bin_dir_package_app_paths += _get_exposed_app_paths_for_package(
+        venv.bin_path, [add_suffix(app, suffix) for app in apps], local_bin_dir
+    )
+    return bin_dir_package_app_paths
+
+
+def _get_venv_bin_dir_app_paths(venv: Venv, local_bin_dir: Path) -> List[Path]:
+    bin_dir_app_paths: List[Path] = []
+    if venv.pipx_metadata.main_package.package is not None:
+        for viewed_package in venv.package_metadata.values():
+            bin_dir_app_paths += _get_package_bin_dir_app_paths(
+                venv, viewed_package, local_bin_dir
+            )
+    elif venv.python_path.is_file():
+        # fallback if not metadata from pipx_metadata.json
+        # has a valid python interpreter and can get metadata about the package
+        # In pre-metadata-pipx venv.root.name is name of main package
+        # In pre-metadata-pipx there is no suffix
+        # We make the conservative assumptions: no injected packages,
+        # not include_dependencies.  Other PackageInfo fields are irrelevant
+        # here.
+        venv_metadata = venv.get_venv_metadata_for_package(venv.root.name, set())
+        main_package_info = venv_metadata_to_package_info(
+            venv_metadata,
+            package_name=venv.root.name,
+            package_or_url="",
+            pip_args=[],
+            include_apps=True,
+            include_dependencies=False,
+            suffix="",
+        )
+        bin_dir_app_paths += _get_package_bin_dir_app_paths(
+            venv, main_package_info, local_bin_dir
+        )
+    else:
+        # No metadata and no valid python interpreter.
+        # We'll take our best guess on what to uninstall here based on symlink
+        # location for symlink-capable systems.  For non-symlink systems we
+        # give up and return and empty list.
+        # The heuristic here is any symlink in ~/.local/bin pointing to
+        # .local/pipx/venvs/VENV_NAME/bin should be uninstalled.
+        if not _can_symlink(local_bin_dir):
+            return []
+
+        apps_linking_to_venv_bin_dir = [
+            f
+            for f in constants.LOCAL_BIN_DIR.iterdir()
+            if str(f.resolve()).startswith(str(venv.bin_path))
+        ]
+        app_paths = apps_linking_to_venv_bin_dir
+
+        for filepath in local_bin_dir.iterdir():
+            symlink = filepath
+            for b in app_paths:
+                if symlink.exists() and b.exists() and symlink.samefile(b):
+                    logger.info(f"removing symlink {str(symlink)}")
+                    bin_dir_app_paths.append(symlink)
+
+    return bin_dir_app_paths
 
 
 def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
@@ -36,58 +134,7 @@ def uninstall(venv_dir: Path, local_bin_dir: Path, verbose: bool) -> ExitCode:
 
     venv = Venv(venv_dir, verbose=verbose)
 
-    bin_dir_app_paths: List[Path] = []
-    if venv.pipx_metadata.main_package.package is not None:
-        for viewed_package in venv.package_metadata.values():
-            suffix = viewed_package.suffix
-            apps = viewed_package.apps
-            if viewed_package.include_dependencies:
-                apps += viewed_package.apps_of_dependencies
-            bin_dir_app_paths += _get_exposed_app_paths_for_package(
-                venv.bin_path, [add_suffix(app, suffix) for app in apps], local_bin_dir
-            )
-    else:
-        # fallback if not metadata from pipx_metadata.json
-
-        # TODO: determine suffix for Windows
-        suffix = ""
-
-        if venv.python_path.is_file():
-            # has a valid python interpreter and can get metadata about the package
-            # In pre-metadata-pipx venv_dir.name is name of main package
-            metadata = venv.get_venv_metadata_for_package(venv_dir.name, set())
-            app_paths = metadata.app_paths
-            for dep_paths in metadata.app_paths_of_dependencies.values():
-                app_paths += dep_paths
-        else:
-
-            # Doesn't have a valid python interpreter. We'll take our best guess on what to uninstall
-            # here based on symlink location. pipx doesn't use symlinks on windows, so this is for
-            # non-windows only.
-            # The heuristic here is any symlink in ~/.local/bin pointing to .local/pipx/venvs/VENV_NAME/bin
-            # should be uninstalled.
-            if WINDOWS:
-                app_paths = []
-            else:
-                apps_linking_to_venv_bin_dir = [
-                    f
-                    for f in constants.LOCAL_BIN_DIR.iterdir()
-                    if str(f.resolve()).startswith(str(venv.bin_path))
-                ]
-                app_paths = apps_linking_to_venv_bin_dir
-
-        for filepath in local_bin_dir.iterdir():
-            if WINDOWS:
-                for b in app_paths:
-                    bin_name = b.stem + suffix + b.suffix
-                    if filepath.exists() and filepath.name == bin_name:
-                        bin_dir_app_paths.append(filepath)
-            else:
-                symlink = filepath
-                for b in app_paths:
-                    if symlink.exists() and b.exists() and symlink.samefile(b):
-                        logger.info(f"removing symlink {str(symlink)}")
-                        bin_dir_app_paths.append(symlink)
+    bin_dir_app_paths = _get_venv_bin_dir_app_paths(venv, local_bin_dir)
 
     for bin_dir_app_path in bin_dir_app_paths:
         bin_dir_app_path.unlink()

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -70,8 +70,7 @@ def _get_venv_bin_dir_app_paths(venv: Venv, local_bin_dir: Path) -> List[Path]:
                 venv, viewed_package, local_bin_dir
             )
     elif venv.python_path.is_file():
-        # fallback if not metadata from pipx_metadata.json
-        # has a valid python interpreter and can get metadata about the package
+        # No metadata from pipx_metadata.json, but valid python interpreter.
         # In pre-metadata-pipx venv.root.name is name of main package
         # In pre-metadata-pipx there is no suffix
         # We make the conservative assumptions: no injected packages,

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -68,9 +68,9 @@ def _get_venv_bin_dir_app_paths(venv: Venv, local_bin_dir: Path) -> Set[Path]:
     bin_dir_app_paths = set()
     if venv.pipx_metadata.main_package.package is not None:
         # Valid metadata for venv
-        for viewed_package in venv.package_metadata.values():
+        for package_info in venv.package_metadata.values():
             bin_dir_app_paths |= _get_package_bin_dir_app_paths(
-                venv, viewed_package, local_bin_dir
+                venv, package_info, local_bin_dir
             )
     elif venv.python_path.is_file():
         # No metadata from pipx_metadata.json, but valid python interpreter.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,6 @@ def pipx_temp_env(tmp_path, monkeypatch):
     # On Windows, monkeypatch pipx.commands.common._can_symlink_cache to
     #   indicate that constants.LOCAL_BIN_DIR cannot use symlinks, even if
     #   we're running as administrator and symlinks are actually possible.
-    # On all other platforms than Windows this has no effect.
     if WIN:
         monkeypatch.setitem(
             commands.common._can_symlink_cache, constants.LOCAL_BIN_DIR, False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 import pytest  # type: ignore
 
-from pipx import constants, shared_libs, venv
+from helpers import WIN
+from pipx import commands, constants, shared_libs, venv
 
 
 def pytest_addoption(parser):
@@ -54,3 +55,12 @@ def pipx_temp_env(tmp_path, monkeypatch):
     monkeypatch.setenv("PATH_ORIG", str(bin_dir) + os.pathsep + os.getenv("PATH"))
     monkeypatch.setenv("PATH_TEST", str(bin_dir))
     monkeypatch.setenv("PATH", str(bin_dir))
+
+    # On Windows, monkeypatch pipx.commands.common._can_symlink_cache to
+    #   indicate that constants.LOCAL_BIN_DIR cannot use symlinks, even if
+    #   we're running as administrator and symlinks are actually possible.
+    # On all other platforms than Windows this has no effect.
+    if WIN:
+        monkeypatch.setitem(
+            commands.common._can_symlink_cache, constants.LOCAL_BIN_DIR, False
+        )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -78,18 +78,21 @@ def mock_legacy_venv(venv_name: str, metadata_version: Optional[str] = None) -> 
     """
     venv_dir = Path(constants.PIPX_LOCAL_VENVS) / canonicalize_name(venv_name)
 
-    if metadata_version is None:
+    if metadata_version == "0.2":
+        # Current metadata version, do nothing
+        return
+    elif metadata_version == "0.1":
+        mock_pipx_metadata_template = MOCK_PIPXMETADATA_0_1
+    elif metadata_version is None:
+        # No metadata
         os.remove(venv_dir / "pipx_metadata.json")
         return
-
-    modern_metadata = pipx_metadata_file.PipxMetadata(venv_dir).to_dict()
-
-    if metadata_version == "0.1":
-        mock_pipx_metadata_template = MOCK_PIPXMETADATA_0_1
     else:
         raise Exception(
             f"Internal Test Error: Unknown metadata_version={metadata_version}"
         )
+
+    modern_metadata = pipx_metadata_file.PipxMetadata(venv_dir).to_dict()
 
     # Convert to mock old metadata
     mock_pipx_metadata = {}
@@ -159,6 +162,6 @@ def assert_package_metadata(test_metadata, ref_metadata):
         apps=sorted(test_metadata.apps), app_paths=sorted(test_metadata.app_paths)
     )
     ref_metadata_replaced = ref_metadata._replace(
-        apps=sorted(ref_metadata.apps), app_paths=sorted(ref_metadata.app_paths),
+        apps=sorted(ref_metadata.apps), app_paths=sorted(ref_metadata.app_paths)
     )
     assert test_metadata_replaced == ref_metadata_replaced

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,7 @@ from unittest import mock
 from packaging.utils import canonicalize_name
 
 from package_info import PKG
-from pipx import constants, main, pipx_metadata_file
+from pipx import constants, main, pipx_metadata_file, util
 
 WIN = sys.platform.startswith("win")
 
@@ -165,3 +165,10 @@ def assert_package_metadata(test_metadata, ref_metadata):
         apps=sorted(ref_metadata.apps), app_paths=sorted(ref_metadata.app_paths)
     )
     assert test_metadata_replaced == ref_metadata_replaced
+
+
+def remove_venv_interpreter(venv_name):
+    _, venv_python_path = util.get_venv_paths(constants.PIPX_LOCAL_VENVS / venv_name)
+    assert venv_python_path.is_file()
+    venv_python_path.unlink()
+    assert not venv_python_path.is_file()

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -8,10 +8,11 @@ from helpers import (
     assert_package_metadata,
     create_package_info_ref,
     mock_legacy_venv,
+    remove_venv_interpreter,
     run_pipx_cli,
 )
 from package_info import PKG
-from pipx import constants, util
+from pipx import constants
 from pipx.pipx_metadata_file import PackageInfo, _json_decoder_object_hook
 
 
@@ -24,14 +25,12 @@ def test_cli(pipx_temp_env, monkeypatch, capsys):
 def test_missing_interpreter(pipx_temp_env, monkeypatch, capsys):
     assert not run_pipx_cli(["install", "pycowsay"])
 
-    _, python_path = util.get_venv_paths(constants.PIPX_LOCAL_VENVS / "pycowsay")
-    assert (python_path).is_file()
-
     assert not run_pipx_cli(["list"])
     captured = capsys.readouterr()
     assert "package pycowsay has invalid interpreter" not in captured.out
 
-    python_path.unlink()
+    remove_venv_interpreter("pycowsay")
+
     assert run_pipx_cli(["list"])
     captured = capsys.readouterr()
     assert "package pycowsay has invalid interpreter" in captured.out

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -2,9 +2,29 @@ import sys
 
 import pytest  # type: ignore
 
-from helpers import app_name, mock_legacy_venv, remove_venv_interpreter, run_pipx_cli
+from helpers import (
+    WIN,
+    app_name,
+    mock_legacy_venv,
+    remove_venv_interpreter,
+    run_pipx_cli,
+)
 from package_info import PKG
-from pipx import constants
+from pipx import commands, constants
+
+
+@pytest.fixture(autouse=True)
+def windows_no_symlinks(monkeypatch):
+    """On Windows, monkeypatch pipx.commands.common._can_symlink_cache
+    to indicate that constants.LOCAL_BIN_DIR cannot use symlinks, even
+    if we're running as administrator and symlinks are actually possible.
+
+    On all other platforms than Windows this fixture has no effect.
+    """
+    if WIN:
+        monkeypatch.setitem(
+            commands.common._can_symlink_cache, constants.LOCAL_BIN_DIR, False
+        )
 
 
 def file_or_symlink(filepath):

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -7,6 +7,16 @@ from package_info import PKG
 from pipx import constants
 
 
+def file_or_symlink(filepath):
+    # Returns True for file or broken symlink or non-broken symlink
+    # Returns False for no file and no symlink
+
+    # filepath.exists() returns True for file or non-broken symlink
+    # filepath.exists() returns False for broken symlink
+    # filepath.is_symlink() returns True for broken or non-broken symlink
+    return filepath.exists() or filepath.is_symlink()
+
+
 def test_uninstall(pipx_temp_env):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["uninstall", "pycowsay"])
@@ -31,9 +41,7 @@ def test_uninstall_legacy_venv(pipx_temp_env, metadata_version):
 
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)
     assert not run_pipx_cli(["uninstall", "pycowsay"])
-    # Also use is_symlink to check for broken symlink.
-    #   exists() returns False if symlink exists but target doesn't exist
-    assert not executable_path.exists() and not executable_path.is_symlink()
+    assert not file_or_symlink(executable_path)
 
 
 def test_uninstall_suffix(pipx_temp_env):
@@ -45,9 +53,7 @@ def test_uninstall_suffix(pipx_temp_env):
     assert executable_path.exists()
 
     assert not run_pipx_cli(["uninstall", f"{name}{suffix}"])
-    # Also use is_symlink to check for broken symlink.
-    #   exists() returns False if symlink exists but target doesn't exist
-    assert not executable_path.exists() and not executable_path.is_symlink()
+    assert not file_or_symlink(executable_path)
 
 
 @pytest.mark.parametrize("metadata_version", ["0.1"])
@@ -63,9 +69,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
     assert executable_path.exists()
 
     assert not run_pipx_cli(["uninstall", f"{name}{suffix}"])
-    # Also use is_symlink to check for broken symlink.
-    #   exists() returns False if symlink exists but target doesn't exist
-    assert not executable_path.exists() and not executable_path.is_symlink()
+    assert not file_or_symlink(executable_path)
 
 
 def test_uninstall_with_missing_interpreter(pipx_temp_env):
@@ -89,9 +93,7 @@ def test_uninstall_with_missing_interpreter_legacy_venv(
     assert not run_pipx_cli(["uninstall", "pycowsay"])
     # On Windows we cannot remove app binaries if no metadata and no python
     if not sys.platform.startswith("win"):
-        # Also use is_symlink to check for broken symlink.
-        #   exists() returns False if symlink exists but target doesn't exist
-        assert not executable_path.exists() and not executable_path.is_symlink()
+        assert not file_or_symlink(executable_path)
 
 
 @pytest.mark.parametrize("metadata_version", [None, "0.1", "0.2"])
@@ -113,9 +115,7 @@ def test_uninstall_proper_dep_behavior(pipx_temp_env, metadata_version):
     assert not run_pipx_cli(["uninstall", "pylint"])
 
     for pylint_app_path in pylint_app_paths:
-        # Also use is_symlink to check for broken symlink.
-        #   exists() returns False if symlink exists but target doesn't exist
-        assert not pylint_app_path.exists() and not pylint_app_path.is_symlink()
+        assert not file_or_symlink(pylint_app_path)
     # THIS is what we're making sure is true:
     for isort_app_path in isort_app_paths:
         assert isort_app_path.exists()
@@ -147,9 +147,7 @@ def test_uninstall_proper_dep_behavior_missing_interpreter(
     #   remove bin dir links by design for missing interpreter in that case
     if not (sys.platform.startswith("win") and metadata_version is None):
         for pylint_app_path in pylint_app_paths:
-            # Also use is_symlink to check for broken symlink.
-            #   exists() returns False if symlink exists but target doesn't exist
-            assert not pylint_app_path.exists() and not pylint_app_path.is_symlink()
+            assert not file_or_symlink(pylint_app_path)
     # THIS is what we're making sure is true:
     for isort_app_path in isort_app_paths:
         assert isort_app_path.exists()

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -100,12 +100,15 @@ def test_uninstall_with_missing_interpreter_legacy_venv(
         assert not executable_path.exists() and not executable_path.is_symlink()
 
 
-def test_uninstall_proper_dep_behavior(pipx_temp_env):
+@pytest.mark.parametrize("metadata_version", [None, "0.1", "0.2"])
+def test_uninstall_proper_dep_behavior(pipx_temp_env, metadata_version):
     isort_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["isort"]["apps"]]
     pylint_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pylint"]["apps"]]
 
     assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
     assert not run_pipx_cli(["install", PKG["isort"]["spec"]])
+    mock_legacy_venv("pylint", metadata_version=metadata_version)
+    mock_legacy_venv("isort", metadata_version=metadata_version)
     for pylint_app_path in pylint_app_paths:
         assert pylint_app_path.exists()
     for isort_app_path in isort_app_paths:

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -11,8 +11,8 @@ def file_or_symlink(filepath):
     # Returns True for file or broken symlink or non-broken symlink
     # Returns False for no file and no symlink
 
-    # filepath.exists() returns True for file or non-broken symlink
-    # filepath.exists() returns False for broken symlink
+    # filepath.exists() returns True for regular file or non-broken symlink
+    # filepath.exists() returns False for no regular file or broken symlink
     # filepath.is_symlink() returns True for broken or non-broken symlink
     return filepath.exists() or filepath.is_symlink()
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -56,6 +56,27 @@ def test_uninstall_suffix(pipx_temp_env):
     assert not file_or_symlink(executable_path)
 
 
+def test_uninstall_injected(pipx_temp_env):
+    pycowsay_app_paths = [
+        constants.LOCAL_BIN_DIR / app for app in PKG["pycowsay"]["apps"]
+    ]
+    pylint_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pylint"]["apps"]]
+    app_paths = pycowsay_app_paths + pylint_app_paths
+
+    assert not run_pipx_cli(["install", PKG["pycowsay"]["spec"]])
+    assert not run_pipx_cli(
+        ["inject", "--include-apps", "pycowsay", PKG["pylint"]["spec"]]
+    )
+
+    for app_path in app_paths:
+        assert app_path.exists()
+
+    assert not run_pipx_cli(["uninstall", "pycowsay"])
+
+    for app_path in app_paths:
+        assert not file_or_symlink(app_path)
+
+
 @pytest.mark.parametrize("metadata_version", ["0.1"])
 def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
     name = "pbr"

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -98,3 +98,25 @@ def test_uninstall_with_missing_interpreter_legacy_venv(
         # Also use is_symlink to check for broken symlink.
         #   exists() returns False if symlink exists but target doesn't exist
         assert not executable_path.exists() and not executable_path.is_symlink()
+
+
+def test_uninstall_proper_dep_behavior(pipx_temp_env):
+    isort_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["isort"]["apps"]]
+    pylint_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pylint"]["apps"]]
+
+    assert not run_pipx_cli(["install", PKG["pylint"]["spec"]])
+    assert not run_pipx_cli(["install", PKG["isort"]["spec"]])
+    for pylint_app_path in pylint_app_paths:
+        assert pylint_app_path.exists()
+    for isort_app_path in isort_app_paths:
+        assert isort_app_path.exists()
+
+    assert not run_pipx_cli(["uninstall", "pylint"])
+
+    for pylint_app_path in pylint_app_paths:
+        # Also use is_symlink to check for broken symlink.
+        #   exists() returns False if symlink exists but target doesn't exist
+        assert not pylint_app_path.exists() and not pylint_app_path.is_symlink()
+    # THIS is what we're making sure is true:
+    for isort_app_path in isort_app_paths:
+        assert isort_app_path.exists()

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -7,23 +7,23 @@ from package_info import PKG
 from pipx import constants, util
 
 
-def test_uninstall(pipx_temp_env, capsys):
+def test_uninstall(pipx_temp_env):
     assert not run_pipx_cli(["install", "pycowsay"])
     assert not run_pipx_cli(["uninstall", "pycowsay"])
 
 
-def test_uninstall_multiple_same_app(pipx_temp_env, capsys):
+def test_uninstall_multiple_same_app(pipx_temp_env):
     assert not run_pipx_cli(["install", "kaggle==1.5.9", "--include-deps"])
     assert not run_pipx_cli(["uninstall", "kaggle"])
 
 
-def test_uninstall_circular_deps(pipx_temp_env, capsys):
+def test_uninstall_circular_deps(pipx_temp_env):
     assert not run_pipx_cli(["install", PKG["cloudtoken"]["spec"]])
     assert not run_pipx_cli(["uninstall", "cloudtoken"])
 
 
 @pytest.mark.parametrize("metadata_version", [None, "0.1"])
-def test_uninstall_legacy_venv(pipx_temp_env, capsys, metadata_version):
+def test_uninstall_legacy_venv(pipx_temp_env, metadata_version):
     executable_path = constants.LOCAL_BIN_DIR / app_name("pycowsay")
 
     assert not run_pipx_cli(["install", "pycowsay"])
@@ -36,7 +36,7 @@ def test_uninstall_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not executable_path.exists() and not executable_path.is_symlink()
 
 
-def test_uninstall_suffix(pipx_temp_env, capsys):
+def test_uninstall_suffix(pipx_temp_env):
     name = "pbr"
     suffix = "_a"
     executable_path = constants.LOCAL_BIN_DIR / app_name(f"{name}{suffix}")
@@ -51,7 +51,7 @@ def test_uninstall_suffix(pipx_temp_env, capsys):
 
 
 @pytest.mark.parametrize("metadata_version", ["0.1"])
-def test_uninstall_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
+def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
     name = "pbr"
     # legacy uninstall on Windows only works with "canonical name characters"
     #   in suffix
@@ -68,7 +68,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, capsys, metadata_version):
     assert not executable_path.exists() and not executable_path.is_symlink()
 
 
-def test_uninstall_with_missing_interpreter(pipx_temp_env, capsys):
+def test_uninstall_with_missing_interpreter(pipx_temp_env):
     assert not run_pipx_cli(["install", "pycowsay"])
 
     _, python_path = util.get_venv_paths(constants.PIPX_LOCAL_VENVS / "pycowsay")
@@ -81,7 +81,7 @@ def test_uninstall_with_missing_interpreter(pipx_temp_env, capsys):
 
 @pytest.mark.parametrize("metadata_version", [None, "0.1"])
 def test_uninstall_with_missing_interpreter_legacy_venv(
-    pipx_temp_env, capsys, metadata_version
+    pipx_temp_env, metadata_version
 ):
     executable_path = constants.LOCAL_BIN_DIR / app_name("pycowsay")
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -96,6 +96,8 @@ def test_uninstall_with_missing_interpreter_legacy_venv(
 
 @pytest.mark.parametrize("metadata_version", [None, "0.1", "0.2"])
 def test_uninstall_proper_dep_behavior(pipx_temp_env, metadata_version):
+    # isort is a dependency of pylint.  Make sure that uninstalling pylint
+    #   does not also uninstall isort app in LOCAL_BIN_DIR
     isort_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["isort"]["apps"]]
     pylint_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pylint"]["apps"]]
 
@@ -123,6 +125,8 @@ def test_uninstall_proper_dep_behavior(pipx_temp_env, metadata_version):
 def test_uninstall_proper_dep_behavior_missing_interpreter(
     pipx_temp_env, metadata_version
 ):
+    # isort is a dependency of pylint.  Make sure that uninstalling pylint
+    #   does not also uninstall isort app in LOCAL_BIN_DIR
     isort_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["isort"]["apps"]]
     pylint_app_paths = [constants.LOCAL_BIN_DIR / app for app in PKG["pylint"]["apps"]]
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -143,10 +143,13 @@ def test_uninstall_proper_dep_behavior_missing_interpreter(
 
     assert not run_pipx_cli(["uninstall", "pylint"])
 
-    for pylint_app_path in pylint_app_paths:
-        # Also use is_symlink to check for broken symlink.
-        #   exists() returns False if symlink exists but target doesn't exist
-        assert not pylint_app_path.exists() and not pylint_app_path.is_symlink()
+    # Do not check the following on Windows without metadata, we do not
+    #   remove bin dir links by design for missing interpreter in that case
+    if not (sys.platform.startswith("win") and metadata_version is None):
+        for pylint_app_path in pylint_app_paths:
+            # Also use is_symlink to check for broken symlink.
+            #   exists() returns False if symlink exists but target doesn't exist
+            assert not pylint_app_path.exists() and not pylint_app_path.is_symlink()
     # THIS is what we're making sure is true:
     for isort_app_path in isort_app_paths:
         assert isort_app_path.exists()

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -72,16 +72,8 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
     assert not file_or_symlink(executable_path)
 
 
-def test_uninstall_with_missing_interpreter(pipx_temp_env):
-    assert not run_pipx_cli(["install", "pycowsay"])
-    remove_venv_interpreter("pycowsay")
-    assert not run_pipx_cli(["uninstall", "pycowsay"])
-
-
-@pytest.mark.parametrize("metadata_version", [None, "0.1"])
-def test_uninstall_with_missing_interpreter_legacy_venv(
-    pipx_temp_env, metadata_version
-):
+@pytest.mark.parametrize("metadata_version", [None, "0.1", "0.2"])
+def test_uninstall_with_missing_interpreter(pipx_temp_env, metadata_version):
     executable_path = constants.LOCAL_BIN_DIR / app_name("pycowsay")
 
     assert not run_pipx_cli(["install", "pycowsay"])
@@ -92,7 +84,7 @@ def test_uninstall_with_missing_interpreter_legacy_venv(
 
     assert not run_pipx_cli(["uninstall", "pycowsay"])
     # On Windows we cannot remove app binaries if no metadata and no python
-    if not sys.platform.startswith("win"):
+    if not (sys.platform.startswith("win") and metadata_version is None):
         assert not file_or_symlink(executable_path)
 
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -2,29 +2,9 @@ import sys
 
 import pytest  # type: ignore
 
-from helpers import (
-    WIN,
-    app_name,
-    mock_legacy_venv,
-    remove_venv_interpreter,
-    run_pipx_cli,
-)
+from helpers import app_name, mock_legacy_venv, remove_venv_interpreter, run_pipx_cli
 from package_info import PKG
-from pipx import commands, constants
-
-
-@pytest.fixture(autouse=True)
-def windows_no_symlinks(monkeypatch):
-    """On Windows, monkeypatch pipx.commands.common._can_symlink_cache
-    to indicate that constants.LOCAL_BIN_DIR cannot use symlinks, even
-    if we're running as administrator and symlinks are actually possible.
-
-    On all other platforms than Windows this fixture has no effect.
-    """
-    if WIN:
-        monkeypatch.setitem(
-            commands.common._can_symlink_cache, constants.LOCAL_BIN_DIR, False
-        )
+from pipx import constants
 
 
 def file_or_symlink(filepath):

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -2,9 +2,9 @@ import sys
 
 import pytest  # type: ignore
 
-from helpers import app_name, mock_legacy_venv, run_pipx_cli
+from helpers import app_name, mock_legacy_venv, remove_venv_interpreter, run_pipx_cli
 from package_info import PKG
-from pipx import constants, util
+from pipx import constants
 
 
 def test_uninstall(pipx_temp_env):
@@ -70,12 +70,7 @@ def test_uninstall_suffix_legacy_venv(pipx_temp_env, metadata_version):
 
 def test_uninstall_with_missing_interpreter(pipx_temp_env):
     assert not run_pipx_cli(["install", "pycowsay"])
-
-    _, python_path = util.get_venv_paths(constants.PIPX_LOCAL_VENVS / "pycowsay")
-    assert python_path.is_file()
-    python_path.unlink()
-    assert not python_path.is_file()
-
+    remove_venv_interpreter("pycowsay")
     assert not run_pipx_cli(["uninstall", "pycowsay"])
 
 
@@ -89,8 +84,7 @@ def test_uninstall_with_missing_interpreter_legacy_venv(
     assert executable_path.exists()
 
     mock_legacy_venv("pycowsay", metadata_version=metadata_version)
-    _, venv_python_path = util.get_venv_paths(constants.PIPX_LOCAL_VENVS / "pycowsay")
-    venv_python_path.unlink()
+    remove_venv_interpreter("pycowsay")
 
     assert not run_pipx_cli(["uninstall", "pycowsay"])
     # On Windows we cannot remove app binaries if no metadata and no python


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Closes #670 .

This fixes a bug on Windows where uninstalling a venv would uninstall app binaries in the local bin directory from its dependencies also (even though the original `pipx install` did not use `--include-dependencies`.)

This change updates and refactors the code in `uninstall.py` to use the function `get_exposed_app_paths_for_package` from `common.py` to determine the associated binaries in the local binary directory for a given venv.  It thus benefits from the bug fixes that were applied in #650 to `common.py`.

And as a bonus we get rid of duplicate code in `uninstall.py` that did the same function as code in `common.py`.

I also added tests to check that `pipx uninstall` doesn't delete the apps of a dependency if the original app wasn't installed with `--include-dependencies`.

Also in the test code:
* I added a helper function `remove_venv_interpreter`
* updated helper function`mock_legacy_venv` to allow `metadata_version` argument to use the current metadata version
* removed the fixture `capsys` in `test_uninstall.py` from tests where it was not being used.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running on WINDOWS (from example in #670)
```shell
pipx install coveo-stew
pipx install poetry
pipx uninstall coveo-stew
```

This PR result:
```shell
> pipx install coveo-stew
done!
creating virtual environment...
installing coveo-stew...
  installed package coveo-stew 1.2.3, Python 3.9.1
  These apps are now globally available
    - pyproject.exe
    - stew.exe
> ls ~/.local/bin
pyproject.exe*  stew.exe*
> pipx install poetry
done!
creating virtual environment...
installing poetry...
  installed package poetry 1.1.6, Python 3.9.1
  These apps are now globally available
    - poetry.exe
> ls ~/.local/bin
poetry.exe*  pyproject.exe*  stew.exe*
> pipx uninstall coveo-stew
uninstalled coveo-stew!
> ls ~/.local/bin
poetry.exe*
>
```

pipx 0.16.1 result: (`poetry.exe` is erroneously removed from `~/.local/bin`)
```shell
> pipx install coveo-stew
done!
creating virtual environment...
installing coveo-stew...
  installed package coveo-stew 1.2.3, Python 3.9.1
  These apps are now globally available
    - pyproject.exe
    - stew.exe
> ls ~/.local/bin
pyproject.exe*  stew.exe*
> pipx install poetry
done!
creating virtual environment...
installing poetry...
  installed package poetry 1.1.6, Python 3.9.1
  These apps are now globally available
    - poetry.exe
> ls ~/.local/bin
poetry.exe*  pyproject.exe*  stew.exe*
> pipx uninstall coveo-stew
uninstalled coveo-stew!
> ls ~/.local/bin
>
```