### PR TITLE
Speed up tests by only creating pipx shared libs once per test session

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,15 @@ def pytest_configure(config):
     config.option.markexpr = new_markexpr
 
 
+@pytest.fixture(scope="session")
+def pipx_session_shared_dir(tmp_path_factory):
+    # temp_path_factory uses the same directory for the whole session
+    shared_dir = tmp_path_factory.mktemp("session_shareddir")
+    return shared_dir
+
+
 @pytest.fixture
-def pipx_temp_env(tmp_path, tmp_path_factory, monkeypatch):
+def pipx_temp_env(tmp_path, pipx_session_shared_dir, monkeypatch):
     """Sets up temporary paths for pipx to install into.
 
     Shared libs are setup once per session, all other pipx dirs, constants are
@@ -37,9 +44,7 @@ def pipx_temp_env(tmp_path, tmp_path_factory, monkeypatch):
     Also adds environment variables as necessary to make pip installations
     seamless.
     """
-    # temp_path_factory uses the same directory for the whole session
-    shared_dir = tmp_path_factory.mktemp("session_shareddir")
-    monkeypatch.setattr(constants, "PIPX_SHARED_LIBS", shared_dir)
+    monkeypatch.setattr(constants, "PIPX_SHARED_LIBS", pipx_session_shared_dir)
     monkeypatch.setattr(shared_libs, "shared_libs", shared_libs._SharedLibs())
     monkeypatch.setattr(venv, "shared_libs", shared_libs.shared_libs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,44 @@ def pytest_configure(config):
 
 
 @pytest.fixture
-def pipx_temp_env(tmp_path, monkeypatch):
+def pipx_temp_env(tmp_path, tmp_path_factory, monkeypatch):
     """Sets up temporary paths for pipx to install into.
+
+    Shared libs are setup once per session, all other pipx dirs, constants are
+    recreated for every test function.
+
+    Also adds environment variables as necessary to make pip installations
+    seamless.
+    """
+    # temp_path_factory uses the same directory for the whole session
+    shared_dir = tmp_path_factory.mktemp("session_shareddir")
+    monkeypatch.setattr(constants, "PIPX_SHARED_LIBS", shared_dir)
+    monkeypatch.setattr(shared_libs, "shared_libs", shared_libs._SharedLibs())
+    monkeypatch.setattr(venv, "shared_libs", shared_libs.shared_libs)
+
+    home_dir = Path(tmp_path) / "subdir" / "pipxhome"
+    bin_dir = Path(tmp_path) / "otherdir" / "pipxbindir"
+
+    monkeypatch.setattr(constants, "PIPX_HOME", home_dir)
+    monkeypatch.setattr(constants, "LOCAL_BIN_DIR", bin_dir)
+    monkeypatch.setattr(constants, "PIPX_LOCAL_VENVS", home_dir / "venvs")
+    monkeypatch.setattr(constants, "PIPX_VENV_CACHEDIR", home_dir / ".cache")
+    monkeypatch.setattr(constants, "PIPX_LOG_DIR", home_dir / "logs")
+
+    # macOS needs /usr/bin in PATH to compile certain packages, but
+    #   applications in /usr/bin cause test_install.py tests to raise warnings
+    #   which make tests fail (e.g. on Github ansible apps exist in /usr/bin)
+    monkeypatch.setenv("PATH_ORIG", str(bin_dir) + os.pathsep + os.getenv("PATH"))
+    monkeypatch.setenv("PATH_TEST", str(bin_dir))
+    monkeypatch.setenv("PATH", str(bin_dir))
+
+
+@pytest.fixture
+def pipx_ultra_temp_env(tmp_path, monkeypatch):
+    """Sets up temporary paths for pipx to install into.
+
+    Fully temporary environment, every test function starts as if pipx has
+    never been run before
 
     Also adds environment variables as necessary to make pip installations
     seamless.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def pipx_session_shared_dir(tmp_path_factory):
 
 
 @pytest.fixture
-def pipx_temp_env(tmp_path, pipx_session_shared_dir, monkeypatch):
+def pipx_temp_env(tmp_path, monkeypatch, pipx_session_shared_dir):
     """Sets up temporary paths for pipx to install into.
 
     Shared libs are setup once per session, all other pipx dirs, constants are

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,12 +28,12 @@ def pytest_configure(config):
 
 
 def pipx_temp_env_helper(pipx_shared_dir, tmp_path, monkeypatch):
+    home_dir = Path(tmp_path) / "subdir" / "pipxhome"
+    bin_dir = Path(tmp_path) / "otherdir" / "pipxbindir"
+
     monkeypatch.setattr(constants, "PIPX_SHARED_LIBS", pipx_shared_dir)
     monkeypatch.setattr(shared_libs, "shared_libs", shared_libs._SharedLibs())
     monkeypatch.setattr(venv, "shared_libs", shared_libs.shared_libs)
-
-    home_dir = Path(tmp_path) / "subdir" / "pipxhome"
-    bin_dir = Path(tmp_path) / "otherdir" / "pipxbindir"
 
     monkeypatch.setattr(constants, "PIPX_HOME", home_dir)
     monkeypatch.setattr(constants, "LOCAL_BIN_DIR", bin_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,8 +60,7 @@ def pipx_temp_env_helper(pipx_shared_dir, tmp_path, monkeypatch):
 @pytest.fixture(scope="session")
 def pipx_session_shared_dir(tmp_path_factory):
     """Makes a temporary pipx shared libs directory only once per session"""
-    shared_dir = tmp_path_factory.mktemp("session_shareddir")
-    return shared_dir
+    return tmp_path_factory.mktemp("session_shareddir")
 
 
 @pytest.fixture

--- a/tests/test_shared_libs.py
+++ b/tests/test_shared_libs.py
@@ -13,7 +13,9 @@ from pipx import shared_libs
         (-shared_libs.SHARED_LIBS_MAX_AGE_SEC + 5 * 60, False),
     ],
 )
-def test_auto_update_shared_libs(capsys, pipx_temp_env, mtime_minus_now, needs_upgrade):
+def test_auto_update_shared_libs(
+    capsys, pipx_ultra_temp_env, mtime_minus_now, needs_upgrade
+):
     now = time.time()
     shared_libs.shared_libs.create(verbose=True)
     shared_libs.shared_libs.has_been_updated_this_run = False


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
By making basically one change to our tests, setting up the shared libs directory only once per test session, our tests can halve the amount of time they take.  That's what this PR does.  It modifies the fixture `pipx_temp_env` to do this.

I made another fixture `pipx_ultra_temp_env` which does the old thing of creating every directory fresh per test, including the shared libs directory.  I use this for the tests inside of `test_shared_libs.py` which specifically are testing the shared libs.

By watching our tests' stdout and stderr in real-time using the pytest `-s` switch (i.e. "don't capture stdout and stderr") I found that most of the time involved in our tests was consumed by "creating" and then "upgrading" the pipx shared libs.  Because the existing test code makes a new temporary shared libs directory once per test, this took a LOT of time.

Since most tests are testing something other than shared libs creation and upgrade, this seemed to be unnecessary time to me.

The modified code makes a fresh, empty temporary shared libs directory at the beginning of the session, but subsequent tests do not need to recreate it.  So we do test the shared libs creation code at least once, while not making every test go through the motions of it.

Here are some test time duration statistics from Github CI tests on various branches on my fork of pipx.  I used data from the last 100 Github CI runs on my fork.
All times are in seconds.  "speed-tests" are the tests from this PR.
```
speed-tests
    macos-latest, 3.9	mean:  676.5	min:  518	max:  776	n:  6
    ubuntu-latest, 3.6	mean:  420.2	min:  388	max:  448	n:  6
    ubuntu-latest, 3.7	mean:  386.8	min:  353	max:  421	n:  6
    ubuntu-latest, 3.8	mean:  378.2	min:  339	max:  434	n:  6
    ubuntu-latest, 3.9	mean:  408.3	min:  384	max:  438	n:  6
    windows-latest, 3.9	mean:  561.2	min:  448	max:  632	n:  6
fix-win-uninstall
    macos-latest, 3.9	mean: 1452.9	min: 1243	max: 2482	n: 28
    ubuntu-latest, 3.6	mean:  835.6	min:  668	max: 1014	n: 28
    ubuntu-latest, 3.7	mean:  858.2	min:  715	max: 1003	n: 28
    ubuntu-latest, 3.8	mean:  838.9	min:  701	max:  994	n: 28
    ubuntu-latest, 3.9	mean:  859.6	min:  729	max:  988	n: 28
    windows-latest, 3.9	mean: 1416.5	min: 1155	max: 1664	n: 28
master
    macos-latest, 3.9	mean: 1463.1	min: 1228	max: 2381	n:  8
    ubuntu-latest, 3.6	mean:  817.8	min:  703	max:  899	n:  8
    ubuntu-latest, 3.7	mean:  870.9	min:  831	max:  912	n:  8
    ubuntu-latest, 3.8	mean:  843.4	min:  729	max:  950	n:  8
    ubuntu-latest, 3.9	mean:  898.0	min:  782	max: 1006	n:  8
    windows-latest, 3.9	mean: 1500.8	min: 1129	max: 1723	n:  8
```

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
