### PR TITLE
Userpath upgrade

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 dev
 
 - Fixed `pipx list --json` to return valid json with no venvs installed.  Previously would return and empty string to stdout.
+- Changed `pipx ensurepath` bash behavior so that only one of {`~/.profile`, `~/.bash\_profile`} is modified with the extra pipx paths, not both.  Previously, if a `.bash_profile` file was created where one didn't exist, it could cause problems, e.g. #456. The internal change is to use userpath v1.5.0 or greater.
 
 0.16.2.1
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 dev
 
-- Fixed `pipx list --json` to return valid json with no venvs installed.  Previously would return and empty string to stdout.
-- Changed `pipx ensurepath` bash behavior so that only one of {`~/.profile`, `~/.bash\_profile`} is modified with the extra pipx paths, not both.  Previously, if a `.bash_profile` file was created where one didn't exist, it could cause problems, e.g. #456. The internal change is to use userpath v1.5.0 or greater.
+- Fixed `pipx list --json` to return valid json with no venvs installed.  Previously would return and empty string to stdout. (#681)
+- Changed `pipx ensurepath` bash behavior so that only one of {`~/.profile`, `~/.bash\_profile`} is modified with the extra pipx paths, not both.  Previously, if a `.bash_profile` file was created where one didn't exist, it could cause problems, e.g. #456. The internal change is to use userpath v1.5.0 or greater. (#684)
 
 0.16.2.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ zip_safe = true
 python_requires = >=3.6
 install_requires =
     colorama>=0.4.4
-    userpath>=1.4.1
+    userpath>=1.5.0
     argcomplete>=1.9.4, <2.0
     packaging>=20.0
     importlib-metadata>=3.3.0; python_version < '3.8'


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes
This changes the minimum userpath version to 1.5.0, so that we can take advantage of the new userpath behavior in bash to only modify `~/.profile` OR `~/.bash_profile` but not both.  

Some systems do not have a `~/.bash_profile` file but do have a `~/.profile` file.  In the past when userpath (or `pipx ensurepath`) created a new `~/.bash_profile` it actually prevented `~/.profile` from executing and caused problems (e.g. https://github.com/pipxproject/pipx/issues/456#issuecomment-828903198).

See #456.
In userpath, see: ofek/userpath#19, ofek/userpath#36, and https://github.com/ofek/userpath/issues/3#issuecomment-512973913

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# command(s) to exercise these changes
```
