### PR TITLE
Lint tool version updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: v4.0.0
   hooks:
   - id: end-of-file-fixer
   - id: check-added-large-files
@@ -18,11 +18,11 @@ repos:
   - id: isort
     args: ['--profile','black']
 - repo: https://github.com/psf/black
-  rev: 19.10b0
+  rev: 21.5b1
   hooks:
   - id: black
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.0
+  rev: 3.9.2
   hooks:
   - id: flake8
     additional_dependencies: [

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,8 +8,8 @@ PYTHON_ALL_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
 PYTHON_DEFAULT_VERSION = "3.9"
 DOC_DEPENDENCIES = [".", "jinja2", "mkdocs", "mkdocs-material"]
 LINT_DEPENDENCIES = [
-    "black==19.10b0",
-    "flake8==3.9.0",
+    "black==21.5b1",
+    "flake8==3.9.2",
     "flake8-bugbear==21.3.2",
     "mypy==0.812",
     "check-manifest==0.46",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,6 @@ known_first_party = ["helpers", "package_info"]
 markers = [
     "all_packages: test install with maximum number of packages",
 ]
+
+[tool.black]
+skip-magic-trailing-comma = true

--- a/src/pipx/main.py
+++ b/src/pipx/main.py
@@ -489,7 +489,7 @@ def _add_list(subparsers: argparse._SubParsersAction) -> None:
         help="Show packages injected into the main app's environment",
     )
     p.add_argument(
-        "--json", action="store_true", help="Output rich data in json format.",
+        "--json", action="store_true", help="Output rich data in json format."
     )
     p.add_argument("--verbose", action="store_true")
 

--- a/src/pipx/venv.py
+++ b/src/pipx/venv.py
@@ -352,8 +352,7 @@ class Venv:
         if not self.python_path.exists():
             return None
         dists = Distribution.discover(
-            name=self.main_package_name,
-            path=[str(get_site_packages(self.python_path))],
+            name=self.main_package_name, path=[str(get_site_packages(self.python_path))]
         )
         for dist in dists:
             for ep in dist.entry_points:

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -107,7 +107,7 @@ def test_list_json(pipx_temp_env, capsys):
         **{
             "app_paths_of_dependencies": {
                 "isort": [pipx_venvs_dir / "pylint" / venv_bin_dir / app_name("isort")]
-            },
+            }
         },
     )
     assert_package_metadata(


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
This updates the version of black and flake8 to the latest versions in our lint nox session and in `.pre-commit-config.yaml`.

It takes advantage of the new `--skip-magic-trailing-comma` option in black (added this option to black config in `pyproject.toml`).  I dislike the black "magic trailing comma" behavior because it treats all trailing commas as a user directive to never collapse a multi-line list, even in those cases that black and not the user added the trailing comma in the first place.  See psf/black#1742 .  Before I had kept the version of black at 19.10b0 to avoid this new magic comma behavior, but with the new switch we can advance black to the latest version.

In addition, with the new switch, there were some unnecessary trailing commas in a few source files that got cleaned up.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
nox -s lint
```
