### PR TITLE
Adopt the PSF Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,3 +269,5 @@ pipx is maintained by a team of volunteers (in alphabetical order)
 
 ## Contributing
 Issues and Pull Requests are definitely welcome! Check out [Contributing](https://pipxproject.github.io/pipx/contributing/) to get started.
+Everyone who interacts with the pipx project via codebase, issue tracker, chat rooms, or otherwise is expected to follow
+the [PSF Code of Conduct](https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,8 @@
 Thanks for your interest in contributing to pipx!
 
+Everyone who interacts with the pipx project via codebase, issue tracker, chat rooms, or otherwise is expected to follow
+the [PSF Code of Conduct](https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md).
+
 ## Running pipx From Source Tree
 To run the pipx executable from your source tree during development, run pipx from the src directory:
 


### PR DESCRIPTION
Required to join the PyPA organization.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>
