### PR TITLE
Uninstall app fix

### DIFF
--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -55,7 +55,9 @@ def _get_package_bin_dir_app_paths(
 ) -> Set[Path]:
     bin_dir_package_app_paths = set()
     suffix = package_info.suffix
-    apps = package_info.apps
+    apps = []
+    if package_info.include_apps:
+        apps += package_info.apps
     if package_info.include_dependencies:
         apps += package_info.apps_of_dependencies
     bin_dir_package_app_paths |= get_exposed_app_paths_for_package(

--- a/src/pipx/commands/uninstall.py
+++ b/src/pipx/commands/uninstall.py
@@ -53,17 +53,15 @@ def _venv_metadata_to_package_info(
 def _get_package_bin_dir_app_paths(
     venv: Venv, package_info: PackageInfo, local_bin_dir: Path
 ) -> Set[Path]:
-    bin_dir_package_app_paths = set()
     suffix = package_info.suffix
     apps = []
     if package_info.include_apps:
         apps += package_info.apps
     if package_info.include_dependencies:
         apps += package_info.apps_of_dependencies
-    bin_dir_package_app_paths |= get_exposed_app_paths_for_package(
+    return get_exposed_app_paths_for_package(
         venv.bin_path, local_bin_dir, [add_suffix(app, suffix) for app in apps]
     )
-    return bin_dir_package_app_paths
 
 
 def _get_venv_bin_dir_app_paths(venv: Venv, local_bin_dir: Path) -> Set[Path]:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
This should've been included with #672 (my bad).  When looking at the metadata to determine the apps installed, we should check each `PackageInfo` for `include_apps` to tell if there were apps ACTUALLY installed into the local binary directory.  Injected packages using `pipx inject` without the `--include-apps` switch need to be handled here properly (they won't install their apps to the local bin dir).

This really only affects uninstalls on Windows (without symlinks to determine parent venv) with injected packages.  But it needs to be fixed nonetheless.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
