### PR TITLE
Create valid json from `pipx list --json` when no venvs installed

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 dev
 
+- Fixed `pipx list --json` to return valid json with no venvs installed.  Previously would return and empty string to stdout.
 
 0.16.2.1
 

--- a/src/pipx/commands/list_packages.py
+++ b/src/pipx/commands/list_packages.py
@@ -82,13 +82,14 @@ def list_packages(
     venv_dirs: Collection[Path] = sorted(venv_container.iter_venv_dirs())
     if not venv_dirs:
         print(f"nothing has been installed with pipx {sleep}", file=sys.stderr)
-        return EXIT_CODE_OK
 
     venv_container.verify_shared_libs()
 
     if json_format:
         all_venv_problems = list_json(venv_dirs)
     else:
+        if not venv_dirs:
+            return EXIT_CODE_OK
         all_venv_problems = list_text(venv_dirs, include_injected, str(venv_container))
 
     if all_venv_problems.bad_venv_name:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
Closes #678 (again 😄 )

An empty string is not valid json.  This makes sure that we print valid json to stdout for the case of no venvs installed, instead of nothing as we did before to stdout.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running the following with no venvs installed.
```shell
> pipx list --json > test.out
nothing has been installed with pipx 😴
> more test.out              
{
    "pipx_spec_version": "0.1",
    "venvs": {}
}
```
