### PR TITLE
Only install and import colorama on Windows. 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@ dev
 
 - Fixed `pipx list --json` to return valid json with no venvs installed.  Previously would return and empty string to stdout. (#681)
 - Changed `pipx ensurepath` bash behavior so that only one of {`~/.profile`, `~/.bash\_profile`} is modified with the extra pipx paths, not both.  Previously, if a `.bash_profile` file was created where one didn't exist, it could cause problems, e.g. #456. The internal change is to use userpath v1.5.0 or greater. (#684)
+* Colorama is now only installed on Windows. (#691)
 
 0.16.2.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ include_package_data = true
 zip_safe = true
 python_requires = >=3.6
 install_requires =
-    colorama>=0.4.4
+    colorama>=0.4.4;sys_platform=="win32"
     userpath>=1.5.0
     argcomplete>=1.9.4, <2.0
     packaging>=20.0

--- a/src/pipx/colors.py
+++ b/src/pipx/colors.py
@@ -1,11 +1,13 @@
 import sys
 from typing import Callable
 
-import colorama  # type: ignore
+from pipx.constants import WINDOWS
 
 PRINT_COLOR = sys.stdout.isatty()
 
-if PRINT_COLOR:
+if PRINT_COLOR and WINDOWS:
+    import colorama  # type: ignore
+
     colorama.init()
 
 

--- a/src/pipx/colors.py
+++ b/src/pipx/colors.py
@@ -1,12 +1,12 @@
 import sys
 from typing import Callable
 
-PRINT_COLOR = sys.stdout.isatty()
-
 try:
     import colorama  # type: ignore
 except ImportError:  # Colorama is Windows only package
     colorama = None
+
+PRINT_COLOR = sys.stdout.isatty()
 
 if PRINT_COLOR and colorama:
     colorama.init()

--- a/src/pipx/colors.py
+++ b/src/pipx/colors.py
@@ -1,13 +1,14 @@
 import sys
 from typing import Callable
 
-from pipx.constants import WINDOWS
-
 PRINT_COLOR = sys.stdout.isatty()
 
-if PRINT_COLOR and WINDOWS:
+try:
     import colorama  # type: ignore
+except ImportError:  # Colorama is Windows only package
+    colorama = None
 
+if PRINT_COLOR and colorama:
     colorama.init()
 
 


### PR DESCRIPTION
Related: #612

Only install and import colorama on Windows. Importing and init call has no effect on other platforms, so no need to do it on other platforms.

<!-- add an 'x' in the brackets below -->
* [x] I have added an entry to `docs/changelog.md`

## Summary of changes

Just check if on Windows, do import and call init. Also, colorama dep is now listed as a windows specific dep. 

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running: 
```
pipx list --verbose
```
