### PR TITLE
Slow all-packages tests bug fixes

### DIFF
--- a/tests/package_info.py
+++ b/tests/package_info.py
@@ -338,10 +338,10 @@ PKG: Dict[str, Dict[str, Any]] = {
         ),
     },
     "kaggle": {
-        "spec": "kaggle==1.5.9",
+        "spec": "kaggle==1.5.12",
         "apps": _exe_if_win(["kaggle"]),
         "apps_of_dependencies": list(
-            set(_exe_if_win(["chardetect", "slugify", "tqdm"]) + ["slugify"])
+            set(_exe_if_win(["chardetect", "slugify", "tqdm"]))
         ),
     },
     "kibitzr": {

--- a/tests/package_info.py
+++ b/tests/package_info.py
@@ -273,9 +273,7 @@ PKG: Dict[str, Dict[str, Any]] = {
     "howdoi": {
         "spec": "howdoi==2.0.7",
         "apps": _exe_if_win(["howdoi"]),
-        "apps_of_dependencies": _exe_if_win(
-            ["chardetect", "keep", "pygmentize", "pyjwt"]
-        ),
+        "apps_of_dependencies": _exe_if_win(["chardetect", "keep", "pygmentize"]),
     },
     "httpie": {
         "spec": "httpie==2.3.0",
@@ -775,7 +773,6 @@ PKG: Dict[str, Dict[str, Any]] = {
                 "pretranslate",
                 "prop2po",
                 "pydiff",
-                "pyjwt",  # PyJWT EXE
                 "pypo2phppo",
                 "rc2po",
                 "resx2po",

--- a/tests/test_install_all_packages.py
+++ b/tests/test_install_all_packages.py
@@ -167,7 +167,7 @@ def pip_cache_purge() -> None:
 
 
 def write_report_legend(report_legend_path: Path) -> None:
-    with report_legend_path.open("w") as report_legend_fh:
+    with report_legend_path.open("w", encoding="utf-8") as report_legend_fh:
         print(
             textwrap.dedent(
                 """
@@ -345,7 +345,7 @@ def print_error_report(
     test_type: str,
     pip_error_file: Optional[Path],
 ) -> None:
-    with module_globals.errors_path.open("a") as errors_fh:
+    with module_globals.errors_path.open("a", encoding="utf-8") as errors_fh:
         print("\n\n", file=errors_fh)
         print("=" * 79, file=errors_fh)
         print(
@@ -467,7 +467,7 @@ def install_package_both_paths(
         or (package_data.sys_pip_pass and package_data.sys_pipx_pass)
     )
 
-    with module_globals.report_path.open("a") as report_fh:
+    with module_globals.report_path.open("a", encoding="utf-8") as report_fh:
         print(format_report_table_row(package_data), file=report_fh, flush=True)
 
     if not package_data.clear_pip_pass and not package_data.sys_pip_pass:
@@ -506,13 +506,13 @@ def start_end_test_class(module_globals: ModuleGlobalsData, request):
 
     write_report_legend(reports_path / f"{REPORT_FILENAME_ROOT}_report_legend.txt")
 
-    with module_globals.report_path.open("a") as report_fh:
+    with module_globals.report_path.open("a", encoding="utf-8") as report_fh:
         print(format_report_table_header(module_globals), file=report_fh)
 
     yield
 
     module_globals.test_end = datetime.now()
-    with module_globals.report_path.open("a") as report_fh:
+    with module_globals.report_path.open("a", encoding="utf-8") as report_fh:
         print(format_report_table_footer(module_globals), file=report_fh)
 
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
* [ ] I have added an entry to `docs/changelog.md`

## Summary of changes
This updates the manual slow "all packages" tests to make sure that all platforms (especially Windows) print reports using encoding UTF-8 to avoid `UnicodeError`s when printing errors to the report.  

It also updates `package_specifier.py` to update things for the new version of `pyjwt` with no cli app.  It also updates to a later version of `kaggle` that doesn't contain two competing forms of slugify dependencies with the same named app (Thank goodness!!!)

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
Github CI "Test all packages (slow)" or
```
nox -s test_all_packages
```
